### PR TITLE
Add support for deleting variables

### DIFF
--- a/damnit/backend/api.py
+++ b/damnit/backend/api.py
@@ -1,3 +1,4 @@
+import glob
 from pathlib import Path
 from contextlib import contextmanager
 
@@ -5,7 +6,7 @@ import h5py
 import xarray as xr
 
 from .db import DamnitDB
-from ..ctxsupport.ctxrunner import DataType
+from ..ctxsupport.ctxrunner import DataType, add_to_h5_file
 
 
 class VariableData:
@@ -117,3 +118,14 @@ class RunVariables:
     @property
     def file(self):
         return self._h5_path
+
+def delete_variable(db, name):
+    # Remove from the database
+    db.delete_variable(name)
+
+    # And the HDF5 files
+    for h5_path in glob.glob(f"{db.path.parent}/extracted_data/*.h5"):
+        with add_to_h5_file(h5_path) as f:
+            if name in f:
+                del f[f".reduced/{name}"]
+                del f[name]

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -402,9 +402,9 @@ da-dev@xfel.eu"""
             self._columns_dialog.setWindowTitle("Column settings")
             layout = QtWidgets.QVBoxLayout()
 
-            layout.addWidget(QtWidgets.QLabel("These columns can be hidden but not reordered:"))
+            layout.addWidget(QtWidgets.QLabel("These columns can be hidden but not reordered or deleted:"))
             layout.addWidget(self.table_view._static_columns_widget)
-            layout.addWidget(QtWidgets.QLabel("Drag these columns to reorder them:"))
+            layout.addWidget(QtWidgets.QLabel("Drag these columns to reorder them, right-click to delete:"))
             layout.addWidget(self.table_view._columns_widget)
             self._columns_dialog.setLayout(layout)
 
@@ -460,7 +460,7 @@ da-dev@xfel.eu"""
         fileMenu.addAction(action_exit)
 
         # Table menu
-        action_columns = QtWidgets.QAction("Select && reorder columns", self)
+        action_columns = QtWidgets.QAction("Select, delete, && reorder columns", self)
         action_columns.triggered.connect(self.open_column_dialog)
         self.action_autoscroll = QtWidgets.QAction('Scroll to newly added runs', self)
         self.action_autoscroll.setCheckable(True)


### PR DESCRIPTION
This is mildly cursed because it will reload the database upon deletion. For two reasons:
- There are lingering bugs surrounding moving columns after changing the number of variables, and I don't want to deal with that right now.
- Laziness :innocent: 

My justification is that deleting a variable is something that will (hopefully) occur rarely, and occur when writing the context file for the first time while the database is likely to be empty-ish (so it won't take an obnoxious amount of time to reload). Plus, loading databases isn't *too* awful with the v1 format.

Another thing I'm unsure about is the location of the `api.delete_variable()` function. I put it in `api.py` because I have vague ideas about having a writable wrapper for a future read-only API (exposed to users through a separate package), but I couldn't think of a nice way to fit that into the `VariableData`/`RunVariables` classes. I also considered merging it with `DamnitDB.delete_variable()` but then `DamnitDB` would come to mean 'database and HDF5 files' while it's currently just 'database'. Not sure how I feel about that.

Demo:
![damnit-delete-variable](https://github.com/European-XFEL/DAMNIT/assets/5361518/72294ec0-f325-489e-9ec3-58bc017a2307)

Fixes #69.