### PR TITLE
Refactor: separate ctxrunner from database

### DIFF
--- a/damnit/backend/api.py
+++ b/damnit/backend/api.py
@@ -6,7 +6,7 @@ import h5py
 import xarray as xr
 
 from .db import DamnitDB
-from ..ctxsupport.ctxrunner import DataType, add_to_h5_file
+from ..context import DataType, add_to_h5_file
 
 
 class VariableData:

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from secrets import token_hex
 from typing import Any
 
-from ..context import UserEditableVariable
+from .user_variables import UserEditableVariable
 
 DB_NAME = Path('runs.sqlite')
 
@@ -167,6 +167,22 @@ class DamnitDB:
             )
 
         self.update_views()
+
+    def get_user_variables(self):
+        user_variables = {}
+        rows = self.conn.execute("SELECT name, title, type, description, attributes FROM variables")
+        for rr in rows:
+            var_name = rr["name"]
+            new_var = UserEditableVariable(
+                var_name,
+                title=rr["title"],
+                variable_type=rr["type"],
+                description=rr["description"],
+                attributes=rr["attributes"],
+            )
+            user_variables[var_name] = new_var
+        log.debug("Loaded %d user variables", len(user_variables))
+        return user_variables
 
     def variable_names(self):
         names = { record[0] for record in

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -23,7 +23,6 @@ from extra_data.read_machinery import find_proposal
 from kafka import KafkaProducer
 
 from ..context import ContextFile, RunData
-from ..ctxsupport.ctxrunner import get_user_variables
 from ..definitions import UPDATE_BROKERS, UPDATE_TOPIC
 from .db import DamnitDB, ReducedData, BlobTypes
 
@@ -135,7 +134,7 @@ def get_context_file(ctx_path: Path, context_python=None):
     if context_python is None:
         db = DamnitDB.from_dir(ctx_path.parent)
         with db.conn:
-            ctx = ContextFile.from_py_file(ctx_path, external_vars=get_user_variables(db.conn))
+            ctx = ContextFile.from_py_file(ctx_path)
 
         db.close()
         return ctx, None

--- a/damnit/context.py
+++ b/damnit/context.py
@@ -6,5 +6,5 @@ if ctxsupport_dir not in sys.path:
     sys.path.insert(0, ctxsupport_dir)
 
 # Exposing these here for compatibility
-from damnit_ctx import RunData, UserEditableVariable, Variable
+from damnit_ctx import RunData, Variable
 from ctxrunner import ContextFile, PNGData, Results, get_proposal_path

--- a/damnit/context.py
+++ b/damnit/context.py
@@ -7,4 +7,7 @@ if ctxsupport_dir not in sys.path:
 
 # Exposing these here for compatibility
 from damnit_ctx import RunData, Variable
-from ctxrunner import ContextFile, PNGData, Results, get_proposal_path
+from ctxrunner import (
+    ContextFileErrors, ContextFile, DataType, PNGData, Results,
+    add_to_h5_file, get_proposal_path,
+)

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -17,7 +17,6 @@ import time
 from datetime import timezone
 import traceback
 from enum import Enum
-from numbers import Number
 from pathlib import Path
 from unittest.mock import MagicMock
 from graphlib import CycleError, TopologicalSorter
@@ -44,6 +43,15 @@ class DataType(Enum):
     Image = "image"
     Timestamp = "timestamp"
 
+
+class ContextFileErrors(RuntimeError):
+    def __init__(self, problems):
+        self.problems = problems
+
+    def __str__(self):
+        return "\n".join(self.problems)
+
+
 class ContextFile:
 
     def __init__(self, vars, code):
@@ -58,12 +66,11 @@ class ContextFile:
             raise CycleError(f"These Variables have cyclical dependencies, which is not allowed: {e.args[1]}") from e
 
         # Check for raw-data variables that depend on proc-data variables
-        raw_vars = { name: var for name, var in self.vars.items()
-                     if hasattr(var, "data") and var.data == RunData.RAW }
-        for name, var in raw_vars.items():
-            dependencies = self.all_dependencies(var)
-            proc_dependencies = [dep for dep in dependencies
-                                 if not hasattr(self.vars[dep], "data") or self.vars[dep].data == RunData.PROC]
+        for name, var in self.vars.items():
+            if var.data != RunData.RAW:
+                continue
+            proc_dependencies = [dep for dep in self.all_dependencies(var)
+                                 if self.vars[dep].data == RunData.PROC]
 
             if len(proc_dependencies) > 0:
                 # If we have a variable that depends on proc data but didn't
@@ -71,13 +78,23 @@ class ContextFile:
                 # data.
                 if var._data == None:
                     var._data = RunData.PROC.value
-                # Otherwise, if the user explicitly requested raw data but the
-                # variable depends on proc data, that's a problem with the
-                # context file and we raise an exception.
-                elif var._data == RunData.RAW.value:
-                    raise RuntimeError(f"Variable '{name}' is triggered by migration of raw data by data='raw', "
-                                       f"but depends on these Variables that require proc data: {', '.join(proc_dependencies)}\n"
-                                       f"Either remove data='raw' for '{name}' or change it to data='proc'")
+
+    def check(self):
+        problems = []
+        for name, var in self.vars.items():
+            problems.extend(var.check())
+            if var.data != RunData.RAW:
+                continue
+            proc_dependencies = [dep for dep in self.all_dependencies(var)
+                                 if self.vars[dep].data == RunData.PROC]
+
+            if proc_dependencies:
+                if var.data == RunData.RAW:
+                    problems.append(
+                        f"Variable {name} is triggered by migration of raw data (data='raw'), "
+                        f"but depends on these Variables that require proc data: {', '.join(proc_dependencies)}\n"
+                        f"Remove data='raw' for {name} or change it to data='proc'"
+                    )
 
         # Check that no variables have duplicate titles
         titles = [var.title for var in self.vars.values() if var.title is not None]
@@ -85,7 +102,12 @@ class ContextFile:
         if len(duplicate_titles) > 0:
             bad_variables = [name for name, var in self.vars.items()
                              if var.title in duplicate_titles]
-            raise RuntimeError(f"These Variables have duplicate titles between them: {', '.join(bad_variables)}")
+            problems.append(
+                f"These Variables have duplicate titles between them: {', '.join(bad_variables)}"
+            )
+
+        if problems:
+            raise ContextFileErrors(problems)
 
     def ordered_vars(self):
         """
@@ -370,27 +392,27 @@ class Results:
 
         xarray_dsets = []
         obj_type_hints = {}
-        dsets = [(f'.reduced/{name}', v) for name, v in self.reduced.items()
-                 if name in implicit_vars or ctx_vars[name].store_result]
+        dsets = [(f'.reduced/{name}', v) for name, v in self.reduced.items()]
+                 #if name in implicit_vars or ctx_vars[name].store_result]
         if not reduced_only:
             for name, obj in self.data.items():
-                if name in implicit_vars or ctx_vars[name].store_result:
-                    if isinstance(obj, (xr.DataArray, xr.Dataset)):
-                        xarray_dsets.append((name, obj))
-                        obj_type_hints[name] = (
-                            DataType.DataArray if isinstance(obj, xr.DataArray)
-                            else DataType.Dataset
-                        )
+                # if name in implicit_vars or ctx_vars[name].store_result:
+                if isinstance(obj, (xr.DataArray, xr.Dataset)):
+                    xarray_dsets.append((name, obj))
+                    obj_type_hints[name] = (
+                        DataType.DataArray if isinstance(obj, xr.DataArray)
+                        else DataType.Dataset
+                    )
+                else:
+                    if isinstance(obj, Figure):
+                        value =  figure2array(obj)
+                        obj_type_hints[name] = DataType.Image
+                    elif isinstance(obj, str):
+                        value = obj
                     else:
-                        if isinstance(obj, Figure):
-                            value =  figure2array(obj)
-                            obj_type_hints[name] = DataType.Image
-                        elif isinstance(obj, str):
-                            value = obj
-                        else:
-                            value = np.asarray(obj)
+                        value = np.asarray(obj)
 
-                        dsets.append((f'{name}/data', value))
+                    dsets.append((f'{name}/data', value))
 
         log.info("Writing %d variables to %d datasets in %s",
                  len(self.data), len(dsets), hdf5_path)
@@ -516,6 +538,7 @@ def main(argv=None):
             run_data = RunData.RAW
 
         ctx_whole = ContextFile.from_py_file(Path('context.py'))
+        ctx_whole.check()
         ctx = ctx_whole.filter(
             run_data=run_data, cluster=args.cluster_job, name_matches=args.match
         )

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -226,7 +226,7 @@ class ContextFile:
 
                 func = functools.partial(var.func, **kwargs)
 
-                data = func(run_data)  # TODO - fix methods
+                data = func(run_data)
                 if not isinstance(data, (xr.Dataset, xr.DataArray, str, type(None), Figure)):
                     data = np.asarray(data)
             except Exception:
@@ -393,10 +393,8 @@ class Results:
         xarray_dsets = []
         obj_type_hints = {}
         dsets = [(f'.reduced/{name}', v) for name, v in self.reduced.items()]
-                 #if name in implicit_vars or ctx_vars[name].store_result]
         if not reduced_only:
             for name, obj in self.data.items():
-                # if name in implicit_vars or ctx_vars[name].store_result:
                 if isinstance(obj, (xr.DataArray, xr.Dataset)):
                     xarray_dsets.append((name, obj))
                     obj_type_hints[name] = (

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -28,9 +28,8 @@ import extra_data
 import h5py
 import numpy as np
 import xarray as xr
-import sqlite3
 
-from damnit_ctx import RunData, Variable, UserEditableVariable
+from damnit_ctx import RunData, Variable
 
 log = logging.getLogger(__name__)
 
@@ -57,14 +56,6 @@ class ContextFile:
         except CycleError as e:
             # Tweak the error message to make it clearer
             raise CycleError(f"These Variables have cyclical dependencies, which is not allowed: {e.args[1]}") from e
-
-        # Temporarily prevent User Editable Variables as dependencies
-        user_var_deps = set()
-        for name, var in self.vars.items():
-            user_var_deps |= {dep for dep in self.all_dependencies(var) if isinstance(self.vars[dep], UserEditableVariable)}
-        if len(user_var_deps):
-            all_vars_quoted = ", ".join(f'"{name}"' for name in sorted(user_var_deps))
-            raise ValueError(f"The following user-editable variables are used as dependencies, this is currently unsupported: {all_vars_quoted}")
 
         # Check for raw-data variables that depend on proc-data variables
         raw_vars = { name: var for name, var in self.vars.items()
@@ -124,22 +115,18 @@ class ContextFile:
         return dependencies
 
     @classmethod
-    def from_py_file(cls, path: Path, external_vars={}):
+    def from_py_file(cls, path: Path):
         code = path.read_text()
         log.debug("Loading context from %s", path)
-        return ContextFile.from_str(code, external_vars)
+        return ContextFile.from_str(code)
 
     @classmethod
-    def from_str(cls, code: str, external_vars={}):
+    def from_str(cls, code: str):
         d = {}
         exec(code, d)
         vars = {v.name: v for v in d.values() if isinstance(v, Variable)}
         log.debug("Loaded %d variables", len(vars))
-        clashing_vars = vars.keys() & external_vars.keys()
-
-        if len(clashing_vars) > 0:
-            raise RuntimeError(f"These Variables have clashing names: {', '.join(clashing_vars)}")
-        return cls(vars | external_vars, code)
+        return cls(vars, code)
 
     def filter(self, run_data=RunData.ALL, cluster=True, name_matches=()):
         new_vars = {}
@@ -167,52 +154,57 @@ class ContextFile:
 
         return ContextFile(new_vars, self.code)
 
-    def execute(self, inputs, run_number, proposal) -> 'Results':
-        res = {'start_time': np.asarray(get_start_time(inputs['run_data']))}
-
-        def get_dep_or_default(var, arg_name, dep_name):
-            """
-            Helper function to get either the value returned from the dependency
-            `dep_name` of `var`, if any, or the default value of the argument in
-            the function signature.
-            """
-            value = res.get(dep_name)
-            if value is None:
-                value = inspect.signature(var.func).parameters[arg_name].default
-
-            return value
+    def execute(self, run_data, run_number, proposal, input_vars) -> 'Results':
+        res = {'start_time': np.asarray(get_start_time(run_data))}
 
         for name in self.ordered_vars():
             var = self.vars[name]
 
             try:
-                # Add all variable dependencies
-                kwargs = { arg_name: get_dep_or_default(var, arg_name, dep_name)
-                           for arg_name, dep_name in var.arg_dependencies().items() }
+                kwargs = {}
+                missing_deps = []
+                missing_input = []
 
-                # Check for missing dependencies with no default value
-                missing_deps = [key for key, value in kwargs.items() if value is inspect.Parameter.empty]
-                if len(missing_deps) > 0:
-                    log.warning(f"Skipping {name} because of missing dependencies: {', '.join(missing_deps)}")
-                    continue
-
-                # And all meta dependencies
-                for arg_name, annotation in var.annotations().items():
-                    if not annotation.startswith("meta#"):
+                for arg_name, param in inspect.signature(var.func).parameters.items():
+                    annotation = param.annotation
+                    if not isinstance(annotation, str):
                         continue
 
-                    if annotation == "meta#run_number":
+                    # Dependency within the context file
+                    if annotation.startswith("var#"):
+                        dep_name = annotation.removeprefix("var#")
+                        if dep_name in res:
+                            kwargs[arg_name] = res[dep_name]
+                        elif param.default is inspect.Parameter.empty:
+                            missing_deps.append(dep_name)
+
+                    # Input variable passed from outside
+                    elif annotation.startswith("input#"):
+                        inp_name = annotation.removeprefix("input#")
+                        if inp_name in input_vars:
+                            kwargs[arg_name] = input_vars[inp_name]
+                        elif param.default is inspect.Parameter.empty:
+                            missing_input.append(inp_name)
+
+                    elif annotation == "meta#run_number":
                         kwargs[arg_name] = run_number
                     elif annotation == "meta#proposal":
                         kwargs[arg_name] = proposal
                     elif annotation == "meta#proposal_path":
-                        kwargs[arg_name] = get_proposal_path(inputs['run_data'])
+                        kwargs[arg_name] = get_proposal_path(run_data)
                     else:
                         raise RuntimeError(f"Unknown path '{annotation}' for variable '{var.title}'")
 
+                if missing_deps:
+                    log.warning(f"Skipping {name} because of missing dependencies: {', '.join(missing_deps)}")
+                    continue
+                elif missing_input:
+                    log.warning(f"Skipping {name} because of missing input variables: {', '.join(missing_input)}")
+                    continue
+
                 func = functools.partial(var.func, **kwargs)
 
-                data = func(inputs)
+                data = func(run_data)  # TODO - fix methods
                 if not isinstance(data, (xr.Dataset, xr.DataArray, str, type(None), Figure)):
                     data = np.asarray(data)
             except Exception:
@@ -222,24 +214,6 @@ class ContextFile:
                 if data is not None:
                     res[name] = data
         return Results(res, self)
-
-
-def get_user_variables(conn):
-    user_variables = {}
-    rows = conn.execute("SELECT name, title, type, description, attributes FROM variables")
-    name_to_pos = {ff[0] : ii for ii, ff in enumerate(rows.description)}
-    for rr in rows:
-        var_name = rr[name_to_pos["name"]]
-        new_var = UserEditableVariable(
-            var_name,
-            title=rr[name_to_pos["title"]],
-            variable_type=rr[name_to_pos["type"]],
-            description=rr[name_to_pos["description"]],
-            attributes=rr[name_to_pos["attributes"]]
-        )
-        user_variables[var_name] = new_var
-    log.debug("Loaded %d user variables", len(user_variables))
-    return user_variables
 
 
 def get_start_time(xd_run):
@@ -520,8 +494,6 @@ def main(argv=None):
     args = ap.parse_args(argv)
     logging.basicConfig(level=logging.INFO)
 
-    db_conn = sqlite3.connect('runs.sqlite', timeout=30)
-
     if args.subcmd == "exec":
         # Check if we have proc data
         proc_available = False
@@ -543,7 +515,7 @@ def main(argv=None):
             log.warning("Proc data is unavailable, only raw variables will be executed.")
             run_data = RunData.RAW
 
-        ctx_whole = ContextFile.from_py_file(Path('context.py'), external_vars = get_user_variables(db_conn))
+        ctx_whole = ContextFile.from_py_file(Path('context.py'))
         ctx = ctx_whole.filter(
             run_data=run_data, cluster=args.cluster_job, name_matches=args.match
         )
@@ -559,11 +531,7 @@ def main(argv=None):
             actual_run_data = RunData.ALL if run_data == RunData.PROC else run_data
             run_dc = extra_data.open_run(args.proposal, args.run, data=actual_run_data.value)
 
-        inputs = {
-            'run_data' : run_dc,
-            'db_conn' : db_conn
-        }
-        res = ctx.execute(inputs, args.run, args.proposal)
+        res = ctx.execute(run_dc, args.run, args.proposal, input_vars={})
 
         for path in args.save:
             res.save_hdf5(path)
@@ -573,7 +541,7 @@ def main(argv=None):
         error_info = None
 
         try:
-            ctx = ContextFile.from_py_file(args.context_file, external_vars = get_user_variables(db_conn))
+            ctx = ContextFile.from_py_file(args.context_file)
 
             # Strip the functions from the Variable's, these cannot always be
             # pickled.

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -6,138 +6,7 @@ environments.
 """
 import re
 
-from functools import wraps
 from enum import Enum
-
-import pandas as pd
-
-class ValueType:
-
-    # These are intended to be overridden in subclasses.
-    type_instance = None
-
-    type_name = None
-
-    description = None
-
-    examples = None
-
-    def __str__(self):
-        return self.type_name
-
-
-    @classmethod
-    def unwrap(cls, x):
-        if len(x) == 1:
-            return x.to_numpy().item()
-        return list(x)
-
-    @classmethod
-    def convert(cls, data, unwrap=False):
-        is_string = isinstance(data, str)
-        is_sequence = hasattr(data, "__len__") and not is_string
-
-        if not is_sequence:
-            data = [data]
-
-        if len(data) > 0:
-            res = pd.Series(data).convert_dtypes().astype(cls.type_instance)
-        else:
-            res = pd.Series([], dtype=cls.type_instance)
-
-        return cls.unwrap(res) if unwrap else res
-
-class BooleanValueType(ValueType):
-
-    type_instance = pd.BooleanDtype()
-
-    type_name = "boolean"
-
-    description = "A value type that can be used to denote truth values."
-
-    examples = ["True", "T", "true", "1", "False", "F", "f", "0"]
-
-    _valid_values = {
-        "true": True,
-        "yes": True,
-        "1": True,
-        "false": False,
-        "no": False,
-        "0": False
-    }
-
-    @classmethod
-    def _map_strings_to_values(cls, to_convert, valid_strings):
-        res = valid_strings.str.startswith(to_convert.lower())
-        n_matches = res.sum()
-        if n_matches == 1:
-            return cls._valid_values[valid_strings[res.argmax()]]
-        else:
-            raise ValueError(f"Value \"{to_convert}\" matches {'more than one' if n_matches > 0 else 'none'} of the allowed ones ({', '.join(valid_strings)})")
-
-    @classmethod
-    def convert(cls, data, unwrap=False):
-        is_string = isinstance(data, str)
-        is_sequence = hasattr(data, "__len__") and not is_string
-
-        if not is_sequence:
-            data = [data]
-
-        to_convert = pd.Series(data).convert_dtypes()
-        res = None
-
-        if len(data) > 0:
-            if to_convert.dtype == "object":
-                raise ValueError("The input array contains mixed object types")
-            elif to_convert.dtype == "string":
-                valid_strings = pd.Series(cls._valid_values.keys(), dtype="string")
-                res = to_convert.map(lambda x: cls._map_strings_to_values(x, valid_strings))
-            else:
-                res = to_convert.astype(cls.type_instance)
-        else:
-            res = pd.Series([], dtype=cls.type_instance)
-
-        return cls.unwrap(res) if unwrap else res
-
-
-class IntegerValueType(ValueType):
-
-    type_instance = pd.Int32Dtype()
-
-    type_name = "integer"
-
-    description = "A value type that can be used to count whole number of elements or classes."
-
-    examples = ["-7", "-2", "0", "10", "34"]
-
-class NumberValueType(ValueType):
-
-    type_instance = pd.Float32Dtype()
-
-    type_name = "number"
-
-    description = "A value type that can be used to represent decimal numbers."
-
-    examples = ["-34.1e10", "-7.1", "-4", "0.0", "3.141592653589793", "85.4E7"]
-
-class StringValueType(ValueType):
-
-    type_instance = pd.StringDtype()
-
-    type_name = "string"
-
-    description = "A value type that can be used to represent text."
-
-    examples = ["Broken", "Dark frame", "test_frame"]
-
-types_map = { tt.type_name : tt for tt in [BooleanValueType(), IntegerValueType(), NumberValueType(), StringValueType()] }
-
-def get_type_from_typename(type_name):
-
-    if type_name not in types_map:
-        raise ValueError(f"The type \"{type_name}\" is not valid available types are {', '.join(list(types_map.keys()))}")
-
-    return types_map[type_name]
 
 
 class VariableBase:
@@ -184,37 +53,6 @@ class VariableBase:
         return getattr(self.func, '__annotations__', {})
 
 
-class UserEditableVariable(VariableBase):
-
-    def __init__(self, _name, title, variable_type, description=None, attributes={}):
-        super().__init__(name=_name, title=title, description=description, attributes=attributes)
-
-        self.variable_type = variable_type
-        self.func = self.get_data_func()
-
-    def get_data_func(self):
-
-        variable_name = self.name
-
-        def retrieve_data(inputs, proposal_id : 'meta#proposal', run_id : 'meta#run_number'):
-            db = inputs['db_conn']
-            res = db.execute(
-                f'SELECT {variable_name} FROM runs WHERE proposal=:proposal_id AND run=:run_id',
-                {
-                    'proposal_id' : proposal_id,
-                    'run_id' : run_id
-                }
-            )
-            # add cast
-            return res.fetchone()[0]
-
-        return retrieve_data
-
-        self.func = retrieve_data
-
-    def get_type_class(self):
-        return get_type_from_typename(self.variable_type)
-
 
 class RunData(Enum):
     RAW = "raw"
@@ -240,12 +78,7 @@ class Variable(VariableBase):
         self.cluster = cluster
 
     def __call__(self, func):
-
-        @wraps(func)
-        def get_default_inputs(inputs, **kwargs):
-            return func(inputs['run_data'], **kwargs)
-
-        self.func = get_default_inputs
+        self.func = func
         self.name = func.__name__
         return self
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -246,7 +246,7 @@ da-dev@xfel.eu"""
         assert error_info is None, error_info
 
         self._attributi = ctx_file.vars
-        self._title_to_name = { "Comment" : "comment"} | {
+        self._title_to_name = {"Comment" : "comment", "Timestamp": "start_time"} | {
             (aa.title or kk) : kk for kk, aa in self._attributi.items()
         }
         self._name_to_title = {vv : kk for kk, vv in self._title_to_name.items()}

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -373,6 +373,7 @@ da-dev@xfel.eu"""
         else:
             before_pos += before
         variable = UserEditableVariable(name, title=title, variable_type=variable_type, description=description)
+        self.user_variables[name] = variable
         self.db.add_user_variable(variable)
         self._attributi[name] = variable
         self._name_to_title[name] = title
@@ -380,7 +381,6 @@ da-dev@xfel.eu"""
         self.table.insert_columns(
             before_pos, [title], [name], variable.get_type_class(), editable=True
         )
-        self.table.insertColumn(before_pos)
         self.table_view.add_new_columns([title], [True], [before_pos - n_static_cols - 1])
         self.table.add_editable_column(title)
 

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -540,11 +540,11 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
 
         if role == Qt.ItemDataRole.DisplayRole or role == Qt.ItemDataRole.EditRole:
             # Change the value in the table
-            changed_column = self._main_window.col_title_to_name(self._data.columns[index.column()])
+            changed_column = self.column_id(index.column())
             if changed_column == "comment":
                 self._data.iloc[index.row(), index.column()] = value
             else:
-                variable_type_class = self._main_window.get_variable_from_name(changed_column).get_type_class()
+                variable_type_class = self._main_window.user_variables[changed_column].get_type_class()
 
                 try:
                     value = variable_type_class.convert(value, unwrap=True) if value != '' else None

--- a/damnit/gui/user_variables.py
+++ b/damnit/gui/user_variables.py
@@ -2,7 +2,7 @@ import re
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 
-from ..ctxsupport.damnit_ctx import types_map
+from ..backend.user_variables import value_types_by_name
 from ..util import icon_path
 
 
@@ -89,7 +89,7 @@ class AddUserVariableDialog(QtWidgets.QDialog):
         self.variable_example = QtWidgets.QLabel()
         self.variable_example.setAlignment(self.variable_example.alignment() | QtCore.Qt.AlignRight)
 
-        for ii, (kk, vv) in enumerate(types_map.items()):
+        for ii, (kk, vv) in enumerate(value_types_by_name.items()):
             self.variable_type.addItem(kk)
             self.variable_type.setItemData(ii, vv.description, QtCore.Qt.ToolTipRole)
 
@@ -106,7 +106,7 @@ class AddUserVariableDialog(QtWidgets.QDialog):
 
         label = self.variable_example
         format_text = lambda x: f"<span style='color: gray; font-size: 10px;'>{x}</span>"
-        cur_type_class = types_map[current_type]
+        cur_type_class = value_types_by_name[current_type]
         type_examples = cur_type_class.examples
         joined_examples = ', '.join(type_examples)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 import numpy as np
 
-from damnit.ctxsupport.damnit_ctx import types_map, UserEditableVariable
+from damnit.backend.user_variables import value_types_by_name, UserEditableVariable
 from damnit.backend.db import DamnitDB
 
 from .helpers import amore_proto, mkcontext
@@ -60,7 +60,7 @@ def mock_user_vars():
 
     user_variables = {}
 
-    for kk in types_map.keys():
+    for kk in value_types_by_name.keys():
         var_name = f"user_{kk}"
         user_variables[var_name] = UserEditableVariable(
             var_name,
@@ -80,28 +80,28 @@ def mock_ctx_user(mock_user_vars):
     from damnit.context import Variable
 
     @Variable(title="Depend from user integer")
-    #def dep_integer(run, user_integer: "var#user_integer"):
+    #def dep_integer(run, user_integer: "input#user_integer"):
     def dep_integer(run, user_integer=12):
         return user_integer + 1
 
     @Variable(title="Depend from user number")
-    #def dep_number(run, user_number: "var#user_number"):
+    #def dep_number(run, user_number: "input#user_number"):
     def dep_number(run, user_number=10.2):
         return user_number * 1.0
 
     @Variable(title="Depend from user boolean")
-    #def dep_boolean(run, user_boolean: "var#user_boolean"):
+    #def dep_boolean(run, user_boolean: "input#user_boolean"):
     def dep_boolean(run, user_boolean=True):
         return user_boolean and False
 
     @Variable(title="Depend from user string")
-    #def dep_string(run, user_string: "var#user_string"):
+    #def dep_string(run, user_string: "input#user_string"):
     def dep_string(run, user_string="foo"):
         return user_string * 2
 
     """
 
-    return mkcontext(code, external_vars=mock_user_vars)
+    return mkcontext(code)
 
 @pytest.fixture
 def mock_run():

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -31,5 +31,5 @@ def amore_proto(args):
           patch("damnit.backend.extract_data.KafkaProducer")):
         main()
 
