### PR TITLE
Reprocess from gui two

### DIFF
--- a/damnit/gui/reprocess.py
+++ b/damnit/gui/reprocess.py
@@ -1,0 +1,58 @@
+import logging
+
+from PyQt5 import QtCore
+from queue import Queue
+from time import sleep
+
+from ..backend.extract_data import Extractor
+
+log = logging.getLogger(__name__)
+
+class Reprocessor(QtCore.QObject):
+    color_scheme = QtCore.pyqtSignal(object, bool)
+    failed_reprocessing = QtCore.pyqtSignal()
+
+    def __init__(self):
+        QtCore.QObject.__init__(self)
+
+        self.reprocess_queue = Queue(500)
+        self.running = False
+
+    def loop(self) -> None:
+        self.running = True
+        run = None
+        try:
+            while self.running:
+                if not self.reprocess_queue.empty(): 
+                    run = self.reprocess_queue.get()
+                    log.info(f'Request to reprocess run {run} recieved')
+                    self.reprocess_finished = False
+                    self.color_scheme.emit(run, self.reprocess_finished)
+                    try:
+                        extr = Extractor()
+                        extr.extract_and_ingest(None, run)
+                        self.reprocess_finished = True
+                        self.color_scheme.emit(run, self.reprocess_finished)
+
+                    except Exception: 
+                        log.error(f'Can not reprocess run {run}', exc_info=True)
+                        self.reprocess_finished = True
+                        if self.reprocess_queue.empty():
+                            self.color_scheme.emit(None, self.reprocess_finished)
+                            self.failed_reprocessing.emit()
+                        else:
+                            self.color_scheme.emit(run, self.reprocess_finished)
+                        continue
+
+                    self.reprocess_finished = True
+                    if self.reprocess_queue.empty():
+                        self.color_scheme.emit(None, self.reprocess_finished)
+
+                else:
+                    sleep(0.1)
+
+        except Exception: 
+            log.error('An error occurred in the reprocessing loop', exc_info=True)
+
+    def stop(self):
+        self.running = False


### PR DESCRIPTION
A copy of my old branch with a few alterations. Enables reprocessing from the GUI by right-clicking a given row (or selection of) on the run table. A color scheme indicates the reprocessing status (a row green background means the run is being reprocessed and blue means that the row/run is in the queue to be reprocessed). 

The runs to be reprocessed are added to a queue and reprocessed in a separated thread, one by one, in order. If one or more reprocessing fails, a message will appear at the status bar advising the user to read the log files.

Support for SLURM jobs it's still not available, thus the color scheme might be misleading if SLURM jobs are required for some variables. Yet, for the HED use-case SLURM jobs are not so relevant (an alternative would be to merge this to HED branch, but I'm not sure which one would that be). 

Upon closing the GUI, if a run is in the middle of being reprocessed, the reprocessing will continue. I'm not sure how to overcome this nor if there's a use case in which the user would actually close the GUI during the experiment. I'm open to suggestions on this regard.