### PR TITLE
Make per-run logs accessible from the GUI

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -845,6 +845,8 @@ da-dev@xfel.eu"""
         if file.is_file():
             log_window = LogViewWindow(file, self)
             log_window.show()
+            vsb = log_window.text_edit.verticalScrollBar()
+            vsb.setValue(vsb.maximum())
         else:
             self.show_status_message(f"No log found for run {run}")
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -1110,7 +1110,7 @@ class LogViewWindow(QtWidgets.QMainWindow):
         font.setFamily('monospace')
         self.text_edit.document().setDefaultFont(font)
         self.setCentralWidget(self.text_edit)
-        self.setMinimumSize(1000, 800)
+        self.resize(1000, 800)
 
 
 def prompt_setup_db_and_backend(context_dir: Path, prop_no=None, parent=None):


### PR DESCRIPTION
The actual viewer is super simple for now - just a QPlainTextEdit in read-only mode. But as log files are now per-run, they're relatively small, so I think the ability to filter them is less important. I'm sure we'll want to add features at some point, but we can start simple.

![Screenshot from 2023-11-08 14-54-29](https://github.com/European-XFEL/DAMNIT/assets/327925/89c0b941-f141-469a-9654-a1d2fea24e1b)

![Screenshot from 2023-11-08 14-54-52](https://github.com/European-XFEL/DAMNIT/assets/327925/9dcf9fc3-d703-41a8-bec0-07b880a4fe69)
