### PR TITLE
Skip over Variables returning unexpected types

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -240,7 +240,17 @@ class ContextFile:
 
                 data = func(run_data)
                 if not isinstance(data, (xr.Dataset, xr.DataArray, str, type(None), Figure)):
-                    data = np.asarray(data)
+                    arr = np.asarray(data)
+                    # Numpy will wrap any Python object, but only native arrays
+                    # can be saved in HDF5, not those containing Python objects.
+                    if arr.dtype.hasobject:
+                        log.error(
+                            "Variable %s returned %s which cannot be saved",
+                            name, type(data)
+                        )
+                        data = None
+                    else:
+                        data = arr
             except Exception:
                 log.error("Could not get data for %s", name, exc_info=True)
             else:


### PR DESCRIPTION
We already catch exceptions from variable functions, log them and continue computing other variables. But a variable which returned an unexpected type (like a matplotlib `Axes` instead of a `Figure`) would break saving output, with an error like this:

```
...
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-mid/conda_env/lib/python3.10/site-packages/damnit/ctxsupport/ctxrunner.py", line 575, in main
    res.save_hdf5(path)
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-mid/conda_env/lib/python3.10/site-packages/damnit/ctxsupport/ctxrunner.py", line 453, in save_hdf5
    f.create_dataset(path, shape=obj.shape, dtype=obj.dtype)
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202401/lib/python3.10/site-packages/h5py/_hl/group.py", line 183, in create_dataset
    dsid = dataset.make_new_dset(group, shape, dtype, data, name, **kwds)
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202401/lib/python3.10/site-packages/h5py/_hl/dataset.py", line 86, in make_new_dset
    tid = h5t.py_create(dtype, logical=1)
  File "h5py/h5t.pyx", line 1664, in h5py.h5t.py_create
  File "h5py/h5t.pyx", line 1688, in h5py.h5t.py_create
  File "h5py/h5t.pyx", line 1748, in h5py.h5t.py_create
TypeError: Object dtype dtype('O') has no native HDF5 equivalent
```

With this change, we discard the returned object, carry on with other variables, and log a message like:

> Variable bad returned <class 'object'> which cannot be saved