### PR TITLE
Improve support for executing a context file in another environment

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -10,8 +10,11 @@ import functools
 import inspect
 import logging
 import os
+import pickle
+import sys
 import time
 from datetime import timezone
+import traceback
 from pathlib import Path
 from unittest.mock import MagicMock
 from graphlib import CycleError, TopologicalSorter
@@ -21,11 +24,11 @@ import h5py
 import numpy as np
 import xarray
 import sqlite3
-from scipy import ndimage
 
 from damnit_ctx import RunData, Variable, UserEditableVariable
 
 log = logging.getLogger(__name__)
+
 
 class ContextFile:
 
@@ -110,7 +113,7 @@ class ContextFile:
         code = path.read_text()
         log.debug("Loading context from %s", path)
         return ContextFile.from_str(code, external_vars)
- 
+
     @classmethod
     def from_str(cls, code: str, external_vars={}):
         d = {}
@@ -118,7 +121,7 @@ class ContextFile:
         vars = {v.name: v for v in d.values() if isinstance(v, Variable)}
         log.debug("Loaded %d variables", len(vars))
         clashing_vars = vars.keys() & external_vars.keys()
- 
+
         if len(clashing_vars) > 0:
             raise RuntimeError(f"These Variables have clashing names: {', '.join(clashing_vars)}")
         return cls(vars | external_vars, code)
@@ -182,6 +185,26 @@ def get_start_time(xd_run):
     else:
         # Convert np datetime64 [ns] -> [us] -> datetime -> float  :-/
         return np.datetime64(ts, 'us').item().replace(tzinfo=timezone.utc).timestamp()
+
+
+def extract_error_info(exc_type, e, tb):
+    lineno = -1
+    offset = 0
+
+    if isinstance(e, SyntaxError):
+        # SyntaxError and its child classes are special, their
+        # tracebacks don't include the line number.
+        lineno = e.lineno
+        offset = e.offset - 1
+    else:
+        # Look for the frame with a filename matching the context
+        for frame in traceback.extract_tb(tb):
+            if frame.filename == "<string>":
+                lineno = frame.lineno
+                break
+
+    stacktrace = "".join(traceback.format_exception(exc_type, e, tb))
+    return (stacktrace, lineno, offset)
 
 
 def get_proposal_path(xd_run):
@@ -304,6 +327,8 @@ class Results:
         elif data.ndim == 0:
             return data
         elif data.ndim == 2 and self.ctx.vars[name].summary is None:
+            from scipy import ndimage
+
             # For the sake of space and memory we downsample images to a
             # resolution of 150x150.
             zoom_ratio = 150 / max(data.shape)
@@ -384,64 +409,87 @@ def mock_run():
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
-    ap.add_argument('proposal', type=int)
-    ap.add_argument('run', type=int)
-    ap.add_argument('run_data', choices=('raw', 'proc', 'all'))
-    ap.add_argument('--mock', action='store_true')
-    ap.add_argument('--cluster-job', action="store_true")
-    ap.add_argument('--match', action="append", default=[])
-    ap.add_argument('--save', action='append', default=[])
-    ap.add_argument('--save-reduced', action='append', default=[])
+    subparsers = ap.add_subparsers(required=True, dest="subcmd")
+
+    exec_ap = subparsers.add_parser("exec", help="Execute context file on a run")
+    exec_ap.add_argument('proposal', type=int)
+    exec_ap.add_argument('run', type=int)
+    exec_ap.add_argument('run_data', choices=('raw', 'proc', 'all'))
+    exec_ap.add_argument('--mock', action='store_true')
+    exec_ap.add_argument('--cluster-job', action="store_true")
+    exec_ap.add_argument('--match', action="append", default=[])
+    exec_ap.add_argument('--save', action='append', default=[])
+    exec_ap.add_argument('--save-reduced', action='append', default=[])
+
+    ctx_ap = subparsers.add_parser("ctx", help="Evaluate context file and pickle it to a file")
+    ctx_ap.add_argument("context_file", type=Path)
+    ctx_ap.add_argument("out_file", type=Path)
 
     args = ap.parse_args(argv)
     logging.basicConfig(level=logging.INFO)
 
     db_conn = sqlite3.connect('runs.sqlite', timeout=30)
 
