### PR TITLE
Database v1 - further changes

### DIFF
--- a/damnit/backend/api.py
+++ b/damnit/backend/api.py
@@ -31,7 +31,7 @@ class VariableData:
 
     @staticmethod
     def _type_hint(group):
-        hint_s = group.attrs.get('damnit_objtype', '')
+        hint_s = group.attrs.get('_damnit_objtype', '')
         if hint_s:
             return DataType(hint_s)
         return None
@@ -59,7 +59,11 @@ class VariableData:
 
     def _read_netcdf(self, one_array=False):
         load = xr.load_dataarray if one_array else xr.load_dataset
-        return load(self._h5_path, group=self.name, engine="h5netcdf")
+        obj = load(self._h5_path, group=self.name, engine="h5netcdf")
+        # Remove internal attributes from loaded object
+        obj.attrs = {k: v for (k, v) in obj.attrs.items()
+                     if not k.startswith('_damnit_')}
+        return obj
 
     def xarray(self):
         with self._open_h5_group() as group:

--- a/damnit/backend/api.py
+++ b/damnit/backend/api.py
@@ -84,10 +84,8 @@ class VariableData:
         if len(set(coord_sizes.keys())) != len(coord_sizes.keys()):
             raise RuntimeError(f"Could not read DataArray for variable '{self.name}', dimensions have the same length")
 
-        dims = [coord_sizes[dim] for dim in data.shape]
-        return xr.DataArray(
-            data, dims=dims, coords={ dim: coords[dim] for dim in dims }
-        )
+        dims = [coord_sizes.get(dim, f'dim_{i}') for i, dim in enumerate(data.shape)]
+        return xr.DataArray(data, dims=dims, coords=coords)
 
     def ndarray(self):
         with self._open_h5_group() as group:

--- a/damnit/backend/api.py
+++ b/damnit/backend/api.py
@@ -9,13 +9,12 @@ from ..ctxsupport.ctxrunner import DataType
 
 
 class VariableData:
-    def __init__(self, name, proposal, run, h5_path, data_format_version, stored_type):
+    def __init__(self, name, proposal, run, h5_path, data_format_version):
         self._name = name
         self._proposal = proposal
         self._run = run
         self._h5_path = h5_path
         self._data_format_version = data_format_version
-        self._stored_type = stored_type
 
     @property
     def name(self):
@@ -25,93 +24,80 @@ class VariableData:
     def file(self):
         return self._h5_path
 
-    @property
-    def stored_type(self):
-        if self._stored_type is None:
-            with self._open_h5_group() as (group, stored_type):
-                self._stored_type = stored_type
-
-        return self._stored_type
-
-    def _type(self, group: h5py.Group) -> DataType:
-        # Versions from 1 onwards store the type
-        if self._data_format_version > 0:
-            return self._stored_type
-
-        # Otherwise fall back to guessing from the HDF5 file
-
-        if h5py.check_string_dtype(group["data"].dtype) is not None:
-            return DataType.String
-
-        if group["data"].ndim == 0:
-            return DataType.Scalar
-
-        if group["data"].ndim > 0:
-            has_coords = len(group.keys()) > 1
-            return DataType.DataArray if has_coords else DataType.NDArray
-
-        raise RuntimeError(f"Couldn't determine type of variable '{self.name}'")
-
     @contextmanager
     def _open_h5_group(self):
         with h5py.File(self._h5_path) as f:
-            group = f[self.name]
-            stored_type = self.stored_type
-            yield group, stored_type
+            yield f[self.name]
+
+    @staticmethod
+    def _type_hint(group):
+        hint_s = group.attrs.get('damnit_objtype', '')
+        if hint_s:
+            return DataType(hint_s)
+        return None
 
     def read(self):
