### PR TITLE
Add a hidden Python console for debugging

### DIFF
--- a/.github/dependabot/constraints.txt
+++ b/.github/dependabot/constraints.txt
@@ -1,6 +1,4 @@
-euxfel-bunch-pattern==0.6
 EXtra-data==1.16.0
-EXtra-geom==1.11.0
 ipython==8.22.1
 kafka-python==2.0.2
 matplotlib==3.8.3
@@ -9,16 +7,13 @@ mpl-pan-zoom==1.0.0
 numpy==1.26.4
 openpyxl==3.1.2
 pandas==1.5.3
-pasha==0.1.1
 pyflakes==3.2.0
 PyQt5==5.15.10
 pytest==8.0.2
 pytest-qt==4.4.0
 pytest-xvfb==3.0.0
-PyYAML==6.0.1
 QScintilla==2.13.0
 scipy==1.12.0
 supervisor==4.2.5
 termcolor==2.4.0
-tomli==2.0.1
 xarray==2024.2.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python3 -m pip install .[test] --constraint .github/dependabot/constraints.txt
+        python3 -m pip install .[gui,test] --constraint .github/dependabot/constraints.txt
 
     - name: Test with pytest
       run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ cd DAMNIT
 conda create -n amore python
 
 conda activate amore
-pip install .
+pip install '.[gui]'
 ```
 
 ## Usage
@@ -81,5 +81,5 @@ $ ssh xsoft@max-exfl.desy.de
 # Helper command to cd into the module directory and activate its environment
 $ amoremod mid
 $ git pull # Or whatever command is necessary to update the code
-$ pip install .
+$ pip install '.[gui]'
 ```

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -346,6 +346,10 @@ da-dev@xfel.eu"""
         self.context_dir_changed.connect(lambda _: action_export.setEnabled(True))
         action_export.triggered.connect(self.export_table)
 
+        action_adeqt = QtWidgets.QAction("Python console", self)
+        action_adeqt.setShortcut("F12")
+        action_adeqt.triggered.connect(self.show_adeqt)
+
         action_help = QtWidgets.QAction(QtGui.QIcon("help.png"), "&Help", self)
         action_help.setShortcut("Shift+H")
         action_help.setStatusTip("Get help.")
@@ -362,6 +366,7 @@ da-dev@xfel.eu"""
         fileMenu.addAction(action_autoconfigure)
         fileMenu.addAction(action_create_var)
         fileMenu.addAction(action_export)
+        fileMenu.addAction(action_adeqt)
         fileMenu.addAction(action_help)
         fileMenu.addAction(action_exit)
 
@@ -892,6 +897,15 @@ da-dev@xfel.eu"""
         df = df.applymap(prettify_notation)
         df.replace(["None", '<NA>', 'nan'], '', inplace=True)
         self.zulip_messenger.send_table(df)
+
+    adeqt_window = None
+
+    def show_adeqt(self):
+        from adeqt import AdeqtWindow
+        if self.adeqt_window is None:
+            ns = {'window': self, 'table': self.table}
+            self.adeqt_window = AdeqtWindow(ns, parent=self)
+        self.adeqt_window.show()
 
 class TableViewStyle(QtWidgets.QProxyStyle):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,22 +12,15 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version", "description"]
 dependencies = [
-    "adeqt",
     "EXtra-data",
     "euxfel_bunch_pattern",
     "h5netcdf",
     "ipython",
     "kafka-python",
     "matplotlib",
-    "mplcursors",
-    "mpl-pan-zoom",
     "numpy",
-    "openpyxl",
     "pandas<2",
-    "PyQt5",
     "PyYAML",
-    "pyflakes",
-    "QScintilla==2.13",
     "xarray",
     "scipy",
     "supervisor",
@@ -35,11 +28,20 @@ dependencies = [
     "tomli",
     "pasha",
     "extra_geom",
-    "zulip",
-    "tabulate"
 ]
 
 [project.optional-dependencies]
+gui = [
+    "adeqt",
+    "mplcursors",
+    "mpl-pan-zoom",
+    "openpyxl",  # for spreadsheet export
+    "PyQt5",
+    "pyflakes",  # for checking context file in editor
+    "QScintilla==2.13",
+    "tabulate",  # used in pandas to make markdown tables (for Zulip)
+    "zulip",
+]
 test = [
     "pytest",
     "pytest-qt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ license = {file = "LICENSE"}
 classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version", "description"]
 dependencies = [
+    "adeqt",
     "EXtra-data",
     "euxfel_bunch_pattern",
     "h5netcdf",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,21 +13,16 @@ classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version", "description"]
 dependencies = [
     "EXtra-data",
-    "euxfel_bunch_pattern",
     "h5netcdf",
     "ipython",
     "kafka-python",
     "matplotlib",
     "numpy",
     "pandas<2",
-    "PyYAML",
     "xarray",
     "scipy",
     "supervisor",
     "termcolor",
-    "tomli",
-    "pasha",
-    "extra_geom",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This pops up a basic Python console when you press F12, to investigate objects in the GUI. It uses my newly published [Adeqt](https://pypi.org/project/adeqt/) package as an optional dependency - if that's not installed, you see an error message when trying to launch the console. I'm thinking we'll install it in the amore modules, so we can easily do a bit of debugging in a running GUI wherever it is, without requiring any special tools.

We could also make it visible in a menu, but for now I thought it might make sense to have it as a lightly hidden feature.

![image](https://github.com/European-XFEL/DAMNIT/assets/327925/5393fb5e-7e71-405f-9736-cb524e2cd8c1)
