### PR TITLE
FIX: kafka event for offline correction

### DIFF
--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -22,7 +22,7 @@ KAFKA_CONF = {
     'maxwell': {
         'brokers': [f'it-kafka-broker{i:02}.desy.de' for i in range(1, 4)],
         'topics': ["xfel-test-r2d2", "xfel-test-offline-cal"],
-        'events': ["migration_complete", "correction_complete"],
+        'events': ["migration_complete", "run_corrections_complete"],
     },
     'onc': {
         'brokers': ['exflwgs06:9091'],


### PR DESCRIPTION
bug introduced in #133 the event name changed to trigger only once all detector corrections are done.