-        with self._open_h5_group() as (group, stored_type):
-            if stored_type == DataType.String:
-                return group["data"].asstr()[0]
-            elif stored_type == DataType.Scalar:
-                return group["data"][()].item()
-            elif stored_type == DataType.NDArray:
-                return self._read_ndarray(group, stored_type)
-            elif stored_type == DataType.DataArray:
-                return self._read_xarray(group, stored_type)
-            else:
-                raise RuntimeError(f"Unsupported type: {stored_type}")
+        with self._open_h5_group() as group:
+            type_hint = self._type_hint(group)
+            if type_hint is DataType.Dataset:
+                return self._read_netcdf()
+            elif type_hint is DataType.DataArray:
+                return self._read_netcdf(one_array=True)
+
+            dset = group["data"]
+            if dset.ndim == 0:  # Scalars
+                if h5py.check_string_dtype():
+                    return dset[()].decode("utf-8", "surrogateescape")
+                return dset[()]
+
+            if len(group.keys()) > 1:
+                # Has coordinates - old-style DataArray storage
+                self._read_xarray_oldfmt(group)
+
+            # Otherwise, return a Numpy array
+            return group["data"][()]
+
+    def _read_netcdf(self, one_array=False):
+        load = xr.load_dataarray if one_array else xr.load_dataset
+        return load(self._h5_path, group=self.name, engine="h5netcdf")
 
     def xarray(self):
-        with self._open_h5_group() as (group, stored_type):
-            return self._read_xarray(group, stored_type)
+        with self._open_h5_group() as group:
+            type_hint = self._type_hint(group)
+            if type_hint is DataType.DataArray:
+                return self._read_netcdf(one_array=True)
+            elif type_hint is DataType.Dataset:
+                return self._read_netcdf()
+            else:
+                return self._read_xarray_oldfmt(group)
 
-    def _read_xarray(self, group, stored_type):
-            if stored_type == DataType.DataArray:
-                if self._data_format_version >= 1:
-                    return xr.open_dataarray(self._h5_path, group=self.name, engine="h5netcdf")
-                else:
-                    data = group["data"][()]
-                    coords = { ds_name: group[ds_name][()] for ds_name in group.keys()
-                               if ds_name != "data" }
+    def _read_xarray_oldfmt(self, group):
+        # Old-style, coordinates stored ad-hoc rather than using NetCDF4
+        data = group["data"][()]
+        coords = { ds_name: group[ds_name][()] for ds_name in group.keys()
+                   if ds_name != "data" }
 
-                    # Attempt to map the coords to the right dimensions. This
-                    # will fail if there are two coordinates/dimensions with the
-                    # same length.
-                    coord_sizes = { len(coord_data): coord for coord, coord_data in coords.items() }
-                    if len(set(coord_sizes.keys())) != len(coord_sizes.keys()):
-                        raise RuntimeError(f"Could not read DataArray for variable '{self.name}', dimensions have the same length")
+        # Attempt to map the coords to the right dimensions. This
+        # will fail if there are two coordinates/dimensions with the
+        # same length.
+        coord_sizes = { len(coord_data): coord for coord, coord_data in coords.items() }
+        if len(set(coord_sizes.keys())) != len(coord_sizes.keys()):
+            raise RuntimeError(f"Could not read DataArray for variable '{self.name}', dimensions have the same length")
 
-                    dims = [coord_sizes[dim] for dim in data.shape]
-                    return xr.DataArray(data,
-                                        dims=dims,
-                                        coords={ dim: coords[dim] for dim in dims })
-
-            elif stored_type == DataType.NDArray:
-                data = group["data"][()]
-                return xr.DataArray(data)
+        dims = [coord_sizes[dim] for dim in data.shape]
+        return xr.DataArray(
+            data, dims=dims, coords={ dim: coords[dim] for dim in dims }
+        )
 
     def ndarray(self):
-        with self._open_h5_group() as (group, stored_type):
-            return self._read_ndarray(group, stored_type)
-
-    def _read_ndarray(self, group, stored_type):
-        if stored_type in [DataType.NDArray, DataType.Image]:
-            return group["data"][()]
-        elif stored_type == DataType.DataArray:
-            return self._read_xarray(group, stored_type).data
-        else:
-            raise RuntimeError(f"Could not read ndarray for variable '{self.name}', actual type is '{stored_type}'")
+        with self._open_h5_group() as group:
+            type_hint = self._type_hint(group)
+            if type_hint is DataType.DataArray:
+                return self._read_netcdf(one_array=True).data
+            elif type_hint is DataType.Dataset:
+                raise TypeError("Variable is an xarray Dataset, can't convert to ndarray")
+            else:
+                return group["data"][()]
 
 
 class RunVariables:
