### PR TITLE
Ensure that proc variables have access to raw data in the run object

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -420,7 +420,10 @@ def main(argv=None):
     if args.mock:
         run_dc = mock_run()
     else:
-        run_dc = extra_data.open_run(args.proposal, args.run, data=run_data.value)
+        # Make sure that we always select the most data possible, so proc
+        # variables have access to raw data too.
+        actual_run_data = RunData.ALL if run_data == RunData.PROC else run_data
+        run_dc = extra_data.open_run(args.proposal, args.run, data=actual_run_data.value)
 
     inputs = {
         'run_data' : run_dc,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -435,6 +435,15 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
         main(["1234", "42", "all", "--mock"])
         open_run.assert_not_called()
 
+    # When only proc variables are reprocessed, the run should still be opened
+    # with `data='all'` so that raw data is available. Note that we patch
+    # Results too so that the test doesn't throw exceptions.
+    with patch("ctxrunner.extra_data.open_run") as open_run, \
+         patch("ctxrunner.Results"):
+        main(["1234", "42", "proc"])
+
+        open_run.assert_called_with(1234, 42, data="all")
+
 def test_initialize_and_start_backend(tmp_path, bound_port, request):
     db_dir = tmp_path / "foo"
     supervisord_config_path = db_dir / "supervisord.conf"


### PR DESCRIPTION
Previously proc variables executed with `ctxrunner <proposal> <run> proc` (i.e. by the listener) would also open the run with `data="proc"`, which meant that proc variables wouldn't have access to raw non-detector data.

(cherry-picked from one of my giant branches)