### PR TITLE
Feat/add container cd

### DIFF
--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -52,3 +52,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=pep440,pattern={{version}}  # '{version}' on tag
+            type=edge,branch=master  # 'edge' on push to master branch
+            type=ref,event=pr  # 'pr-{pr-no}' on pr
 
       - name: Build and push Docker image
         uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09  # v5.0.0

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -1,0 +1,48 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - 'master'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09  # v5.0.0
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/build-push-docker.yml
+++ b/.github/workflows/build-push-docker.yml
@@ -29,13 +29,6 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d  # v3.0.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934  # v5.0.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+FROM debian:bookworm AS build
+
+# install build dependencies
+RUN set -eux; \
+    apt update; \
+    apt install -y --no-install-recommends \
+        g++ \
+        gcc \
+        python3-dev \
+        python3-pip \
+        python3-venv \
+        # include pyqt deps so pip does not install them later
+        python3-pyqt5 \
+        python3-pyqt5.qsci \
+        python3-pyqt5.qtsvg \
+    ; \
+    apt list --installed $(apt-mark showmanual) > /.apt-deps-build
+
+COPY pyproject.toml /src/pyproject.toml
+
+# set up venv and python dependencies
+RUN set -eux; \
+    mkdir -p /src/damnit; \
+    # install dependencies w/o installing package itself
+    # https://github.com/pypa/pip/issues/11440
+    echo '"""Hello"""' > /src/damnit/__init__.py; \
+    echo '__version__="0.0.0"' >> /src/damnit/__init__.py; \
+    python3 -m venv --system-site-packages /app; \
+    /app/bin/python3 -m pip install /src; \
+    /app/bin/python3 -m pip uninstall -y damnit; \
+    /app/bin/python3 -m pip freeze > /.python-deps-build
+
+FROM debian:bookworm-slim
+
+COPY --from=build /app /app
+COPY --from=build /.apt-deps-build /.apt-deps-build
+COPY --from=build /.python-deps-build /.python-deps-build
+
+ENV PATH="/app/bin:${PATH}"
+
+WORKDIR /app
+
+# install runtime dependencies
+RUN set -eux; \
+    apt update; \
+    apt install -y --no-install-recommends \
+        ca-certificates \
+        python3-pyqt5 \
+        python3-pyqt5.qsci \
+        python3-pyqt5.qtsvg \
+    ; \
+    apt clean; \
+    rm -rf /var/lib/apt/lists/*; \
+    apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+    apt list --installed $(apt-mark showmanual) > /.apt-deps-runtime
+
+# install DAMNIT
+COPY . /src
+RUN set -eux; \
+    /app/bin/python3 -m pip install -vv --no-cache-dir /src; \
+    /app/bin/python3 -m pip freeze > /.python-deps-runtime; \
+    python3 -m pip check; \
+    python3 -c "import damnit; print(damnit.__version__)"
+
+CMD ["/app/bin/amore-proto", "gui"]
+


### PR DESCRIPTION
This PR adds a `Dockerfile` for DAMNIT and a CI workflow to build a container and push it to GHCR. Intended usecase is adding a new desktop shortcut to the Visa VMs which will start up DAMNIT via singularity.

A follow up PR could (should?) bundle a small example DB with the image which can be selected from the GUI at startup so that we can say "Click the DAMNIT button/copy-paste this docker or singularity command to see a demo of the GUI", since without that it's just the DAMNIT GUI with an empty table and nothing to see. 

To try and keep the size of the container as small as possible it's a multi-stage Dockerfile where the `build` stage sets up the build environment and a venv in `/app` with the required python dependencies, then the final unnamed stage copies over the `/app` directory, installs runtime requirements, then installs DAMNIT into the venv.

The resulting image is still relatively huge (~1GB) but a bit smaller than it would otherwise be with build tools/layers included.

<details>
  <summary>Options if size is an issue</summary>

- After an (unrelated) meeting w/ DESY-people about VISA/containerisation we decided that, if download speeds are too slow for the image, we can publish the container to the DESY GitLab Registry as well as GHCR. That way the downloads will be done over LAN and should be much faster than from GitHub's registry.
- Alternatively there are tools to make containers slimmer and only store the files required to run a given application, this is done by triggering all the functionality of an application (e.g. by running tests) and only retaining files which were opened during this period. An approach like this can hugely reduce container size, but can also introduce issues if all files are not found during the probing phase.

</details>

Starting the GUI from the container can be done with:

```shell
# docker, excluded mounts:
docker run --rm -it --net=host -e DISPLAY=:0 ghcr.io/european-xfel/damnit:$TAG

# singularity:
apptainer run docker://ghcr.io/european-xfel/damnit:$TAG
```

As for the actual tags, the workflow will build the image and push it to the container registry with different tags based on the workflow trigger:

| event | tag |
| - | - |
| tag release | `damnit:{x.y.z}`, `damnit:latest` - 'latest' and version no. |
| pull request | `damnit:pr-{N}` - pull request number |
| merge/push to master |  `damnit:edge` - 'edge' for most recent commit to master |

Which covers the main use cases I think we'd have: using a tagged release, a current PR, and using current head.

Tested this with some local PRs to a fork of the repo here: <https://github.com/RobertRosca/DAMNIT/pull/3>

- On PR trigger image tag was `ghcr.io/robertrosca/damnit:pr-3`, created from the PR branch
- On PR merge `ghcr.io/robertrosca/damnit:edge`, created from master branch
- On creating tag `ghcr.io/robertrosca/damnit:0.1.0` and `latest`, created from master branch