### PR TITLE
Listen for incoming events on EuXFEL Kafka broker

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,26 +40,26 @@ at the command line.
 
 ## Kafka
 The GUI is updated by Kafka messages sent by the backend. Currently we use
-XFEL's internal Kafka broker at `exflwebstor01.desy.de:9102`, but this is only
+XFEL's internal Kafka broker at `exflwgs06.desy.de:9091`, but this is only
 accessible inside the DESY network.
 
 DAMNIT can run offline, but if you want updates from the backend and you're
 running DAMNIT outside the network and not using a VPN, you'll first have to
 forward the broker port to your machine:
 ```bash
-ssh -L 9102:exflwebstor01.desy.de:9102 max-exfl.desy.de
+ssh -L 9091:exflwgs06.desy.de:9091 max-exfl.desy.de
 ```
 
-And then add a line in your `/etc/hosts` file to resolve `exflwebstor01.desy.de`
+And then add a line in your `/etc/hosts` file to resolve `exflwgs06.desy.de`
 to `localhost` (remember to remove it afterwards!):
 ```
-127.0.0.1 exflwebstor01.desy.de
+127.0.0.1 exflwgs06.desy.de
 ```
 
 And then DAMNIT should be able to use XFELs broker. If you want to use a specific
 broker you can set the `AMORE_BROKER` variable:
 ```bash
-export AMORE_BROKER=localhost:9102
+export AMORE_BROKER=localhost:9091
 ```
 
 DAMNIT will then connect to the broker at that address.

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -21,7 +21,7 @@ CONSUMER_ID = 'xfel-da-amore-prototype-{}'
 KAFKA_CONF = {
     'maxwell': {
         'brokers': ['exflwgs06:9091'],
-        'topics': ["xfel-test-r2d2", "cal.offline-corrections"],
+        'topics': ["test.r2d2", "cal.offline-corrections"],
         'events': ["migration_complete", "run_corrections_complete"],
     },
     'onc': {

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -20,8 +20,8 @@ from .extract_data import RunData, process_log_path
 CONSUMER_ID = 'xfel-da-amore-prototype-{}'
 KAFKA_CONF = {
     'maxwell': {
-        'brokers': [f'it-kafka-broker{i:02}.desy.de' for i in range(1, 4)],
-        'topics': ["xfel-test-r2d2", "xfel-test-offline-cal"],
+        'brokers': ['exflwgs06:9091'],
+        'topics': ["xfel-test-r2d2", "cal.offline-corrections"],
         'events': ["migration_complete", "run_corrections_complete"],
     },
     'onc': {

--- a/damnit/definitions.py
+++ b/damnit/definitions.py
@@ -4,6 +4,6 @@ import os
 if "AMORE_BROKER" in os.environ:
     UPDATE_BROKERS = [os.environ["AMORE_BROKER"]]
 else:
-    UPDATE_BROKERS = ['exflwebstor01.desy.de:9102']
+    UPDATE_BROKERS = ['exflwgs06.desy.de:9091']
 
-UPDATE_TOPIC = "amore-db-{}"  # Fill in ID stored in database
+UPDATE_TOPIC = "test.damnit.db-{}"  # Fill in ID stored in database


### PR DESCRIPTION
We still need to know the new topic for migration events (topics are now namespaced).

Do we want to move over the internal updates as well? We're currently using the first test broker that was set up (exflwebstor01).