### PR TITLE
Add summary method (e.g. 'mean', 'sum') to database

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -19,7 +19,7 @@ V1_SCHEMA = """
 CREATE TABLE IF NOT EXISTS run_info(proposal, run, start_time, added_at);
 CREATE UNIQUE INDEX IF NOT EXISTS proposal_run ON run_info (proposal, run);
 
-CREATE TABLE IF NOT EXISTS run_variables(proposal, run, name, version, value, timestamp, max_diff, provenance, summary_type);
+CREATE TABLE IF NOT EXISTS run_variables(proposal, run, name, version, value, timestamp, max_diff, provenance, summary_type, summary_method);
 CREATE UNIQUE INDEX IF NOT EXISTS variable_version ON run_variables (proposal, run, name, version);
 
 -- These are dummy views that will be overwritten later, but they should at least
@@ -48,6 +48,7 @@ class ReducedData:
     """
     value: Any
     max_diff: float = None
+    summary_method: str = ''
 
 
 class BlobTypes(Enum):
@@ -226,7 +227,7 @@ class DamnitDB:
         variable["version"] = 1 # if latest_version is None else latest_version + 1
 
         # These columns should match those in the run_variables table
-        cols = ["proposal", "run", "name", "version", "value", "timestamp", "max_diff", "provenance"]
+        cols = ["proposal", "run", "name", "version", "value", "timestamp", "max_diff", "provenance", "summary_method"]
         col_list = ", ".join(cols)
         col_values = ", ".join([f":{col}" for col in cols])
         col_updates = ", ".join([f"{col} = :{col}" for col in cols])

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -166,8 +166,11 @@ def load_reduced_data(h5_path):
 
     with h5py.File(h5_path, 'r') as f:
         return {
-            name: ReducedData(get_dset_value(dset),
-                              dset.attrs.get("max_diff", np.array(None)).item())
+            name: ReducedData(
+                get_dset_value(dset),
+                max_diff=dset.attrs.get("max_diff", np.array(None)).item(),
+                summary_method=dset.attrs.get("summary_method", "")
+            )
             for name, dset in f['.reduced'].items()
         }
 

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -462,6 +462,10 @@ class Results:
                    and data.ndim == 1 and data.shape[0] > 1:
                     reduced_ds.attrs["max_diff"] = abs(np.nanmax(data) - np.nanmin(data))
 
+                var_obj = ctx_vars.get(name)
+                if var_obj is not None:
+                    reduced_ds.attrs['summary_method'] = var_obj.summary or ''
+
         for name, obj in xarray_dsets:
             # HDF5 doesn't allow slashes in names :(
             if isinstance(obj, xr.DataArray) and obj.name is not None and "/" in obj.name:


### PR DESCRIPTION
In the `run_variables` table, so we know how each summary value was calculated. An empty value means no explicit summarisation - either the function returned a single value already, or we've got the default string representation of an array.

I'm working with a copy of the p900385 database. I went back to the v0 files, re-migrated to get the new `summary_method` field, and then reprocessed a run to put values in there. Here it is in sqlite-glance:

![image](https://github.com/European-XFEL/DAMNIT/assets/327925/8a37671f-5d79-4796-857c-3bbf12777165)

Part of #151