### PR TITLE
Fix the instructions for connecting to XFELs broker offline

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ at the command line.
 ## Kafka
 The GUI is updated by Kafka messages sent by the backend. Currently we use
 XFEL's internal Kafka broker at `exflwebstor01.desy.de:9102`, but this is only
-accessible inside the control network.
+accessible inside the DESY network.
 
 DAMNIT can run offline, but if you want updates from the backend and you're
 running DAMNIT outside the network and not using a VPN, you'll first have to
@@ -50,7 +50,14 @@ forward the broker port to your machine:
 ssh -L 9102:exflwebstor01.desy.de:9102 max-exfl.desy.de
 ```
 
-And then set the `AMORE_BROKER` variable:
+And then add a line in your `/etc/hosts` file to resolve `exflwebstor01.desy.de`
+to `localhost` (remember to remove it afterwards!):
+```
+127.0.0.1 exflwebstor01.desy.de
+```
+
+And then DAMNIT should be able to use XFELs broker. If you want to use a specific
+broker you can set the `AMORE_BROKER` variable:
 ```bash
 export AMORE_BROKER=localhost:9102
 ```


### PR DESCRIPTION
I'm not sure how this worked originally, but when testing it I found that the KafkaConsumer will connect to the bootstrap server (localhost) correctly with the AMORE_BROKER variable set, but it will then try to connect to exflwebstor01.desy.de and hang. I'm guessing that when it connects to the bootstrap server it gets a list of all brokers and then tries to connect to them; and since it sees localhost and exflwebstor01.desy.de as different brokers it'll try to connect to exflwebstor01.desy.de too.

(cherry-picked from one of my giant branches)