### PR TITLE
Only attempt to change file permissions when the user is the owner

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -29,7 +29,8 @@ class DamnitDB:
         log.debug("Opening database at %s", path)
         self.conn = sqlite3.connect(path, timeout=30)
         # Ensure the database is writable by everyone
-        os.chmod(path, 0o666)
+        if os.stat(path).st_uid == os.getuid():
+            os.chmod(path, 0o666)
 
         self.conn.executescript(BASE_SCHEMA)
         self.conn.row_factory = sqlite3.Row

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -178,7 +178,8 @@ class Extractor:
 
         out_path = Path('extracted_data', f'p{proposal}_r{run}.h5')
         out_path.parent.mkdir(parents=True, exist_ok=True)
-        os.chmod(out_path.parent, 0o777)
+        if out_path.parent.stat().st_uid == os.getuid():
+            os.chmod(out_path.parent, 0o777)
 
         python_exe = self.db.metameta.get('context_python', '')
         reduced_data = extract_in_subprocess(
@@ -200,7 +201,8 @@ class Extractor:
         if set(ctx_slurm.vars) > set(ctx.vars):
             slurm_logs_dir = Path.cwd() / "slurm_logs"
             slurm_logs_dir.mkdir(exist_ok=True)
-            slurm_logs_dir.chmod(0o777)
+            if slurm_logs_dir.stat().st_uid == os.getuid():
+                slurm_logs_dir.chmod(0o777)
 
             python_cmd = [sys.executable, '-m', 'damnit.backend.extract_data',
                           '--cluster-job', str(proposal), str(run), run_data.value]

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -157,7 +157,8 @@ def listen():
 
     # Ensure that the log file is writable by everyone (so that different users
     # can start the backend).
-    os.chmod("amore.log", 0o666)
+    if os.stat("amore.log").st_uid == os.getuid():
+        os.chmod("amore.log", 0o666)
 
 if __name__ == '__main__':
     listen()

--- a/damnit/backend/supervisord.py
+++ b/damnit/backend/supervisord.py
@@ -76,7 +76,9 @@ def write_supervisord_conf(root_path):
     config_path = root_path / "supervisord.conf"
     with open(config_path, "w") as f:
         config.write(f)
-    os.chmod(config_path, 0o666)
+
+    if config_path.stat().st_uid == os.getuid():
+        os.chmod(config_path, 0o666)
 
 def start_backend(root_path: Path, try_again=True):
     config_path = root_path / "supervisord.conf"
@@ -135,7 +137,8 @@ def start_backend(root_path: Path, try_again=True):
 def initialize_and_start_backend(root_path, proposal=None):
     # Ensure the directory exists
     root_path.mkdir(parents=True, exist_ok=True)
-    os.chmod(root_path, 0o777)
+    if root_path.stat().st_uid == os.getuid():
+        os.chmod(root_path, 0o777)
 
     # If the database doesn't exist, create it
     if not db_path(root_path).is_file():
@@ -154,7 +157,7 @@ def initialize_and_start_backend(root_path, proposal=None):
     # Copy initial context file if necessary
     if not context_path.is_file():
         shutil.copyfile(Path(__file__).parents[1] / "base_context_file.py", context_path)
-    os.chmod(context_path, 0o666)
+        os.chmod(context_path, 0o666)
 
     # Start backend
     return start_backend(root_path)

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -357,7 +357,8 @@ class Results:
             for path, arr in dsets:
                 f[path][()] = arr
 
-        os.chmod(hdf5_path, 0o666)
+        if os.stat(hdf5_path).st_uid == os.getuid():
+            os.chmod(hdf5_path, 0o666)
 
 def mock_run():
     run = MagicMock()


### PR DESCRIPTION
Otherwise it will block other users from doing things like reprocessing runs or starting the listener under a different user, even if the permissions are already loose enough.

(cherry-picked from one of my giant branches)