### PR TITLE
Store variables from context file in database

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -407,8 +407,8 @@ class MsgKind(Enum):
     run_values_updated = 'run_values_updated'
     run_deleted = 'run_deleted'
     # The comment_ types refer to timestamped comments *not* in a run row
-    comment_set = 'comment_set'
-    comment_deleted = 'comment_deleted'
+    standalone_comment_set = 'standalone_comment_set'
+    standalone_comment_deleted = 'standalone_comment_deleted'
 
 def msg_dict(kind: MsgKind, data: dict):
     return {'msg_kind': kind.value, 'data': data}

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -403,12 +403,12 @@ class MsgKind(Enum):
     # objects, so recipients can easily tell if an object is new to them.
     # This also means messages are idempotent.
     variable_set = 'variable_set'
-    variable_deleted = 'variable_deleted'
+    #variable_deleted = 'variable_deleted'
     run_values_updated = 'run_values_updated'
-    run_deleted = 'run_deleted'
-    # The comment_ types refer to timestamped comments *not* in a run row
-    standalone_comment_set = 'standalone_comment_set'
-    standalone_comment_deleted = 'standalone_comment_deleted'
+    #run_deleted = 'run_deleted'
+    #standalone_comment_set = 'standalone_comment_set'
+    #standalone_comment_deleted = 'standalone_comment_deleted'
+    # Commented out options are not implemented yet
 
 def msg_dict(kind: MsgKind, data: dict):
     return {'msg_kind': kind.value, 'data': data}

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -243,6 +243,8 @@ class Extractor:
         if proposal is None:
             proposal = self.proposal
 
+        self.db.update_computed_variables(self.ctx_whole.vars_to_dict())
+
         out_path = Path('extracted_data', f'p{proposal}_r{run}.h5')
         out_path.parent.mkdir(parents=True, exist_ok=True)
         if out_path.parent.stat().st_uid == os.getuid():

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -102,6 +102,11 @@ def main():
              "or pass 'all' to reprocess all runs in the database."
     )
 
+    readctx_ap = subparsers.add_parser(
+        'read-context',
+        help="Re-read the context file and update variables in the database"
+    )
+
     proposal_ap = subparsers.add_parser(
         'proposal',
         help="Get or set the proposal number to collect metadata from"
@@ -202,6 +207,10 @@ def main():
 
         from .backend.extract_data import reprocess
         reprocess(args.run, args.proposal, args.match, args.mock)
+
+    elif args.subcmd == 'read-context':
+        from .backend.extract_data import Extractor
+        Extractor().update_db_vars()
 
     elif args.subcmd == 'proposal':
         from .backend.db import DamnitDB

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -150,6 +150,17 @@ class ContextFile:
         log.debug("Loaded %d variables", len(vars))
         return cls(vars, code)
 
+    def vars_to_dict(self):
+        """Get a plain dict of variable metadata to store in the database"""
+        return {
+            name: {
+                'title': v.title,
+                'description': v.description,
+                'attributes': None,
+            }
+            for (name, v) in self.vars.items()
+        }
+
     def filter(self, run_data=RunData.ALL, cluster=True, name_matches=()):
         new_vars = {}
         for name, var in self.vars.items():

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -157,6 +157,7 @@ class ContextFile:
                 'title': v.title,
                 'description': v.description,
                 'attributes': None,
+                'type': None,
             }
             for (name, v) in self.vars.items()
         }

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -537,6 +537,7 @@ da-dev@xfel.eu"""
         if 'msg_kind' not in message:
             # Old message format. Temporarily handled so GUIs with new code can
             # work with listeners with older code, but can be removed soon.
+            message = message.copy()
             proposal = message.pop("Proposal")
             run = message.pop("Run")
             message = {

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -777,6 +777,9 @@ da-dev@xfel.eu"""
         self._context_is_saved = False
 
     def reload_context(self):
+        if not self._context_path.is_file():
+            self.show_status_message("No context.py file found")
+            return
         self._editor.setText(self._context_path.read_text())
         self.test_context()
         self.mark_context_saved()

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -256,7 +256,7 @@ da-dev@xfel.eu"""
             header.setSectionResizeMode(column_index, QtWidgets.QHeaderView.ResizeToContents)
 
         # Update the column widget and plotting controls with the new columns
-        titles = self.table.column_titles()
+        titles = self.table.column_titles
         self.table_view.set_columns(titles,
                                     [col_settings.get(col, True) for col in titles])
         self.plot.update_columns()
@@ -560,7 +560,7 @@ da-dev@xfel.eu"""
         quantity = self.table.column_id(index.column())
 
         # Don't try to plot strings
