### PR TITLE
Handle all exceptions when checking for proc data

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -406,6 +406,8 @@ def main(argv=None):
             proc_available = True
         except FileNotFoundError:
             pass
+        except Exception as e:
+            log.warning(f"Error when checking if proc data available: {e}")
 
     run_data = RunData(args.run_data)
     if run_data == RunData.ALL and not proc_available:


### PR DESCRIPTION
Previously we only checked for `FileNotFoundError`'s, which would be thrown when the proc directory didn't exist at all. But sometimes the calibration pipeline will be really fast and create the proc directory and even create some files by the time the backend has received the migration message and launched a job. In this case `open_run()` will fail with an `Exception` about no HDF5 files being usable, which we didn't catch before and would cause processing of freshly-migrated runs to fail.