### PR TITLE
Set a default summary for the number of pulses

### DIFF
--- a/damnit/base_context_file.py
+++ b/damnit/base_context_file.py
@@ -44,6 +44,6 @@ def xgm_intensity(run):
     xgm = run[f"{xgm_name}:output", 'data.intensityTD'].xarray()
     return xgm[:, np.where(xgm[0] > 1)[0]].mean(axis=1)
 
-@Variable(title="Pulses")
+@Variable(title="Pulses", summary="mean")
 def pulses(run):
     return run[xgm_name, 'pulseEnergy.numberOfBunchesActual'].xarray()


### PR DESCRIPTION
This was a silly oversight, if the summary isn't specified then the variable will be displayed in the table in the `<type>: <shape>` format.