### PR TITLE
Add a newline to the log before reprocessing a run

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -358,7 +358,7 @@ def reprocess(runs, proposal=None, match=(), mock=False):
         file_handler.setFormatter(log_formatter)
         logging.getLogger().addHandler(file_handler)
         try:
-            log.info("----- Reprocessing r%s (p%s) -----", run, prop)
+            log.info("\n\n----- Reprocessing r%s (p%s) -----", run, prop)
             extr.extract_and_ingest(prop, run, match=match, mock=mock, tee_output=log_path)
         except Exception:
             log.error("Exception while extracting p%s r%s", run, prop, exc_info=True)


### PR DESCRIPTION
This could probably be done more cleanly by changing formatters, but it looks ok:
```
│2023-11-01 12:59:10,455 INFO damnit.backend.extract_data: Sent Kafka update to topic 'amore-db-b785369a10c9a0919f685924a587de9d2395ac6d'                                                                                                     │
│2023-11-01 13:05:05,053 INFO damnit.backend.extract_data:                                                                                                                                                                                    │
│                                                                                                                                                                                                                                             │
│----- Reprocessing r14 (p4442) -----                                                                                                                                                                                                         │
│INFO:extra_data.read_machinery:Found proposal dir '/gpfs/exfel/exp/MID/202302/p004442' in 0.0036 s                                                                                                                                           │
│Loading 94 aliases from: /gpfs/exfel/exp/MID/202302/p004442/usr/extra-data-aliases.yml
```

(note that the log line above the newline is from the current reprocessing job)