-    # Check if we have proc data
-    proc_available = False
-    if args.mock:
-        # If we want to mock a run, assume it's available
-        proc_available = True
-    else:
-        # Otherwise check with open_run()
-        try:
-            extra_data.open_run(args.proposal, args.run, data="proc")
+    if args.subcmd == "exec":
+        # Check if we have proc data
+        proc_available = False
+        if args.mock:
+            # If we want to mock a run, assume it's available
             proc_available = True
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            log.warning(f"Error when checking if proc data available: {e}")
+        else:
+            # Otherwise check with open_run()
+            try:
+                extra_data.open_run(args.proposal, args.run, data="proc")
+                proc_available = True
+            except FileNotFoundError:
+                pass
+            except Exception as e:
+                log.warning(f"Error when checking if proc data available: {e}")
 
-    run_data = RunData(args.run_data)
-    if run_data == RunData.ALL and not proc_available:
-        log.warning("Proc data is unavailable, only raw variables will be executed.")
-        run_data = RunData.RAW
+        run_data = RunData(args.run_data)
+        if run_data == RunData.ALL and not proc_available:
+            log.warning("Proc data is unavailable, only raw variables will be executed.")
+            run_data = RunData.RAW
 
-    ctx_whole = ContextFile.from_py_file(Path('context.py'), external_vars = get_user_variables(db_conn))
-    ctx = ctx_whole.filter(
-        run_data=run_data, cluster=args.cluster_job, name_matches=args.match
-    )
-    log.info("Using %d variables (of %d) from context file", len(ctx.vars), len(ctx_whole.vars))
+        ctx_whole = ContextFile.from_py_file(Path('context.py'), external_vars = get_user_variables(db_conn))
+        ctx = ctx_whole.filter(
+            run_data=run_data, cluster=args.cluster_job, name_matches=args.match
+        )
+        log.info("Using %d variables (of %d) from context file", len(ctx.vars), len(ctx_whole.vars))
 
-    if args.mock:
-        run_dc = mock_run()
-    else:
-        # Make sure that we always select the most data possible, so proc
-        # variables have access to raw data too.
-        actual_run_data = RunData.ALL if run_data == RunData.PROC else run_data
-        run_dc = extra_data.open_run(args.proposal, args.run, data=actual_run_data.value)
+        if args.mock:
+            run_dc = mock_run()
+        else:
+            # Make sure that we always select the most data possible, so proc
+            # variables have access to raw data too.
+            actual_run_data = RunData.ALL if run_data == RunData.PROC else run_data
+            run_dc = extra_data.open_run(args.proposal, args.run, data=actual_run_data.value)
 
-    inputs = {
-        'run_data' : run_dc,
-        'db_conn' : db_conn
-    }
-    res = Results.create(ctx, inputs, args.run, args.proposal)
+        inputs = {
+            'run_data' : run_dc,
+            'db_conn' : db_conn
+        }
+        res = Results.create(ctx, inputs, args.run, args.proposal)
 
-    for path in args.save:
-        res.save_hdf5(path)
-    for path in args.save_reduced:
-        res.save_hdf5(path, reduced_only=True)
+        for path in args.save:
+            res.save_hdf5(path)
+        for path in args.save_reduced:
+            res.save_hdf5(path, reduced_only=True)
+    elif args.subcmd == "ctx":
+        error_info = None
+
+        try:
+            ctx = ContextFile.from_py_file(args.context_file, external_vars = get_user_variables(db_conn))
+
+            # Strip the functions from the Variable's, these cannot always be
+            # pickled.
+            for var in ctx.vars.values():
+                var.func = None
+        except:
+            ctx = None
+            error_info = extract_error_info(*sys.exc_info())
+
+        args.out_file.write_bytes(pickle.dumps((ctx, error_info)))
 
 
 if __name__ == '__main__':

--- a/damnit/gui/editor.py
+++ b/damnit/gui/editor.py
@@ -1,15 +1,18 @@
 import sys
-import traceback
 from enum import Enum
 from io import StringIO
+from pathlib import Path
+from tempfile import NamedTemporaryFile
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor, QFont
+from PyQt5.QtGui import QColor, QFont, QGuiApplication, QCursor
 from PyQt5.Qsci import QsciScintilla, QsciLexerPython, QsciCommand
 
 from pyflakes.reporter import Reporter
 from pyflakes.api import check as pyflakes_check
 
+from ..backend.extract_data import get_context_file
+from ..ctxsupport.ctxrunner import extract_error_info
 from ..context import ContextFile
 
 
@@ -47,30 +50,37 @@ class Editor(QsciScintilla):
         line_del = commands.find(QsciCommand.LineDelete)
         line_del.setKey(Qt.ControlModifier | Qt.Key_D)
 