-def mkcontext(code, **kwargs):
-    return ContextFile.from_str(textwrap.dedent(code), **kwargs)
+def mkcontext(code):
+    return ContextFile.from_str(textwrap.dedent(code))

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -148,7 +148,7 @@ def run_ctx_helper(context, run, run_number, proposal, caplog, additional_inputs
     # variable that throws an error will be logged by Results, the exception
     # will not bubble up.
     with caplog.at_level(logging.ERROR):
-        results = Results.create(context, {"run_data" : run} | additional_inputs, run_number, proposal)
+        results = context.execute({"run_data" : run} | additional_inputs, run_number, proposal)
 
     # Check that there were no errors
     assert caplog.records == []
@@ -157,7 +157,7 @@ def run_ctx_helper(context, run, run_number, proposal, caplog, additional_inputs
 def test_results(mock_ctx, mock_run, caplog, tmp_path):
     run_number = 1000
     proposal = 1234
-    results_create = lambda ctx: Results.create(ctx, { "run_data" : mock_run }, run_number, proposal)
+    results_create = lambda ctx: ctx.execute({ "run_data" : mock_run }, run_number, proposal)
 
     # Simple test
     results = run_ctx_helper(mock_ctx, mock_run, run_number, proposal, caplog)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -16,7 +16,9 @@ import numpy as np
 import xarray as xr
 
 from damnit.util import wait_until
-from damnit.context import ContextFile, PNGData, Results, RunData, get_proposal_path
+from damnit.context import (
+    ContextFileErrors, ContextFile, PNGData, Results, RunData, get_proposal_path
+)
 from damnit.backend.db import DamnitDB
 from damnit.backend import initialize_and_start_backend, backend_is_running
 from damnit.backend.extract_data import add_to_db, Extractor
@@ -70,8 +72,9 @@ def test_context_file(mock_ctx):
     def bar(run): return 43
     """
 
-    with pytest.raises(RuntimeError):
-        ContextFile.from_str(textwrap.dedent(duplicate_titles_code))
+    ctx = ContextFile.from_str(textwrap.dedent(duplicate_titles_code))
+    with pytest.raises(ContextFileErrors):
+        ctx.check()
 
     # Helper lambda to get the names of the direct dependencies of a variable
     var_deps = lambda name: set(mock_ctx.vars[name].arg_dependencies().values())
@@ -122,8 +125,9 @@ def test_context_file(mock_ctx):
         return foo
     """
 
-    with pytest.raises(RuntimeError):
-        ContextFile.from_str(textwrap.dedent(bad_dep_code))
+    ctx = ContextFile.from_str(textwrap.dedent(bad_dep_code))
+    with pytest.raises(ContextFileErrors):
+        ctx.check()
 
     var_promotion_code = """
     from damnit.context import Variable

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -47,10 +47,8 @@ def test_context_file(mock_ctx):
     def foo(run):
         return 42
     """
-    code = textwrap.dedent(code)
-
     # Test creating from a string
-    ctx = ContextFile.from_str(code)
+    ctx = mkcontext(code)
     assert len(ctx.vars) == 1
 
     # Test creating from a file
@@ -72,7 +70,7 @@ def test_context_file(mock_ctx):
     def bar(run): return 43
     """
 
-    ctx = ContextFile.from_str(textwrap.dedent(duplicate_titles_code))
+    ctx = mkcontext(duplicate_titles_code)
     with pytest.raises(ContextFileErrors):
         ctx.check()
 
@@ -110,7 +108,7 @@ def test_context_file(mock_ctx):
 
     # Creating a context from this should fail
     with pytest.raises(graphlib.CycleError):
-        ContextFile.from_str(textwrap.dedent(cycle_code))
+        mkcontext(cycle_code)
 
     # Context file with raw variable's depending on proc variable's
     bad_dep_code = """
@@ -125,7 +123,7 @@ def test_context_file(mock_ctx):
         return foo
     """
 
-    ctx = ContextFile.from_str(textwrap.dedent(bad_dep_code))
+    ctx = mkcontext(bad_dep_code)
     with pytest.raises(ContextFileErrors):
         ctx.check()
 
@@ -141,7 +139,7 @@ def test_context_file(mock_ctx):
         return foo
     """
     # This should not raise an exception
-    var_promotion_ctx = ContextFile.from_str(textwrap.dedent(var_promotion_code))
+    var_promotion_ctx = mkcontext(var_promotion_code)
 
     # `bar` should automatically be promoted to use proc data because it depends
     # on a proc variable.
@@ -405,7 +403,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
         return 42
     """
     mock_code = mock_ctx.code + "\n\n" + textwrap.dedent(no_summary_var)
-    mock_ctx = ContextFile.from_str(mock_code)
+    mock_ctx = mkcontext(mock_code)
 
     ctx_path = db_dir / "context.py"
     ctx_path.write_text(mock_ctx.code)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -4,10 +4,8 @@ import signal
 import logging
 import graphlib
 import textwrap
-import tempfile
 import subprocess
 import configparser
-from pathlib import Path
 from unittest.mock import patch
 
 import h5py
@@ -39,7 +37,7 @@ def kill_pid(pid):
         print(f"PID {pid} doesn't exist")
 
 
-def test_context_file(mock_ctx):
+def test_context_file(mock_ctx, tmp_path):
     code = """
     from damnit.context import Variable
 
@@ -52,11 +50,9 @@ def test_context_file(mock_ctx):
     assert len(ctx.vars) == 1
 
     # Test creating from a file
-    with tempfile.NamedTemporaryFile() as tmp:
-        tmp.write(code.encode())
-        tmp.flush()
-
-        ctx = ContextFile.from_py_file(Path(tmp.name))
+    ctx_path = tmp_path / 'context.py'
+    ctx_path.write_text(textwrap.dedent(code))
+    ctx = ContextFile.from_py_file(ctx_path)
 
     assert len(ctx.vars) == 1
 


### PR DESCRIPTION
This continues the work I started in #192. My goal this time was to separate the low-level ctxrunner machinery, which parses and runs a `context.py` file, from the database.

Using user-editable variables in the context file has never been turned on, and this PR still doesn't, but it changes the way they will work if/when we do. They would be labelled with an `input#` prefix (e.g. `input#sample_type`) instead of `var#` like variables defined in the context file. A higher level piece would be responsible for finding their values and passing them in when running a context file - the precise mechanism for passing them down still to be decided.

I also moved some of the context file checks into a separate `ContextFile.check()` method. The idea is that we can still read a context file and tell you about its contents even if e.g. a raw variable depends on a proc variable. For now, the context file is checked whenever we execute it, so if there are any issues all processing is stopped, but I'd like to relax that in the future, e.g. to allow processing variables without issues.