@@ -122,19 +108,9 @@ class RunVariables:
         self._data_format_version = db.metameta["data_format_version"]
         self._h5_path = Path(db_dir) / f"extracted_data/p{self._proposal}_r{self._run}.h5"
 
-        records = db.conn.execute("""
-            SELECT name, stored_type FROM run_variables
-            WHERE proposal=? AND run=? AND version=1
-        """, (self._proposal, self._run))
-        self._stored_types = { name: None if t is None else DataType(t)
-                               for name, t in records }
-
-        db.close()
-
     def __getitem__(self, name):
         return VariableData(name, self._proposal, self._run,
-                            self._h5_path, self._data_format_version,
-                            self._stored_types[name])
+                            self._h5_path, self._data_format_version)
 
     @property
     def file(self):

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -57,7 +57,7 @@ class BlobTypes(Enum):
 
     @classmethod
     def identify(cls, blob: bytes):
-        if blob.startswith(b'\x89PNG\r\n\x1a\x0a'):
+        if blob.startswith(b'\x89PNG\r\n\x1a\n'):
             return cls.png
         elif blob.startswith(b'\x93NUMPY'):
             return cls.numpy

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -19,7 +19,7 @@ V1_SCHEMA = """
 CREATE TABLE IF NOT EXISTS run_info(proposal, run, start_time, added_at);
 CREATE UNIQUE INDEX IF NOT EXISTS proposal_run ON run_info (proposal, run);
 
-CREATE TABLE IF NOT EXISTS run_variables(proposal, run, name, version, value, timestamp, max_diff, provenance);
+CREATE TABLE IF NOT EXISTS run_variables(proposal, run, name, version, value, timestamp, max_diff, provenance, summary_type);
 CREATE UNIQUE INDEX IF NOT EXISTS variable_version ON run_variables (proposal, run, name, version);
 
 -- These are dummy views that will be overwritten later, but they should at least
@@ -31,6 +31,14 @@ CREATE TABLE IF NOT EXISTS metameta(key PRIMARY KEY NOT NULL, value);
 CREATE TABLE IF NOT EXISTS variables(name TEXT PRIMARY KEY NOT NULL, type TEXT, title TEXT, description TEXT, attributes TEXT);
 CREATE TABLE IF NOT EXISTS time_comments(timestamp, comment);
 """
+
+
+class SummaryType(Enum):
+    # We record summary object types only where it's not clear from the value:
+    # numbers, strings, thumbnails (PNG) don't need a marker.
+
+    # from datetime, stored as seconds since epoch, displayed in local time
+    timestamp = "timestamp"
 
 
 @dataclass

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -53,7 +53,6 @@ class ReducedData:
 class BlobTypes(Enum):
     png = 'png'
     numpy = 'numpy'
-    pickle = 'pickle'  # We try to avoid pickle, but have used it in the past
     unknown = 'unknown'
 
     @classmethod
@@ -62,10 +61,6 @@ class BlobTypes(Enum):
             return cls.png
         elif blob.startswith(b'\x93NUMPY'):
             return cls.numpy
-        elif blob.startswith(b'\x80'):
-            # Since pickle v2 (Python 2.3), all pickles start with a protocol
-            # version opcode (0x80).
-            return cls.pickle
 
         return cls.unknown
 

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -4,6 +4,7 @@ import sqlite3
 from collections.abc import MutableMapping, ValuesView, ItemsView
 from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from secrets import token_hex
 from typing import Any
