### PR TITLE
Fix sending updates containing PNG thumbnails

### DIFF
--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -42,7 +42,7 @@ def migrate_images(new_db, db_dir, dry_run):
                         # Generate a new thumbnail
                         image = reduced[ds_name][()]
                         image = generate_thumbnail(image)
-                        reduced_data[run][ds_name] = ReducedData(image)
+                        reduced_data[run][ds_name] = ReducedData(image.data)
                         files_modified.add(h5_path)
 
                         if not dry_run:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -373,8 +373,7 @@ def test_add_to_db(mock_db):
     reduced_data = {
         "string": "foo",
         "scalar": 42,
-        "np_scalar": np.float32(10),
-        "zero_dim_array": np.asarray(42),
+        "float": 31.7,
         "image": b'\x89PNG\r\n\x1a\n...'  # Not a valid PNG, but good enough for this
     }
 
@@ -385,8 +384,7 @@ def test_add_to_db(mock_db):
 
     assert row["string"] == reduced_data["string"]
     assert row["scalar"] == reduced_data["scalar"]
-    assert row["np_scalar"] == reduced_data["np_scalar"].item()
-    assert row["zero_dim_array"] == reduced_data["zero_dim_array"].item()
+    assert row["float"] == reduced_data["float"]
     assert row["image"] == reduced_data["image"]
 
 def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):


### PR DESCRIPTION
There was some conversion we were doing when the reduced data was inserted into the database, which wasn't affecting the data sent through Kafka. This resulted in `<PNGData at ...>` reprs showing up in the table instead of thumbnails.

This moves the conversion to where we load the data, so the data we add to the database and the Kafka messages should be more similar. And as a bonus, it also comes out simpler.