### PR TITLE
Refactor GUI table machinery

### DIFF
--- a/damnit/gui/user_variables.py
+++ b/damnit/gui/user_variables.py
@@ -43,6 +43,10 @@ class AddUserVariableDialog(QtWidgets.QDialog):
         button_add_var.clicked.connect(self.check_if_variable_is_unique)
         button_cancel.clicked.connect(self.reject)
 
+    @property
+    def table(self):
+        return self._main_window.table
+
     def _load_icons(self):
         def build_icon(idx):
             return QtGui.QIcon(icon_path(f"lock_{idx}_icon.png"))
@@ -159,14 +163,12 @@ class AddUserVariableDialog(QtWidgets.QDialog):
             self.formStatusChanged.emit(new_status)
 
     def check_if_variable_is_unique(self, x):
-        name_already_exists = self._main_window.has_variable(self.variable_name.text())
-        title_already_exists = self._main_window.has_variable(self.variable_title.text(), by_title=True)
         error_type = []
 
-        if name_already_exists:
+        if self.table.has_column(self.variable_name.text()):
             error_type.append('<b>name</b>')
 
-        if title_already_exists:
+        if self.table.has_column(self.variable_title.text(), by_title=True):
             error_type.append('<b>title</b>')
 
         if len(error_type) > 0:


### PR DESCRIPTION
This may seem like an odd thing to do, but every time I go to work on a feature, I stall, because it seems like every part of the code knows about every other part, so it's hard to work on one piece in isolation.

This is an attempt to unpick that a bit. Specifically, I've tried to make only the `Table` class (renamed `DamnitTableModel`) know that it's actually using a pandas Dataframe to hold the data, so everything else that touches the table needs to go through that class. This isn't 100% complete yet - a couple of places in MainWindow still construct dataframes directly - but it's pretty close, and I wanted to open this before the weekend.

This shouldn't change any functionality at all; the tests are passing for me on Maxwell, and I've also tested it interactively.