@@ -39,6 +40,26 @@ class ReducedData:
     """
     value: Any
     max_diff: float = None
+
+
+class BlobTypes(Enum):
+    png = 'png'
+    numpy = 'numpy'
+    pickle = 'pickle'  # We try to avoid pickle, but have used it in the past
+    unknown = 'unknown'
+
+    @classmethod
+    def identify(cls, blob: bytes):
+        if blob.startswith(b'\x89PNG\r\n\x1a\x0a'):
+            return cls.png
+        elif blob.startswith(b'\x93NUMPY'):
+            return cls.numpy
+        elif blob.startswith(b'\x80'):
+            # Since pickle v2 (Python 2.3), all pickles start with a protocol
+            # version opcode (0x80).
+            return cls.pickle
+
+        return cls.unknown
 
 
 def db_path(root_path: Path):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -23,7 +23,7 @@ from extra_data.read_machinery import find_proposal
 from kafka import KafkaProducer
 
 from ..context import ContextFile, RunData
-from ..ctxsupport.ctxrunner import get_user_variables
+from ..ctxsupport.ctxrunner import get_user_variables, PNGData
 from ..definitions import UPDATE_BROKERS, UPDATE_TOPIC
 from .db import DamnitDB, ReducedData
 
@@ -205,6 +205,9 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run):
         # zero-dimensional arrays first.
         if isinstance(value, (np.ndarray, np.generic)) and value.ndim == 0:
             value = value.item()
+
+        if isinstance(value, PNGData):
+            value = value.data
 
         # Serialize non-SQLite-supported types
         if not isinstance(value, (int, float, str, bytes)):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -199,10 +199,7 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run):
     for name, reduced in reduced_data.items():
         value = reduced.value
 
-        # For convenience, all returned values from Variables are stored in
-        # arrays. If a Variable returns a scalar then we'll end up with a
-        # zero-dimensional array here which will be pickled, so we unbox all
-        # zero-dimensional arrays first.
+        # Unbox 0D arrays to get a scalar
         if isinstance(value, (np.ndarray, np.generic)) and value.ndim == 0:
             value = value.item()
 
@@ -211,7 +208,7 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run):
 
         # Serialize non-SQLite-supported types
         if not isinstance(value, (int, float, str, bytes)):
-            value = pickle.dumps(value)
+            raise TypeError(f"Unsupported type for database: {type(value)}")
 
         reduced.value = value
         db.set_variable(proposal, run, name, reduced)

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -25,7 +25,7 @@ from kafka import KafkaProducer
 from ..context import ContextFile, RunData
 from ..ctxsupport.ctxrunner import get_user_variables, PNGData
 from ..definitions import UPDATE_BROKERS, UPDATE_TOPIC
-from .db import DamnitDB, ReducedData
+from .db import DamnitDB, ReducedData, BlobTypes
 
 
 
@@ -157,7 +157,7 @@ def load_reduced_data(h5_path):
         if h5py.check_string_dtype(ds.dtype) is not None:
             return ds.asstr()[()]
         elif (ds.ndim == 1 and ds.dtype == np.uint8
-              and ds[:8].tobytes() == b'\x89PNG\r\n\x1a\n'):
+              and BlobTypes.identify(ds[:8].tobytes()) is BlobTypes.png):
             return PNGData(ds[()].tobytes())
         else:
             value = ds[()]

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -156,7 +156,8 @@ def load_reduced_data(h5_path):
         # If it's a string, extract the string
         if h5py.check_string_dtype(ds.dtype) is not None:
             return ds.asstr()[()]
-        elif ds.attrs.get('damnit_png', 0) == 1:
+        elif (ds.ndim == 1 and ds.dtype == np.uint8
+              and ds[:8].tobytes() == b'\x89PNG\r\n\x1a\n'):
             return PNGData(ds[()].tobytes())
         else:
             value = ds[()]

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -252,7 +252,7 @@ def main():
         db = DamnitDB()
 
         if args.migrate_subcmd == "images":
-            migrate_images(db, Path.cwd())
+            migrate_images(db, Path.cwd(), args.dry_run)
         elif args.migrate_subcmd == "v0-to-v1":
             migrate_v0_to_v1(db, Path.cwd(), args.dry_run)
 

--- a/damnit/context.py
+++ b/damnit/context.py
@@ -7,4 +7,4 @@ if ctxsupport_dir not in sys.path:
 
 # Exposing these here for compatibility
 from damnit_ctx import RunData, UserEditableVariable, Variable
-from ctxrunner import ContextFile, Results, get_proposal_path
+from ctxrunner import ContextFile, PNGData, Results, get_proposal_path

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -431,7 +431,7 @@ class Results:
                     del f[name]
 
             for grp_name, hint in obj_type_hints.items():
-                f.require_group(grp_name).attrs['damnit_objtype'] = hint.value
+                f.require_group(grp_name).attrs['_damnit_objtype'] = hint.value
 
             # Create datasets before filling them, so metadata goes near the
             # start of the file.

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -361,9 +361,9 @@ class Results:
             from scipy import ndimage
 
             # For the sake of space and memory we downsample images to a
-            # resolution of 150x150.
+            # resolution of 35 pixels on the larger dimension.
             image_shape = data.get_size_inches() * data.dpi if is_figure else data.shape
-            zoom_ratio = min(1, 150 / max(image_shape))
+            zoom_ratio = min(1, 35 / max(image_shape))
 
             if is_figure:
                 # If this is a matplotlib figure, we scale down the figure

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -444,7 +444,6 @@ class Results:
                     f.create_dataset(path, shape=(), dtype=h5py.string_dtype())
                 elif isinstance(obj, PNGData):  # Thumbnail
                     f.create_dataset(path, shape=len(obj.data), dtype=np.uint8)
-                    f[path].attrs['damnit_png'] = 1
                 else:
                     f.create_dataset(path, shape=obj.shape, dtype=obj.dtype)
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -1,4 +1,3 @@
-import pickle
 import logging
 import shelve
 import sys
@@ -268,17 +267,6 @@ da-dev@xfel.eu"""
 
         df.insert(len(df.columns), "comment_id", pd.NA)
         df.pop("added_at")
