### PR TITLE
Add support for returning Axes from variables

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from unittest.mock import MagicMock
 from graphlib import CycleError, TopologicalSorter
 
+from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 import extra_data
@@ -239,6 +240,11 @@ class ContextFile:
                 func = functools.partial(var.func, **kwargs)
 
                 data = func(run_data)
+
+                # If the user returns an Axes, save the whole Figure
+                if isinstance(data, Axes):
+                    data = data.get_figure()
+
                 if not isinstance(data, (xr.Dataset, xr.DataArray, str, type(None), Figure)):
                     arr = np.asarray(data)
                     # Numpy will wrap any Python object, but only native arrays

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -275,6 +275,13 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     from damnit_ctx import Variable
     from matplotlib import pyplot as plt
 
+    @Variable(title="Axes")
+    def axes(run):
+        _, ax = plt.subplots()
+        ax.plot([1, 2, 3, 4], [4, 3, 2, 1])
+
+        return ax
+
     @Variable(title="Figure")
     def figure(run):
         fig = plt.figure()
@@ -285,11 +292,13 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     figure_ctx = mkcontext(figure_code)
     results = results_create(figure_ctx)
     assert isinstance(results.reduced["figure"], PNGData)
+    assert isinstance(results.reduced["axes"], PNGData)
 
     results_hdf5_path.unlink()
     results.save_hdf5(results_hdf5_path)
     with h5py.File(results_hdf5_path) as f:
         assert f["figure/data"].ndim == 3
+        assert f["axes/data"].ndim == 3
 
     # Test returning xarray.Datasets
     dataset_code = """


### PR DESCRIPTION
A lot of plotting functions from e.g extra-data and EXtra return Axes objects and it's a little annoying to remember to call `.get_figure()` on them every time, so now that's handled automatically.