### PR TITLE
Don't try to find max_diff from empty datasets

### DIFF
--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -202,7 +202,7 @@ def migrate_v0_to_v1(db, db_dir, dry_run):
 
                 if 'max_diff' in ds.attrs:
                     max_diffs[(proposal, run_no, name)] = ds.attrs['max_diff'].item()
-                elif ds.ndim == 1 and np.issubdtype(ds.dtype, np.number):
+                elif ds.ndim == 1 and ds.size > 0 and np.issubdtype(ds.dtype, np.number):
                     data = ds[()]
                     max_diff = abs(np.nanmax(data) - np.nanmin(data)).item()
                     max_diffs[(proposal, run_no, name)] = max_diff


### PR DESCRIPTION
Migration failed on p4448 when it tried to find the max & min of a length 0 dataset. With this change, I was able to complete migration.

```
Traceback (most recent call last):
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/conda_env/bin/amore-proto", line 8, in <module>
    sys.exit(main())
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/conda_env/lib/python3.10/site-packages/damnit/cli.py", line 254, in main
    migrate_v0_to_v1(db, Path.cwd(), args.dry_run)
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/conda_env/lib/python3.10/site-packages/damnit/migrations.py", line 207, in migrate_v0_to_v1
    max_diff = abs(np.nanmax(data) - np.nanmin(data)).item()
  File "<__array_function__ internals>", line 180, in nanmax
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/conda_env/lib/python3.10/site-packages/numpy/lib/nanfunctions.py", line 476, in nanmax
    res = np.fmax.reduce(a, axis=axis, out=out, **kwargs)
ValueError: zero-size array to reduction operation fmax which has no identity
```