-        if quantity_title in { "Status" } | self.table.editable_columns:
+        if quantity in { "Status" } | self.table.editable_columns:
             return
 
         log.info(

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -348,6 +348,17 @@ da-dev@xfel.eu"""
         self._tab_widget.setEnabled(True)
         self.show_default_status_message()
         self.context_dir_changed.emit(str(path))
+        self.launch_update_computed_vars()
+
+    def launch_update_computed_vars(self):
+        log.debug("Launching subprocess to read variables from context file")
+        proc = QtCore.QProcess(parent=self)
+        # Show stdout & stderr with the parent process
+        proc.setProcessChannelMode(QtCore.QProcess.ProcessChannelMode.ForwardedChannels)
+        proc.finished.connect(proc.deleteLater)
+        proc.setWorkingDirectory(str(self.context_dir))
+        proc.start(sys.executable, ['-m', 'damnit.cli', 'read-context'])
+        proc.closeWriteChannel()
 
     def add_variable(self, name, title, variable_type, description="", before=None):
         n_static_cols = self.table_view.get_static_columns_count()
@@ -543,6 +554,8 @@ da-dev@xfel.eu"""
             self.handle_run_values_updated(
                 data['proposal'], data['run'], data['values']
             )
+        elif msg_kind == MsgKind.variable_set:
+            self.table.handle_variable_set(data)
 
     def handle_run_values_updated(self, proposal, run, values: dict):
         is_constant_df = self.load_max_diffs()

--- a/damnit/gui/plot.py
+++ b/damnit/gui/plot.py
@@ -480,7 +480,7 @@ class Plot:
         }
 
     def update_columns(self):
-        keys = self.table.column_titles()
+        keys = self.table.column_titles
 
         current_x = self._combo_box_x_axis.currentText()
         current_y = self._combo_box_y_axis.currentText()

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -137,7 +137,7 @@ class TableView(QtWidgets.QTableView):
         menu.addAction("Delete")
         action = menu.exec(global_pos)
         if action is not None:
-            name = self.model()._main_window.col_title_to_name(item.text())
+            name = self.model().col_title_to_id(item.text())
             self.confirm_delete_variable(name)
 
     def confirm_delete_variable(self, name):
@@ -289,6 +289,9 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
 
     def column_id(self, col_ix):
         return self.column_ids[col_ix]
+
+    def column_title_to_id(self, title):
+        return self.column_id(self.find_column(title, by_title=True))
 
     def find_row(self, proposal, run):
         df = self._data
@@ -489,8 +492,7 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
         value = self._data.iat[r, c]
         run = self._data.iat[r, self._data.columns.get_loc("Run")]
         proposal = self._data.iat[r, self._data.columns.get_loc("Proposal")]
-        quantity_title = self._data.columns[index.column()]
-        quantity = self._main_window.col_title_to_name(quantity_title)
+        quantity = self.column_id(index.column())
 
         if role == Qt.FontRole:
             # If the variable is not constant, make it bold
@@ -579,18 +581,17 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
 
         return True
 
-    def headerData(self, col, orientation, role=Qt.ItemDataRole.DisplayRole):
+    def headerData(self, ix, orientation, role=Qt.ItemDataRole.DisplayRole):
         if (
             orientation == Qt.Orientation.Horizontal
             and role == Qt.ItemDataRole.DisplayRole
         ):
-            name = self._data.columns[col]
-            return self._main_window.column_title(name)
+            return self.column_title(ix)
         elif(
             orientation == Qt.Orientation.Vertical
             and role == Qt.ItemDataRole.DisplayRole
         ):
-            row = self._data.iloc[col]['Run']
+            row = self._data.iloc[ix]['Run']
             if pd.isna(row):
                 row = ''
             return row

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -472,10 +472,9 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
         if pd.isna(run) or pd.isna(proposal):
             return True
 
