### PR TITLE
Convert - to _ for config keys in db-config command

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -252,6 +252,9 @@ def main():
     elif args.subcmd == 'db-config':
         from .backend.db import DamnitDB
 
+        if args.key:
+            args.key = args.key.replace('-', '_')
+
         db = DamnitDB()
         if args.delete:
             if not args.key:


### PR DESCRIPTION
A very simple one. I tend to forget precisely how our config keys are called, and at the command line I find it more natural to type `-` than `_`. So for the `amore-proto db-config` command, this lets you use e.g. `context-python` instead of `context_python`.

As far as I can see all our settings so far use `_` (`db_id`, `context_python`, `slurm_{partition,reservation,time}`), and I don't think we'd ever want to have two names that differ only in `_` vs. `-`.