### PR TITLE
Reorganise run-processing logs

### DIFF
--- a/damnit/backend/test_listener.py
+++ b/damnit/backend/test_listener.py
@@ -45,10 +45,10 @@ class TestEventProcessor(EventProcessor):
                 if run_data == RunData.RAW:
                     self.handle_migration_complete(record, msg)
                 elif run_data == RunData.PROC:
-                    self.handle_correction_complete(record, msg)
+                    self.handle_run_corrections_complete(record, msg)
                 elif run_data == RunData.ALL:
                     self.handle_migration_complete(record, msg)
-                    self.handle_correction_complete(record, msg)
+                    self.handle_run_corrections_complete(record, msg)
             except EOFError:
                 break  # Allow Ctrl-D to close it
             except Exception:

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -42,10 +42,6 @@ def excepthook(exc_type, value, tb):
     IPython.start_ipython(argv=[], display_banner=False,
                           user_ns=target_frame.f_locals | target_frame.f_globals | {"__tb": lambda: print(tb_msg)})
 
-def proposal_runs(proposal):
-    proposal_name = f"p{int(proposal):06d}"
-    raw_dir = Path(find_proposal(proposal_name)) / "raw"
-    return set(int(p.stem[1:]) for p in raw_dir.glob("*"))
 
 def main():
     ap = ArgumentParser()

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -455,7 +455,9 @@ def main(argv=None):
         ctx = ctx_whole.filter(
             run_data=run_data, cluster=args.cluster_job, name_matches=args.match
         )
-        log.info("Using %d variables (of %d) from context file", len(ctx.vars), len(ctx_whole.vars))
+        log.info("Using %d variables (of %d) from context file %s",
+             len(ctx.vars), len(ctx_whole.vars),
+             "" if args.cluster_job else "(cluster variables will be processed later)")
 
         if args.mock:
             run_dc = mock_run()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,7 +145,7 @@ def test_reprocess(mock_db_with_data, monkeypatch):
     def amore_proto(args):
         with (patch("sys.argv", ["amore-proto", *args]),
               patch("damnit.backend.extract_data.KafkaProducer"),
-              patch("damnit.cli.find_proposal", return_value=raw_dir.parent)):
+              patch("damnit.backend.extract_data.find_proposal", return_value=raw_dir.parent)):
             yield
 
     # Since none of the runs in the database exist on disk, we should skip all


### PR DESCRIPTION
At present, variables evaluated in listener subprocesses go into `amore.log`, variables evaluated under `amore-proto reprocess` are logged in the terminal of whoever ran it, and variables evaluated in a Slurm job get a per-job log file in `slurm_logs`. This makes it hard to find any log messages from processing a given run (see #45, #49).

With this change, all DAMNIT processing for a given run will be logged in a file like `process_logs/r123_p4507.out`. I've tried to put some markers in to delineate different processes adding to the file.

<details>
<summary>Example log file</summary>

```
----- Processing r147 (p3210) -----
2023-10-27 19:27:45,343 INFO __main__: args.run_data='raw', args.match=[]
2023-10-27 19:27:45,472 INFO __main__: Ensured p3210 r147 in database
INFO:extra_data.read_machinery:Found proposal dir '/gpfs/exfel/exp/MID/202221/p003210' in 0.0068 s
INFO:__main__:Using 7 variables (of 8) from context file (cluster variables will be processed later)
INFO:extra_data.read_machinery:Found proposal dir '/gpfs/exfel/exp/MID/202221/p003210' in 0.005 s
INFO:__main__:Writing 8 variables to 22 datasets in extracted_data/p3210_r147.h5
INFO:__main__:Writing 8 variables to 8 datasets in /tmp/tmpta779nkr/reduced.h5
Running in /home/kluyvert/Code/mid-2833/env/bin/python3
2023-10-27 19:28:00,033 INFO __main__: Reduced data has 8 fields
2023-10-27 19:28:00,034 INFO __main__: Adding p3210 r147 to database, with 8 columns
2023-10-27 19:28:00,059 INFO __main__: Sent Kafka update to topic 'amore-db-f7186c94cfbc37ea52d983c43021fe83c109c110'
2023-10-27 19:28:00,099 INFO __main__: Launched Slurm job 3873126 to calculate cluster variables
Running in /home/kluyvert/Code/mid-2833/env/bin/python3

----- Processing r147 (p3210) -----
2023-10-27 19:28:02,152 INFO __main__: args.run_data='raw', args.match=[]
2023-10-27 19:28:02,152 INFO __main__: Extracting cluster variables in Slurm job 3873126 on max-exfl021.desy.de
2023-10-27 19:28:02,284 INFO __main__: Ensured p3210 r147 in database
INFO:extra_data.read_machinery:Found proposal dir '/gpfs/exfel/exp/MID/202221/p003210' in 0.063 s
INFO:__main__:Using 8 variables (of 8) from context file 
INFO:extra_data.read_machinery:Found proposal dir '/gpfs/exfel/exp/MID/202221/p003210' in 0.0051 s
INFO:__main__:Writing 9 variables to 25 datasets in extracted_data/p3210_r147.h5
INFO:__main__:Writing 9 variables to 9 datasets in /tmp/tmpfe1g0kjs/reduced.h5
Running in /home/kluyvert/Code/mid-2833/env/bin/python3
2023-10-27 19:28:06,871 INFO __main__: Reduced data has 9 fields
2023-10-27 19:28:06,871 INFO __main__: Adding p3210 r147 to database, with 9 columns
2023-10-27 19:28:06,877 INFO __main__: Sent Kafka update to topic 'amore-db-f7186c94cfbc37ea52d983c43021fe83c109c110'
Running in /home/kluyvert/Code/mid-2833/env/bin/python3
```
</details>

**Question**: Should we keep older logs at all? For now, when you `reprocess` a run, its log file is overwritten. Another options is to append each new processing to the same file, and another is to write a new file each time (while making it easy to see the latest).

I view this PR as part 1 of 2: this changes where the backend puts the information, part 2 will be to use the new structure so you can get to the logs from the GUI. I've got some ideas about how precisely to do that, but I think having the Slurm, non-Slurm, listener & reprocess logs all going to the same place is a good starting point.

cc @JamesWrigley @matheuscteo 