-
-        # Unpickle serialized objects. First we select all columns that
-        # might need deserializing.
-        object_cols = df.select_dtypes(include=["object"]).drop(columns=["comment", "comment_id"],
-                                                                errors="ignore")
-        # Then we check each element and unpickle it if necessary, and
-        # finally update the main DataFrame.
-        unpickled_cols = object_cols.applymap(lambda x: pickle.loads(x) if (
-                isinstance(x, bytes) and BlobTypes.identify(x) is BlobTypes.pickle
-        ) else x)
-        df.update(unpickled_cols)
 
         # Read the comments and prepare them for merging with the main data
         comments_df = pd.read_sql_query(

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -529,10 +529,10 @@ da-dev@xfel.eu"""
         else:
             extension = export_path.suffix
 
-        # Helper function to convert 2D arrays to a string tag. Meant for
+        # Helper function to convert image blobs to a string tag. Meant for
         # applying to a DataFrame.
         def image2str(value):
-            if isinstance(value, np.ndarray) and value.ndim == 3:
+            if isinstance(value, bytes) and BlobTypes.identify(value) is BlobTypes.png:
                 return "<image>"
             else:
                 return value

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -21,7 +21,7 @@ from PyQt5.QtWidgets import QMessageBox, QTabWidget, QFileDialog
 from PyQt5.Qsci import QsciScintilla, QsciLexerPython
 
 from ..backend.api import RunVariables
-from ..backend.db import db_path, DamnitDB, ReducedData
+from ..backend.db import db_path, DamnitDB, ReducedData, BlobTypes
 from ..backend.extract_data import get_context_file, process_log_path
 from ..backend import initialize_and_start_backend, backend_is_running
 from ..context import ContextFile
@@ -275,7 +275,9 @@ da-dev@xfel.eu"""
                                                                 errors="ignore")
         # Then we check each element and unpickle it if necessary, and
         # finally update the main DataFrame.
-        unpickled_cols = object_cols.applymap(lambda x: pickle.loads(x) if isinstance(x, bytes) else x)
+        unpickled_cols = object_cols.applymap(lambda x: pickle.loads(x) if (
+                isinstance(x, bytes) and BlobTypes.identify(x) is BlobTypes.pickle
+        ) else x)
         df.update(unpickled_cols)
 
         # Read the comments and prepare them for merging with the main data
