### PR TITLE
Inspect 2D summarized data

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -465,8 +465,7 @@ class Results:
 
                 if (
                     isinstance(data, (np.ndarray, xr.DataArray))
-                    and data.ndim == 1
-                    and data.shape[0] > 1
+                    and data.size > 1
                 ):
                     reduced_ds.attrs["max_diff"] = abs(
                         np.subtract(np.nanmax(data), np.nanmin(data), dtype=np.float64)

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -4,35 +4,34 @@ import sys
 import time
 from argparse import ArgumentParser
 from datetime import datetime
-from pathlib import Path
 from enum import Enum
+from pathlib import Path
 from socket import gethostname
 
-import pandas as pd
-import numpy as np
 import h5py
+import numpy as np
+import pandas as pd
 from pandas.api.types import infer_dtype
+from PyQt5 import QtCore, QtGui, QtSvg, QtWidgets
+from PyQt5.Qsci import QsciLexerPython, QsciScintilla
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QFileDialog, QMessageBox, QTabWidget
 
 from kafka.errors import NoBrokersAvailable
 
-from PyQt5 import QtCore, QtGui, QtWidgets, QtSvg
-from PyQt5.QtCore import Qt
-from PyQt5.QtWidgets import QMessageBox, QTabWidget, QFileDialog
-from PyQt5.Qsci import QsciScintilla, QsciLexerPython
-
+from ..backend import backend_is_running, initialize_and_start_backend
 from ..backend.api import RunVariables
-from ..backend.db import db_path, DamnitDB, ReducedData, BlobTypes, MsgKind
+from ..backend.db import BlobTypes, DamnitDB, MsgKind, ReducedData, db_path
 from ..backend.extract_data import get_context_file, process_log_path
 from ..backend.user_variables import UserEditableVariable
-from ..backend import initialize_and_start_backend, backend_is_running
 from ..definitions import UPDATE_BROKERS
-from ..util import icon_path, StatusbarStylesheet
+from ..util import StatusbarStylesheet, fix_data_for_plotting, icon_path
+from .editor import ContextTestResult, Editor
 from .kafka import UpdateReceiver
-from .table import TableView, DamnitTableModel, prettify_notation
-from .plot import Canvas, Plot
-from .user_variables import AddUserVariableDialog
-from .editor import Editor, ContextTestResult
 from .open_dialog import OpenDBDialog
+from .plot import Canvas, Plot
+from .table import DamnitTableModel, TableView, prettify_notation
+from .user_variables import AddUserVariableDialog
 from .widgets import CollapsibleWidget
 from .zulip_messenger import ZulipMessenger
 
@@ -554,21 +553,6 @@ da-dev@xfel.eu"""
     def col_title_to_name(self, title):
         return self.table.column_title_to_id(title)
 
-    def make_finite(self, data):
-        if not isinstance(data, pd.Series):
-            data = pd.Series(data)
-
-        return data.astype('object').fillna(np.nan)
-
-    def bool_to_numeric(self, data):
-        if infer_dtype(data) == 'boolean':
-            data = data.astype('float')
-
-        return data
-
-    def fix_data_for_plotting(self, data):
-        return self.bool_to_numeric(self.make_finite(data))
-
     def inspect_data(self, index):
         proposal, run = self.table.row_to_proposal_run(index.row())
         quantity_title = self.table.column_title(index.column())
@@ -629,8 +613,8 @@ da-dev@xfel.eu"""
 
             canvas = Canvas(
                 self,
-                x=[self.fix_data_for_plotting(x)],
-                y=[self.fix_data_for_plotting(data)],
+                x=[fix_data_for_plotting(x)],
+                y=[fix_data_for_plotting(data)],
                 xlabel=f"Event (run {run})",
                 ylabel=quantity_title,
                 fmt="o",

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -588,7 +588,7 @@ da-dev@xfel.eu"""
             log.warning(f'"{quantity}" not found in {variable.file}...')
             return
 
-        if is_image or data.ndim == 2:
+        if data.ndim == 2 or (data.ndim == 3 and data.shape[-1] in (3, 4)):
             canvas = Canvas(
                 self,
                 image=data.data,

--- a/damnit/gui/plot.py
+++ b/damnit/gui/plot.py
@@ -19,6 +19,7 @@ from matplotlib.figure import Figure
 from mpl_pan_zoom import zoom_factory, PanManager, MouseButton
 
 from ..backend.api import RunVariables
+from ..util import fix_data_for_plotting
 
 log = logging.getLogger(__name__)
 
@@ -653,15 +654,15 @@ class Plot:
 
                 for pi, ri in zip(proposal, run):
                     strongly_correlated, x, y = self.get_run_series_data(pi, ri, xi, yi)
-                    xs.append(self._main_window.fix_data_for_plotting(x))
-                    ys.append(self._main_window.fix_data_for_plotting(y))
+                    xs.append(fix_data_for_plotting(x))
+                    ys.append(fix_data_for_plotting(y))
             else:
                 # not nice to replace NAs/infs with nans, but better solutions require more coding
                 xs.append(
-                    self._main_window.fix_data_for_plotting(self.table.column_series(xi, by_title=True))
+                    fix_data_for_plotting(self.table.column_series(xi, by_title=True))
                 )
                 ys.append(
-                    self._main_window.fix_data_for_plotting(self.table.column_series(yi, by_title=True))
+                    fix_data_for_plotting(self.table.column_series(yi, by_title=True))
                 )
 
             log.debug("Updating plot for x=%s, y=%s", xi, yi)

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -3,12 +3,15 @@ from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
 
+import numpy as np
 import pandas as pd
+from pandas.api.types import infer_dtype
 
 
 class StatusbarStylesheet(Enum):
     NORMAL = "QStatusBar {}"
     ERROR = "QStatusBar {background: red; color: white; font-weight: bold;}"
+
 
 def wait_until(condition, timeout=1):
     """
@@ -40,3 +43,19 @@ def icon_path(name):
     Helper function to get the path to an icon file stored under ico/.
     """
     return str(Path(__file__).parent / "gui/ico" / name)
+
+
+def make_finite(data):
+    if not isinstance(data, pd.Series):
+        data = pd.Series(data)
+    return data.astype('object').fillna(np.nan)
+
+
+def bool_to_numeric(data):
+    if infer_dtype(data) == 'boolean':
+        data = data.astype('float')
+    return data
+
+
+def fix_data_for_plotting(data):
+    return bool_to_numeric(make_finite(data))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -655,6 +655,10 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
         fig = plt.figure()
         plt.plot([1, 2, 3, 4], [4, 3, 2, 1])
         return fig
+
+    @Variable(title='2D data with summary', summary='mean')
+    def mean_2d(run):
+        return np.random.rand(512, 512)
     """
     ctx_code = mock_ctx.code + "\n\n" + textwrap.dedent(const_array_code)
     (db_dir / "context.py").write_text(ctx_code)
@@ -725,6 +729,15 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     with patch.object(QMessageBox, "warning") as warning:
         win.inspect_data(color_image_index)
         warning.assert_not_called()
+
+    # Check that 2D arrays with summary are inspectable
+    mean_2d_index = get_index('2D data with summary')
+    assert win.table.data(mean_2d_index, role=Qt.FontRole).bold()
+    assert isinstance(win.table.data(mean_2d_index, role=Qt.DisplayRole), str)
+    with patch.object(QMessageBox, "warning") as warning:
+        win.inspect_data(mean_2d_index)
+        warning.assert_not_called()
+
 
 def test_open_dialog(mock_db, qtbot):
     db_dir, db = mock_db


### PR DESCRIPTION
It is currently only possible to inspect 1d summarized data.
There's a need at HED to explore 2d data. Use case is that from run to run they have either 1 or multiple pulses per train.
In case there's 1 train the resulting data is 1d, but if there's multiple pulses it is 2d (tid vs pulse index). regardless of the case they want the summary data shown in the table and either a scatter plot (1d) or image (2d) when inspecting the variable.

the actual change is in 64f626747abc9a3fed8cb807d4e1e2bfe6e3788d else it's refactoring.