### PR TITLE
Add the ability to pre-create runs in the database

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -194,7 +194,7 @@ da-dev@xfel.eu"""
             # User said no to setting up a new database
             return
 
-        self.autoconfigure(context_dir, proposal=prop_no)
+        self.autoconfigure(context_dir)
 
     def save_settings(self):
         self._settings_db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -210,7 +210,7 @@ da-dev@xfel.eu"""
         # 1e-9 is the default tolerance of np.isclose()
         return max_diff_df < 1e-9
 
-    def autoconfigure(self, path: Path, proposal=None):
+    def autoconfigure(self, path: Path):
         # use separated directory if running online to avoid file corruption
         # during sync between clusters.
         if gethostname().startswith('exflonc'):

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -309,6 +309,13 @@ da-dev@xfel.eu"""
 
         self._columns_dialog.show()
 
+    def precreate_runs_dialog(self):
+        n_runs, ok = QtWidgets.QInputDialog.getInt(self, "Pre-create new runs",
+                                                   "Select how many runs to create in the database immediately:",
+                                                   value=1, min=1)
+        if ok:
+            self.table.precreate_runs(n_runs)
+
     def _create_menu_bar(self) -> None:
         menu_bar = self.menuBar()
         menu_bar.setNativeMenuBar(False)
@@ -363,10 +370,13 @@ da-dev@xfel.eu"""
         action_columns.triggered.connect(self.open_column_dialog)
         self.action_autoscroll = QtWidgets.QAction('Scroll to newly added runs', self)
         self.action_autoscroll.setCheckable(True)
+        action_precreate_runs = QtWidgets.QAction("Pre-create new runs", self)
+        action_precreate_runs.triggered.connect(self.precreate_runs_dialog)
         tableMenu = menu_bar.addMenu("Table")
         
         tableMenu.addAction(action_columns)
         tableMenu.addAction(self.action_autoscroll)
+        tableMenu.addAction(action_precreate_runs)
         
         #jump to run 
         menu_bar_right = QtWidgets.QMenuBar(self)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -335,7 +335,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
         win._menu_bar_autoconfigure()
 
         # We expect the database to be initialized and the backend started
-        win.autoconfigure.assert_called_once_with(db_dir, proposal=1234)
+        win.autoconfigure.assert_called_once_with(db_dir)
         initialize_and_start_backend.assert_called_once_with(db_dir, 1234)
 
     # Create the directory and database file to fake the database already existing
@@ -348,7 +348,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
         win._menu_bar_autoconfigure()
 
         # We expect the database to be initialized and the backend started
-        win.autoconfigure.assert_called_once_with(db_dir, proposal=1234)
+        win.autoconfigure.assert_called_once_with(db_dir)
         initialize_and_start_backend.assert_not_called()
 
     # Autoconfigure again, the GUI should start the backend again
@@ -357,7 +357,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
         win._menu_bar_autoconfigure()
 
         # This time the database is already initialized
-        win.autoconfigure.assert_called_once_with(db_dir, proposal=1234)
+        win.autoconfigure.assert_called_once_with(db_dir)
         initialize_and_start_backend.assert_called_once_with(db_dir, 1234)
 
 def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -11,7 +11,8 @@ import numpy as np
 import pandas as pd
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QPixmap
-from PyQt5.QtWidgets import QMessageBox, QFileDialog, QDialog, QStyledItemDelegate, QLineEdit
+from PyQt5.QtWidgets import QMessageBox, QFileDialog, QDialog, QInputDialog, \
+    QStyledItemDelegate, QLineEdit
 
 from damnit.ctxsupport.ctxrunner import ContextFile, Results
 from damnit.backend.db import db_path, ReducedData
@@ -861,3 +862,23 @@ def test_delete_variable(mock_db_with_data, qtbot, monkeypatch):
     with h5py.File(db_dir / f"extracted_data/p{proposal}_r1.h5") as f:
         assert "array" not in f.keys()
         assert "array" not in f[".reduced"].keys()
+
+def test_precreate_runs(mock_db_with_data, qtbot, monkeypatch):
+    db_dir, db = mock_db_with_data
+    monkeypatch.chdir(db_dir)
+
+    win = MainWindow(db_dir, connect_to_kafka=False)
+    get_n_runs = lambda: db.conn.execute("SELECT COUNT(run) FROM runs").fetchone()[0]
+    n_runs = get_n_runs()
+
+    # The user cancelling should do nothing
+    with patch.object(QInputDialog, "getInt", return_value=(1, False)) as dialog:
+        win.precreate_runs_dialog()
+        dialog.assert_called_once()
+        assert get_n_runs() == n_runs
+
+    # But accepting should add a run
+    with patch.object(QInputDialog, "getInt", return_value=(1, True)) as dialog:
+        win.precreate_runs_dialog()
+        dialog.assert_called_once()
+        assert get_n_runs() == n_runs + 1


### PR DESCRIPTION
This useful for setting parameters ahead of runs being taken.

Example:
![damnit-precreate-runs](https://github.com/European-XFEL/DAMNIT/assets/5361518/06b2a661-a616-4c20-a583-879f7c24eaa4)
