### PR TITLE
Fix getting POSIX timestamps from files

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -182,7 +182,7 @@ def get_start_time(xd_run):
         return first_file.stat().st_mtime
     else:
         # Convert np datetime64 [ns] -> [us] -> datetime -> float  :-/
-        return np.datetime64(ts, 'us').item().timestamp()
+        return np.datetime64(ts, 'us').item().replace(tzinfo=timezone.utc).timestamp()
 
 
 def get_proposal_path(xd_run):

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -11,6 +11,7 @@ import inspect
 import logging
 import os
 import time
+from datetime import timezone
 from pathlib import Path
 from unittest.mock import MagicMock
 from graphlib import CycleError, TopologicalSorter


### PR DESCRIPTION
See the discussion on #24: Numpy gives us a naive datetime representing UTC, but then `.timestamp()` treats it as a local datetime, so we end up 1 or 2 hours out. The numeric timestamp is meant to be a number of seconds since 1st January 1970 UTC.

We have a similar bug in both the extraction side (this change) and the display change), which currently cancel each other out. So when we merge this, we should also fix the display side, which I hope we'll do in #24. And then in theory we should reprocess runs in any existing databases to get the correct timestamp.