-    def test_context(self):
+    def test_context(self, db, db_dir):
         """
         Check if the current context file is valid.
 
         Returns a tuple of (result, output_msg).
         """
-        try:
-            ContextFile.from_str(self.text())
-        except:
-            # Extract the line number of the error
-            exc_type, e, tb = sys.exc_info()
-            lineno = -1
-            offset = 0
-            if isinstance(e, SyntaxError):
-                # SyntaxError and its child classes are special, their
-                # tracebacks don't include the line number.
-                lineno = e.lineno
-                offset = e.offset - 1
-            else:
-                # Look for the frame with a filename matching the context
-                for frame in traceback.extract_tb(tb):
-                    if frame.filename == "<string>":
-                        lineno = frame.lineno
-                        break
+        error_info = None
+        context_python = db.metameta.get("context_python")
+
+        # If a different environment is not specified, we can evaluate the
+        # context file directly.
+        if context_python is None:
+            try:
+                ContextFile.from_str(self.text())
+            except:
+                # Extract the error information
+                error_info = extract_error_info(*sys.exc_info())
+
+        # Otherwise, write it to a temporary file to evaluate it from another
+        # process.
+        else:
+            with NamedTemporaryFile(prefix=".tmp_ctx", dir=db_dir) as ctx_file:
+                ctx_path = Path(ctx_file.name)
+                ctx_path.write_text(self.text())
+
+                QGuiApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
+                ctx, error_info = get_context_file(ctx_path, context_python)
+                QGuiApplication.restoreOverrideCursor()
+
+        if error_info is not None:
+            stacktrace, lineno, offset = error_info
 
             if lineno != -1:
                 # The line numbers reported by Python are 1-indexed so we
@@ -83,7 +93,7 @@ class Editor(QsciScintilla):
                 if lineno != self.getCursorPosition()[0]:
                     self.setCursorPosition(lineno, offset)
 
-            return ContextTestResult.ERROR, traceback.format_exc()
+            return ContextTestResult.ERROR, stacktrace
 
         # If that worked, try pyflakes
         out_buffer = StringIO()

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -182,6 +182,21 @@ $ amore-proto reprocess $(seq 1 100) --match agipd
 $ amore-proto reprocess all
 ```
 
+## Using custom environments
+DAMNIT supports running the context file in a user-defined Python environment,
+which is handy if there's a certain package you want that's only installed in
+a certain environment. At some point the setting for this will be exposed
+in the GUI, but right now you'll have to change it on the command line by
+passing the path to the `python` executable of the required environment:
+```bash
+$ amore-proto db-config context_python /path/to/your/python
+```
+
+The environment *must* have these dependencies installed for DAMNIT to work:
+
+- `extra_data`
+- `scipy`
+
 ## Managing the backend
 The backend is a process running under [Supervisor](http://supervisord.org/). In
 a nutshell:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest-qt",
     "pytest-xvfb",
     "pytest-timeout",
+    "pytest-virtualenv",
 ]
 docs = [
     "mkdocs",

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -76,7 +76,7 @@ def test_editor(mock_db, mock_ctx, qtbot):
 
     # Saving OK code should work
     win._save_btn.clicked.emit()
-    assert editor.test_context()[0] == ContextTestResult.OK
+    assert editor.test_context(db, db_dir)[0] == ContextTestResult.OK
     assert ctx_path.read_text() == old_code
     assert status_bar.currentMessage() == str(ctx_path.resolve())
 
@@ -126,7 +126,7 @@ def test_editor(mock_db, mock_ctx, qtbot):
     x = 1
     """)
     editor.setText(warning_code)
-    assert editor.test_context()[0] == ContextTestResult.WARNING
+    assert editor.test_context(db, db_dir)[0] == ContextTestResult.WARNING
     win.save_context()
     assert ctx_path.read_text() == warning_code
 


### PR DESCRIPTION
Cherry-picked at long last from one of my giant branches :sweat_smile: 

DAMNIT has had theoretical support for separate environments for a while, but semi-recently that broke. The problem is that in some places in `Extractor` and the GUI the context file needed to be loaded, and if the context file does something like `import` a package only available in the other environment, loading it will fail.

My hacky fix is to evaluate the context file in a subprocess, pickle it, and load it again in the main process. This is simple, but a bit ugly since we have to be careful to strip things that aren't pickleable (like functions) from the `ContextFile`. In the future we should do this slightly better by serializing the `ContextFile` to a JSON object or something (which might also be useful for `cammille.web`, CC @CammilleCC).