@@ -809,12 +811,12 @@ da-dev@xfel.eu"""
         )
 
         cell_data = self.data.iloc[index.row(), index.column()]
-        if not pd.api.types.is_number(cell_data) and not isinstance(cell_data, np.ndarray):
+        is_image = isinstance(cell_data, bytes) and BlobTypes.identify(cell_data) is BlobTypes.png
+
+        if not (is_image or pd.api.types.is_number(cell_data) or isinstance(cell_data, np.ndarray)):
             QMessageBox.warning(self, "Can't inspect variable",
                                 f"'{quantity}' has type '{type(cell_data).__name__}', cannot inspect.")
             return
-
-        is_image = (isinstance(cell_data, np.ndarray) and cell_data.ndim == 3)
 
         try:
             variable = RunVariables(self._context_path.parent, run)[quantity]

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -26,7 +26,7 @@ from ..backend.extract_data import get_context_file, process_log_path
 from ..backend import initialize_and_start_backend, backend_is_running
 from ..context import ContextFile
 from ..ctxsupport.damnit_ctx import UserEditableVariable
-from ..ctxsupport.ctxrunner import get_user_variables, DataType
+from ..ctxsupport.ctxrunner import get_user_variables
 from ..definitions import UPDATE_BROKERS
 from ..util import StatusbarStylesheet, timestamp2str
 from .kafka import UpdateReceiver
@@ -826,14 +826,14 @@ da-dev@xfel.eu"""
             if is_image:
                 image = variable.ndarray()
             else:
-                if variable.stored_type == DataType.Scalar:
+                y = variable.xarray()
+                if y.ndim == 0:
                     # If this is a scalar value, then we can't plot it
                     QMessageBox.warning(self, "Can't inspect variable",
                                         f"'{quantity}' is a scalar, there's nothing more to plot.")
                     return
 
                 # Use the train ID if it's been saved, otherwise generate an X axis
-                y = variable.xarray()
                 if "trainId" in y.coords:
                     x = y.trainId
                 else:

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -6,6 +6,7 @@ import pandas as pd
 from PyQt5 import QtCore, QtWidgets, QtGui
 from PyQt5.QtCore import Qt
 
+from ..backend.db import BlobTypes
 from ..util import StatusbarStylesheet, timestamp2str
 
 ROW_HEIGHT = 30
@@ -349,10 +350,18 @@ class Table(QtCore.QAbstractTableModel):
                 return font
 
         elif role == Qt.DecorationRole:
+            if isinstance(value, bytes) and BlobTypes.identify(value) is BlobTypes.png:
+                pixmap = QtGui.QPixmap()
+                pixmap.loadFromData(value, "PNG")
+                if max(pixmap.height(), pixmap.width()) > THUMBNAIL_SIZE:
+                    pixmap = pixmap.scaled(
+                        THUMBNAIL_SIZE, THUMBNAIL_SIZE, Qt.KeepAspectRatio
+                    )
+                return pixmap
             if isinstance(value, np.ndarray):
                 return self.generateThumbnail(run, proposal, quantity_title)
         elif role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
-            if isinstance(value, np.ndarray):
+            if isinstance(value, (np.ndarray, bytes)):
                 # The image preview for this is taken care of by the DecorationRole
                 return None
 

--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -43,7 +43,6 @@ def migrate_images(db, db_dir, dry_run):
                             dset = reduced.create_dataset(
                                 ds_name, data=np.frombuffer(image.data, dtype=np.uint8)
                             )
-                            dset.attrs['damnit_png'] = 1
 
     # And then update the summaries in the database
     for run, run_reduced_data in reduced_data.items():

--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -123,6 +123,11 @@ def migrate_dataarrays(db, db_dir, dry_run):
 
 
 def main_dataset(grp: h5py.Group):
+    """Get the main dataset from a group representing an xarray or numpy array.
+
+    For an xarray DataArray, this is the one that's not coordinate labels.
+    We're assuming these groups have already been converted to NetCDF format.
+    """
     candidates = {name for (name, dset) in grp.items()
                   if dset.attrs.get('CLASS', b'') != b'DIMENSION_SCALE'}
     if len(candidates) == 1:
@@ -172,6 +177,8 @@ def migrate_v0_to_v1(db, db_dir, dry_run):
                     continue
 
                 if (ds := main_dataset(f[name])) is None:
+                    print(f"Couldn't identify main dataset for {name} in "
+                          f"{h5_path}, skipping max_diff")
                     continue
 
                 if 'max_diff' in ds.attrs:

