### PR TITLE
Pin pandas version

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -7,7 +7,7 @@ matplotlib==3.7.1
 mplcursors==0.5.2
 mpl-interactions==0.23.0
 numpy==1.24.3
-pandas<3
+pandas==1.5.3
 pasha==0.1.1
 pyflakes==3.0.1
 PyQt5==5.15.9

--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -7,7 +7,7 @@ matplotlib==3.7.1
 mplcursors==0.5.2
 mpl-interactions==0.23.0
 numpy==1.24.3
-pandas<2
+pandas<3
 pasha==0.1.1
 pyflakes==3.0.1
 PyQt5==5.15.9


### PR DESCRIPTION
According to @RobertRosca #3 did not fail as it should because `--constraint` does not override the `pyproject.toml` requirements, but add to it, so `<2` + `<3` gets resolved as `<2` from pip.

so we pin it here in the constraint file.