-        is_constant_df = self.is_constant_df
-        if quantity in is_constant_df.columns:
-            return is_constant_df.loc[(proposal, run)][quantity].item()
-        else:
+        try:
+            return self.is_constant_df.loc[(proposal, run)][quantity].item()
+        except KeyError:
             return True
 
     _supported_roles = (

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -365,12 +365,9 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
         self.generateThumbnail.cache_clear()
         self.endInsertRows()
 
-    def handle_update(self, message: dict, is_constant_df):
-        message = message.copy()   # Modify a copy
-        run = message.pop("Run")
-        proposal = message.pop("Proposal")
+    def handle_run_values_changed(self, proposal, run, values: dict, is_constant_df):
         known_col_ids = set(self.column_ids)
-        new_col_ids = [c for c in message if c not in known_col_ids]
+        new_col_ids = [c for c in values if c not in known_col_ids]
 
         if new_col_ids:
             log.info("New columns for table: %s", new_col_ids)
@@ -388,7 +385,7 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
 
         if row_ix is not None:
             log.debug("Update existing row %s for run %s", row_ix, run)
-            for ki, vi in message.items():
+            for ki, vi in values.items():
                 title = column_ids_to_titles[ki]
                 self._data.at[row_ix, title] = vi
 
@@ -397,7 +394,7 @@ class DamnitTableModel(QtCore.QAbstractTableModel):
 
         else:
             # Convert from column ID keys to column titles
-            row_contents = {column_ids_to_titles[k]: v for (k, v) in message.items()}
+            row_contents = {column_ids_to_titles[k]: v for (k, v) in values.items()}
             self.insert_row(row_contents | {
                 "Proposal": proposal, "Run": run, "Comment": "", "Status": True
             })

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,10 +125,14 @@ def mock_run():
     return run
 
 @pytest.fixture
-def mock_db(tmp_path, mock_ctx):
+def mock_db(tmp_path, mock_ctx, monkeypatch):
     db = DamnitDB.from_dir(tmp_path)
 
     (tmp_path / "context.py").write_text(mock_ctx.code)
+
+    with monkeypatch.context() as m:
+        m.chdir(tmp_path)
+        amore_proto(["read-context"])
 
     yield tmp_path, db
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -418,7 +418,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
         extractor.extract_and_ingest(1234, 42, cluster=False,
                                      run_data=RunData.ALL)
         extract_in_subprocess.assert_called_once()
-        extractor.kafka_prd.send.assert_called_once()
+        extractor.kafka_prd.send.assert_called()
         subprocess_run.assert_called_once()
 
     # This works because we loaded damnit.context above

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -291,10 +291,10 @@ def test_handle_update(mock_db, qtbot):
     assert model().data(model().index(0, headers.index("Scalar1"))) == str(msg["scalar1"])
 
     # Add a new column to an existing row
-    msg["array"] = np.array([1,1,2])
+    msg["unexpected_var"] = 7
     win.handle_update(msg)
     assert len(headers) + 1 == len(get_headers())
-    assert "Array" in get_headers()
+    assert "unexpected_var" in get_headers()
 
 def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
     db_dir, db = mock_db_with_data

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -784,7 +784,7 @@ def test_zulip(mock_db_with_data, monkeypatch, qtbot):
         mock_get.assert_called_once()
         assert win.zulip_messenger.stream == "stream"
 
-        df = win.table.dataframe_for_export(columns=['Proposal', 'Run', 'Comment'])
+        df = win.table.dataframe_for_export(['Proposal', 'Run', 'Comment'])
         test_dialog = ZulipConfig(win, win.zulip_messenger,
                                   kind='table', table=df)
         test_dialog.handle_form()


### PR DESCRIPTION
I'm opening this as a draft because it probably still needs some more work, but here's a first draft of storing computed variable metadata in the database.

The metadata is updated whenever a run is processed, and also when launching the GUI - but having an invalid context file (even with syntax errors) no longer prevents the GUI from opening.

Here's a clip of launching the GUI with a proposal that doesn't already have the computed variables in the database. When it first launches, you see the variable IDs like `raw_size` in the column headers, then after a couple of seconds they're updated to the human-friendly titles like 'Raw size [TB]'. The next time you launch the GUI, the titles are there as soon as it opens.

![Screencast from 2024-02-14 17-15-32](https://github.com/European-XFEL/DAMNIT/assets/327925/dbe41e5a-6b8c-4a55-8acc-0c2a6db27843)

I've made a start on defining a new message structure for notifications about changes in the database. It covers set & delete updates for runs, variables & standalone comments. I realised while working on it that it's neater to combine updates for added/changed in one message type, because recipients may not always agree on what already exists.