### PR TITLE
Add Bubblewrap implementation for sandboxing

### DIFF
--- a/damnit/backend/sandboxing.py
+++ b/damnit/backend/sandboxing.py
@@ -1,0 +1,137 @@
+from pathlib import Path
+import shlex
+import subprocess
+
+from extra_data.read_machinery import find_proposal
+
+
+class Bubblewrap:
+    """A class representing a sandbox environment using Bubblewrap.
+
+    Bubblewrap is a sandboxing tool that creates a restricted environment for processes,
+    this class provides methods to configure and build a bubblewrap sandbox for running
+    a context file such that it only has access to data from the relevant proposal.
+
+    Attributes:
+        command (list[str]): The base command for running in the sandbox.
+        command_binds (list[tuple[str, str]]): List of bind mounts commands.
+    """
+
+    def __init__(self):
+        self.command = [
+            "bwrap",
+            "--disable-userns", # Disable creation of user namespaces in sandbox
+            "--die-with-parent",  # Kill sandbox if parent process dies
+            "--unshare-all",  # Unshare all namespaces
+            "--share-net",  # Share network namespace
+            "--dev /dev",  # Bind mount /dev
+            "--tmpfs /tmp",  # Mount tmpfs on /tmp
+            "--dir /gpfs",  # Create empty directory at /gpfs
+        ]
+
+        self.command_binds: list[tuple[str, str]] = []
+
+        for path in (
+            "/bin",
+            "/etc/resolv.conf",
+            "/gpfs/exfel/sw/software",
+            "/lib",
+            "/lib64",
+            "/sbin",
+            "/usr",
+        ):
+            self.add_bind(Path(path), ro=True)
+
+    def add_bind(
+        self, source: Path, dest: Path | None = None, ro: bool = False
+    ) -> None:
+        """Adds a bind mount to the sandbox.
+
+        Args:
+            source (Path): The source path to be bind mounted.
+            dest (Path, optional): The destination path in the sandbox. If not provided, the source path is used.
+            ro (bool, optional): Whether the bind mount should be read-only. Defaults to False.
+
+        Raises:
+            ValueError: If the source path is not absolute.
+        """
+        if not source.is_absolute():
+            raise ValueError("Source path must be absolute")
+
+        if dest is None:
+            dest = source
+
+        self.command_binds.append(
+            (
+                f"--{'ro-' if ro else ''}bind",
+                f"{shlex.quote(str(source))} {shlex.quote(str(dest))}",
+            )
+        )
+
+    def add_bind_proposal(self, proposal_id: int) -> None:
+        """Adds bind mounts for a proposal directory and its contents.
+
+        Args:
+            proposal_id (int): The ID of the proposal.
+
+        Raises:
+            FileNotFoundError: If the proposal directory is not found.
+        """
+        proposal_dir = Path(find_proposal(f"p{proposal_id:06d}"))
+
+        self.add_bind(proposal_dir)
+
+        for path in proposal_dir.iterdir():
+            self.add_bind(path.resolve())
+
+    def add_bind_venv(self, python_exec: Path) -> None:
+        """Adds all paths required by a virtual environment to the sandbox.
+
+        This function will use the given python executable to first call `sys.prefix` to
+        check if the executable is in a venv, if it is then `sysconfig.get_paths()` is
+        used to find required paths and add them paths as read-only binds.
+
+        Args:
+            python_exec (Path): The path to the Python executable.
+
+        Raises:
+            subprocess.CalledProcessError: If the command to get the virtual environment paths fails.
+        """
+        venv = subprocess.check_output(
+            [python_exec, "-c", "import sys; print(sys.prefix != sys.base_prefix)"]
+        ).decode("utf-8")
+
+        if venv == "False":
+            return
+
+        paths = subprocess.check_output(
+            [
+                python_exec,
+                "-c",
+                'import sysconfig; print(" ".join(v for v in sysconfig.get_paths().values()))',
+            ]
+        ).decode("utf-8")
+
+        for path in paths.split():
+            path = Path(path)
+            self.add_bind(Path(path), ro=True)
+            if path.is_symlink():
+                self.add_bind(Path(path).resolve(), ro=True)
+
+    def build_command(self, command: str | list[str]) -> list[str]:
+        """Builds the final command for running in the sandbox.
+
+        Args:
+            command (str or list[str]): The command to be executed in the sandbox.
+
+        Returns:
+            list[str]: The final command for running in the sandbox.
+        """
+        _command = self.command.copy()
+
+        for bind in self.command_binds:
+            _command.extend(bind)
+
+        _command.extend(command if isinstance(command, list) else [command])
+
+        return _command

