### PR TITLE
Refuse to open old databases (except to migrate)

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -249,7 +249,7 @@ def main():
         from .backend.db import DamnitDB
         from .migrations import migrate_images, migrate_v0_to_v1
 
-        db = DamnitDB()
+        db = DamnitDB(allow_old=True)
 
         if args.migrate_subcmd == "images":
             migrate_images(db, Path.cwd(), args.dry_run)


### PR DESCRIPTION
We plan to migrate all the existing DAMNIT DBs to the new format, so to keep the code simpler we will refuse to open databases until they are migrated.

I've tested this with the GUI - both pointing to a folder on the command line, and selecting a proposal from the dialog - as well as the subcommands proposal, reprocess, new-id & db-config, plus I tested doing a migration (with the `--dry-run` option), which shouldn't be blocked. I used p900385 to try this.

Part of #151.