### PR TITLE
Add a default timeout of two minutes per test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ dependencies = [
 test = [
     "pytest",
     "pytest-qt",
-    "pytest-xvfb"
+    "pytest-xvfb",
+    "pytest-timeout"
 ]
 docs = [
     "mkdocs",
@@ -50,3 +51,6 @@ Home = "https://github.com/European-XFEL/DAMNIT"
 
 [project.scripts]
 amore-proto = "damnit.cli:main"
+
+[tool.pytest.ini_options]
+timeout = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ test = [
     "pytest",
     "pytest-qt",
     "pytest-xvfb",
-    "pytest-timeout"
+    "pytest-timeout",
 ]
 docs = [
     "mkdocs",


### PR DESCRIPTION
This is to help prevent hangs, which occasionally happens when writing tests.

I opted for a default of two minutes for each test, which is a bit more than the average time for the entire test suite in CI right now: https://github.com/European-XFEL/DAMNIT/actions