### PR TITLE
Fix call to get_column_states() while exporting to Zulip

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -966,7 +966,7 @@ da-dev@xfel.eu"""
                          self.table_view.selectionModel().selectedRows()]
 
         blacklist_columns = ['Proposal', 'Status']
-        columns = [title for (title, vis) in self.get_column_states()
+        columns = [title for (title, vis) in self.table_view.get_column_states().items()
                    if vis and (title not in blacklist_columns)]
 
         df = self.table.dataframe_for_export(columns, selected_rows, drop_image_cols=True)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -778,6 +778,13 @@ def test_zulip(mock_db_with_data, monkeypatch, qtbot):
         # Check if post was called
         mock_post.assert_called_once()
 
+    # Simple smoke test to make sure a Zulip message is sent
+    with patch.object(win, "zulip_messenger") as messenger, \
+         patch.object(win, "check_zulip_messenger", return_value=True):
+        win.export_selection_to_zulip()
+
+        messenger.send_table.assert_called_once()
+
 @pytest.mark.parametrize("extension", [".xlsx", ".csv"])
 def test_exporting(mock_db_with_data, qtbot, monkeypatch, extension):
     db_dir, db = mock_db_with_data


### PR DESCRIPTION
I think this was missed in one of the recent refactorings.

CC @egorsobolev 