--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -107,7 +107,7 @@ def migrate_dataarrays(db, db_dir, dry_run):
                 if not dry_run:
                     f[name].clear()
                     f[name].attrs.clear()
-                    f[name].attrs['damnit_objtype'] = DataType.DataArray.value
+                    f[name].attrs['_damnit_objtype'] = DataType.DataArray.value
 
         for name, arr in groups_to_replace:
             print(f"{would}Save {name} in {h5_path.relative_to(db_dir)}")

--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -37,7 +37,10 @@ def migrate_images(db, db_dir):
 
                         # Overwrite the dataset
                         del reduced[ds_name]
-                        reduced.create_dataset(ds_name, data=image)
+                        dset = reduced.create_dataset(
+                            ds_name, data=np.frombuffer(image.data, dtype=np.uint8)
+                        )
+                        dset.attrs['damnit_png'] = 1
 
     # And then update the summaries in the database
     for run, run_reduced_data in reduced_data.items():

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -8,20 +8,15 @@ from matplotlib.figure import Figure
 from damnit.cli import main
 from damnit.context import ContextFile
 from damnit.backend.extract_data import ReducedData
-from damnit.ctxsupport.ctxrunner import get_variable_type
 
 
 def reduced_data_from_dict(input_dict):
     """
     Create a dictionary of name -> ReducedData objects for add_to_db().
     """
-    # Types taken from Results.create()
-    not_array_types = (xr.DataArray, str, type(None), Figure)
 
     return {
-        name: ReducedData(data,
-                          get_variable_type(data if type(data) in not_array_types \
-                                            else np.array(data)))
+        name: ReducedData(data)
         for name, data in input_dict.items()
     }
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1,6 +1,5 @@
 import os
 import stat
-import pickle
 import signal
 import logging
 import graphlib
@@ -376,7 +375,7 @@ def test_add_to_db(mock_db):
         "scalar": 42,
         "np_scalar": np.float32(10),
         "zero_dim_array": np.asarray(42),
-        "image": np.random.rand(10, 10)
+        "image": b'\x89PNG\r\n\x1a\n...'  # Not a valid PNG, but good enough for this
     }
 
     add_to_db(reduced_data_from_dict(reduced_data), db, 1234, 42)
@@ -388,7 +387,7 @@ def test_add_to_db(mock_db):
     assert row["scalar"] == reduced_data["scalar"]
     assert row["np_scalar"] == reduced_data["np_scalar"].item()
     assert row["zero_dim_array"] == reduced_data["zero_dim_array"].item()
-    np.testing.assert_array_equal(pickle.loads(row["image"]), reduced_data["image"])
+    assert row["image"] == reduced_data["image"]
 
 def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
     # Change to the DB directory
@@ -421,7 +420,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
         extractor = Extractor()
 
     # Test regular variables and slurm variables are executed