--- a/tests/test_sandboxing.py
+++ b/tests/test_sandboxing.py
@@ -1,0 +1,104 @@
+import sysconfig
+from pathlib import Path
+from unittest.mock import MagicMock
+import sys
+
+import pytest
+
+from damnit.backend.sandboxing import Bubblewrap
+
+
+@pytest.fixture
+def bubblewrap():
+    return Bubblewrap()
+
+
+@pytest.fixture(scope="session")
+def mock_proposal_1111(tmp_path_factory):
+    proposal_str = "p0001111"
+    root: Path = tmp_path_factory.mktemp("root")
+
+    # 'real' directories
+    usr = root / "u" / "usr" / proposal_str
+    raw = root / "pnfs" / "archive" / proposal_str
+
+    for d in (usr, raw):
+        d.mkdir(parents=True)
+
+    # fake gpfs structure - proposal dir with symlinks to usr and raw
+    gpfs = root / "gpfs"
+    p = gpfs / "p0001111"
+
+    p.mkdir(parents=True)
+
+    usr_link = p / "usr"
+    usr_link.symlink_to(usr)
+
+    raw_link = p / "raw"
+    raw_link.symlink_to(raw)
+
+    return p
+
+
+@pytest.mark.parametrize(
+    "src,dest,ro,expected",
+    [
+        (Path("/source"), None, False, ("--bind", "/source /source")),
+        (Path("/source"), None, True, ("--ro-bind", "/source /source")),
+        (Path("/source"), Path("/dest"), False, ("--bind", "/source /dest")),
+    ],
+)
+def test_add_bind(bubblewrap, src, dest, ro, expected):
+    bubblewrap.add_bind(src, dest, ro)
+
+    assert expected in bubblewrap.command_binds
+
+
+def test_add_bind_proposal(bubblewrap, monkeypatch, mock_proposal_1111):
+    proposal_id = 1111
+
+    find_proposal = MagicMock(return_value=str(mock_proposal_1111))
+    monkeypatch.setattr("damnit.backend.sandboxing.find_proposal", find_proposal)
+
+    bubblewrap.add_bind_proposal(proposal_id)
+
+    assert find_proposal.call_args == ((f"p{proposal_id:06d}",),)
+
+    binds = [b[1] for b in bubblewrap.command_binds]
+
+    assert f"{mock_proposal_1111} {mock_proposal_1111}" in binds
+
+    assert any("u/usr" in b for b in binds)
+    assert any("pnfs/archive" in b for b in binds)
+
+
+def test_add_bind_venv(bubblewrap, monkeypatch):
+    python_exec = Path("/path/to/python")
+
+    paths = [
+        "/path/venv/lib",
+        "/path/venv/include",
+        "/path/venv/bin",
+    ]
+
+    monkeypatch.setattr(
+        "subprocess.check_output",
+        MagicMock(return_value="\n".join(paths).encode("utf-8")),
+    )
+
+    bubblewrap.add_bind_venv(python_exec)
+
+    assert ("--ro-bind", "/path/venv/lib /path/venv/lib") in bubblewrap.command_binds
+    assert (
+        "--ro-bind",
+        "/path/venv/include /path/venv/include",
+    ) in bubblewrap.command_binds
+    assert ("--ro-bind", "/path/venv/bin /path/venv/bin") in bubblewrap.command_binds
+
+
+def test_add_bind_venv_with_subprocess(bubblewrap):
+    python_exec = Path(sys.executable)
+    bubblewrap.add_bind_venv(python_exec)
+
+    for path in sysconfig.get_paths().values():
+        assert ("--ro-bind", f"{path} {path}") in bubblewrap.command_binds


### PR DESCRIPTION
Adds sandboxing via bubblewrap for context file execution, closes #150.

Main functionality is implemented via a `Bubblewrap` class which is a convenience class for building up the CLI arguments/flags/mounts required to sandbox a python process to only have access to the data from a single proposal directory.

## Summary

`Bubblewrap` implements:

- `__init__`: initializes with some default flags and bind mounts for running the sandboxed process, these defaults are all security/isolation related (unshare/disable namespaces) or required binds/settings (e.g. share network, bind `/bin`, `/lib`, etc...).
- `add_bind`: main method for adding some bind mount with a `source`, `destination`, and a flag to set the mount to read only or not.
- `add_bind_proposal` which takes in a proposal number, finds the directory, bind mounts the directory, and resolves the top-level symlinks in the proposal directory, then bind mounts those in as well.
- `add_bind_venv` which takes the path to a python executable and, if it is running in a venv, bind mounts all paths required by it to the sandbox.
- `build_command` takes in the command to sandbox and prepends the full bubblewrap command to it, then returns a list that can be called by `subprocess` to start the sandboxed command.

There are some tests to check that the command is built (at least somewhat) correctly, but they're not that robust since I'm not sure how reliable testing with something bubblewrap is when running in a CI environment. 

## Example

An example of building up the commands would be:

```python
b = Bubblewrap()

b.add_bind_proposal(3422)

b.add_bind_venv("/gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/bin/python")

b.build_command("/bin/bash")
```

Which creates:

```bash
bwrap \
  --unshare-all \
  --share-net \
  --dev /dev \
  --tmpfs /tmp \
  --dir /gpfs \
  --ro-bind /bin /bin \
  --ro-bind /etc/resolv.conf /etc/resolv.conf \
  --ro-bind /gpfs/exfel/sw/software /gpfs/exfel/sw/software \
  --ro-bind /lib /lib \
  --ro-bind /lib64 /lib64 \
  --ro-bind /sbin /sbin \
  --ro-bind /usr /usr \
  --bind /gpfs/exfel/exp/MID/202304/p003422 /gpfs/exfel/exp/MID/202304/p003422 \
  --bind /gpfs/exfel/u/scratch/MID/202304/p003422 /gpfs/exfel/u/scratch/MID/202304/p003422 \
  --bind /pnfs/xfel.eu/exfel/archive/XFEL/raw/MID/202304/p003422 /pnfs/xfel.eu/exfel/archive/XFEL/raw/MID/202304/p003422 \
  --bind /gpfs/exfel/u/usr/MID/202304/p003422 /gpfs/exfel/u/usr/MID/202304/p003422 \
  --bind /gpfs/exfel/d/proc/MID/202304/p003422 /gpfs/exfel/d/proc/MID/202304/p003422 \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9 /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9 \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9 /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9 \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9/site-packages /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9/site-packages \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9/site-packages /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/lib/python3.9/site-packages \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/include/python3.9 /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/include/python3.9 \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/include/python3.9 /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/include/python3.9 \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/bin /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env/bin \
  --ro-bind /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env /gpfs/exfel/u/usr/MID/202304/p003422/Software/analysis_env \
  /bin/bash
```

## Questions

PR is WIP since it does not actually use this anywhere :stuck_out_tongue: since I wasn't too sure where to add it and have a few questions.

Main one is... where should this go? It can be added anywhere there is a subprocess command, or even in the `ctxrunner`:

1. https://github.com/European-XFEL/DAMNIT/blob/377af2818b8a3bdc33d092b755c08cacbfb143c4/damnit/backend/listener.py#L150
2. https://github.com/European-XFEL/DAMNIT/blob/377af2818b8a3bdc33d092b755c08cacbfb143c4/damnit/backend/extract_data.py#L56 seems like a good option since it would also cover the case of slurm jobs, as far as I understand from just glancing at https://github.com/European-XFEL/DAMNIT/blob/377af2818b8a3bdc33d092b755c08cacbfb143c4/damnit/backend/extract_data.py#L283
3. https://github.com/European-XFEL/DAMNIT/blob/377af2818b8a3bdc33d092b755c08cacbfb143c4/damnit/ctxsupport/ctxrunner.py#L410 by creating a new flag `--sandbox` which, if present, re-executes itself within the sandbox.

Other questions are:

1. Right now I'm only setting read-only binds for the python `venv` (if there is one). Alternative would be to mount everything as read only by default, and explicitly pass a single output directory which is writable.
2. `--die-with-parent` is set to kill the sandbox if the parent (DAMNIT) process dies, I assume that's desirable?
3. `--unshare-all` and some of the binds break (on purpose) authentication, slurm, ssh, etc..., I assume people don't expect to be able to have some function in a context file that runs a subprocess with ssh or something? 