### PR TITLE
Fix some warnings that occur when running the tests

### DIFF
--- a/damnit/gui/plot.py
+++ b/damnit/gui/plot.py
@@ -10,12 +10,12 @@ from PyQt5 import QtCore, QtWidgets, QtGui
 from PyQt5.QtWidgets import QMessageBox
 
 import mplcursors
+import matplotlib
 from matplotlib.backends.backend_qtagg import (
     FigureCanvas,
     NavigationToolbar2QT as NavigationToolbar,
 )
 from matplotlib.figure import Figure
-from matplotlib import cm as mpl_cm
 from mpl_pan_zoom import zoom_factory, PanManager, MouseButton
 
 from ..backend.api import RunVariables
@@ -217,7 +217,7 @@ class Canvas(QtWidgets.QDialog):
         self.figure.canvas.draw()
 
     def update_canvas(self, xs=None, ys=None, image=None, legend=None, series_names=["default"]):
-        cmap = mpl_cm.get_cmap("tab20")
+        cmap = matplotlib.colormaps["tab20"]
         self._nan_warning_label.hide()
 
         if (xs is None and ys is None) and self.plot_type == "histogram1D":
@@ -279,8 +279,8 @@ class Canvas(QtWidgets.QDialog):
                 self._axis.set_xlabel("")
                 self._axis.set_ylabel("")
             else:
-                vmin = np.nanquantile(image, 0.01, interpolation='nearest')
-                vmax = np.nanquantile(image, 0.99, interpolation='nearest')
+                vmin = np.nanquantile(image, 0.01, method='nearest')
+                vmax = np.nanquantile(image, 0.99, method='nearest')
                 self._image.set_clim(vmin, vmax)
         else:
             self._axis.grid(visible=True)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -467,7 +467,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
     # When only proc variables are reprocessed, the run should still be opened
     # with `data='all'` so that raw data is available. Note that we patch
     # Results too so that the test doesn't throw exceptions.
-    with patch("ctxrunner.extra_data.open_run") as open_run, \
+    with patch("ctxrunner.extra_data.open_run", return_value=mock_run) as open_run, \
          patch("ctxrunner.Results"):
         main(["exec", "1234", "42", "proc"])
 


### PR DESCRIPTION
This gets rid of the warnings below - which aren't all of them, but the ones that were easiest to fix quickly.

```
tests/test_backend.py::test_extractor
  /home/kluyvert/Code/mid-2833/damnit/ctxsupport/ctxrunner.py:244:
  DeprecationWarning: The truth value of an empty array is ambiguous. Returning
  False, but in future this will result in an error. Use `array.size > 0` to check
  that an array is not empty.
    if np.isnan(ts):

tests/test_backend.py::test_extractor
  /home/kluyvert/Code/mid-2833/damnit/ctxsupport/ctxrunner.py:254:
  DeprecationWarning: parsing timezone aware datetimes is deprecated; this will
  raise an error in the future
    return np.datetime64(ts, 'us').item().replace(tzinfo=timezone.utc).timestamp()

tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
  /home/kluyvert/Code/mid-2833/damnit/gui/plot.py:220:
  PendingDeprecationWarning: The get_cmap function will be deprecated in a future version.
  Use ``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap(obj)`` instead.
    cmap = mpl_cm.get_cmap("tab20")

tests/test_gui.py::test_table_and_plotting
tests/test_gui.py::test_table_and_plotting
  /home/kluyvert/Code/mid-2833/damnit/gui/plot.py:154:
  DeprecationWarning: the `interpolation=` argument to nanquantile was renamed to
  `method=`, which has additional options.
  Users of the modes 'nearest', 'lower', 'higher', or 'midpoint' are encouraged to review
  the method they used. (Deprecated NumPy 1.22)
    self.update_canvas(x, y, image, legend=legend)
```