-    reduced_data = reduced_data_from_dict({ "array": np.arange(10) })
+    reduced_data = reduced_data_from_dict({ "n": 53 })
     with patch(f"{pkg}.extract_in_subprocess", return_value=reduced_data) as extract_in_subprocess, \
          patch(f"{pkg}.subprocess.run") as subprocess_run:
         extractor.extract_and_ingest(1234, 42, cluster=False,

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -293,7 +293,6 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     results.save_hdf5(results_hdf5_path)
     with h5py.File(results_hdf5_path) as f:
         assert f["figure/data"].ndim == 3
-        assert f[".reduced/figure"].attrs['damnit_png'] == 1
 
     # Test returning xarray.Datasets
     dataset_code = """

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from damnit.migrations import migrate_images
 from damnit.backend.extract_data import add_to_db
-from damnit.backend.db import BlobTypes
+from damnit.backend.db import BlobTypes, ReducedData
 
 from .helpers import reduced_data_from_dict
 
@@ -28,8 +28,8 @@ def test_migrate_images(mock_db, monkeypatch):
     with h5py.File(mock_h5_path, "w") as f:
         f.create_dataset(".reduced/foo", data=foo)
         f.create_dataset(".reduced/bar", data=np.array(bar))
-    add_to_db(reduced_data_from_dict({"foo": foo, "bar": bar}),
-              db, proposal, run)
+    db.set_variable(proposal, run, "bar", ReducedData(bar))
+    db.set_variable(proposal, run, "foo", ReducedData(pickle.dumps(foo)))
 
     migrate_images(db, db_dir, dry_run=False)
 

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -38,7 +38,6 @@ def test_migrate_images(mock_db, monkeypatch):
     with h5py.File(mock_h5_path) as f:
         assert f[".reduced/foo"].ndim == 1
         assert f[".reduced/foo"].dtype == np.uint8
-        assert f[".reduced/foo"].attrs['damnit_png'] == 1
         assert f[".reduced/bar"][()] == bar
 
     cursor = db.conn.execute("SELECT * FROM runs")

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from damnit.migrations import migrate_images
 from damnit.backend.extract_data import add_to_db
+from damnit.backend.db import BlobTypes
 
 from .helpers import reduced_data_from_dict
 
@@ -30,19 +31,19 @@ def test_migrate_images(mock_db, monkeypatch):
     add_to_db(reduced_data_from_dict({"foo": foo, "bar": bar}),
               db, proposal, run)
 
-    migrate_images(db, db_dir)
+    migrate_images(db, db_dir, dry_run=False)
 
-    # Now the summary should be a 3D RGBA image, and the non-image summary
+    # Now the summary should be a PNG image, and the non-image summary
     # should be unchanged.
     with h5py.File(mock_h5_path) as f:
-        assert f[".reduced/foo"].shape == (*foo.shape, 4)
+        assert f[".reduced/foo"].ndim == 1
         assert f[".reduced/foo"].dtype == np.uint8
+        assert f[".reduced/foo"].attrs['damnit_png'] == 1
         assert f[".reduced/bar"][()] == bar
 
     cursor = db.conn.execute("SELECT * FROM runs")
     row = cursor.fetchone()
-    thumbnail = pickle.loads(row["foo"])
-    assert isinstance(thumbnail, np.ndarray)
-    assert thumbnail.shape == (*foo.shape, 4)
-    assert thumbnail.dtype == np.uint8
+    thumbnail = row["foo"]
+    assert isinstance(thumbnail, bytes)
+    assert BlobTypes.identify(thumbnail) is BlobTypes.png
     assert row["bar"] == bar


### PR DESCRIPTION
@JamesWrigley I've done this as a PR targeting your PR (#134) for now. I've tried to keep the commits separate for piece by piece review, but I haven't managed this as neatly as you always do.

Data changes:

- Move the object type hint for un-summarised results into the HDF5 files, stored as a group attribute `damnit_objtype` (25daf2b61cc7981f8106948b119ed79677b68d63).
   - I'm only using this for types that we can't store & reconstruct with the native type information, so I don't store a type hint for numpy arrays, numbers or strings. This avoids duplicating this information, but it's an aesthetic choice, and we could easily store an object type for every variable if we prefer.
 - Add a column `summary_type` to store additional type hints for summary variables (1c4d2ffabe2a1cea2659f0a5b4b6fce7a6db9612).
   - This is currently unused - I plan to store e.g. 'timestamp' for timestamps, but I didn't want to get into timestamp handling in this PR.
 - Scale thumbnails down to 35 x 35 before storing (65556697f37a523815b196f65cbb99c892dc373a)
 - Store thumbnails as PNG data rather than pickled arrays (6c369c232dd37bceb3f9abb50ee3bc3f801371aa)
   - I think this means the database contents are pickle-free now, but I haven't checked

And some changes to the migration code:

- Separate out the logic to migrate DataArrays to NetCDF format from the database migration code (78b18c9a0101694509fefb2bcf2ba37a6b9fc738), although this is still part of the `v0-to-v1` migration.
- Migrate the database to v1 format by creating a new database and copying data across, rather than changing it in-place (faa602f6c1b987aace22909aa42287c87130df89).
  - This gives a nice way to implement `--dry-run` - do everything apart from the final rename of the file.
- Add `--dry-run` mode for the images migration (ce052bf74e0d62def5d4359f36fe5f827265e612)
  - Not as good as the database dry run, but still  gives you an idea what it would do.