### PR TITLE
Bump the thumbnail size to 300x300

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -34,7 +34,7 @@ from damnit_ctx import RunData, Variable, UserEditableVariable
 
 log = logging.getLogger(__name__)
 
-THUMBNAIL_SIZE = 35 # px
+THUMBNAIL_SIZE = 300 # px
 
 
 # More specific Python types beyond what HDF5/NetCDF4 know about, so we can


### PR DESCRIPTION
This seems to fix the figure-saving errors I was seeing too :crossed_fingers: 