### PR TITLE
Mymdc proxy

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -52,14 +52,14 @@ class Variable:
         """
         return RunData.RAW if self._data is None else RunData(self._data)
 
-    def arg_dependencies(self):
+    def arg_dependencies(self, prefix="var#"):
         """
-        Get all direct dependencies of this Variable. Returns a dict of argument name
-        to variable name.
+        Get all direct dependencies of this Variable with a certain
+        type/prefix. Returns a dict of argument name to variable name.
         """
-        return { arg_name: annotation.removeprefix("var#")
+        return { arg_name: annotation.removeprefix(prefix)
                  for arg_name, annotation in self.annotations().items()
-                 if annotation.startswith("var#") }
+                 if annotation.startswith(prefix) }
 
     def annotations(self):
         """

--- a/damnit/gui/editor.py
+++ b/damnit/gui/editor.py
@@ -99,12 +99,13 @@ class Editor(QsciScintilla):
         out_buffer = StringIO()
         reporter = Reporter(out_buffer, out_buffer)
         pyflakes_check(self.text(), "<ctx>", reporter)
-        # Disgusting hack to avoid getting warnings for "var#foo" and "meta#foo"
-        # type annotations. This needs some tweaking to avoid missing real
-        # errors.
+        # Disgusting hack to avoid getting warnings for "var#foo", "meta#foo",
+        # and "mymdc#foo" type annotations. This needs some tweaking to avoid
+        # missing real errors.
         pyflakes_output = "\n".join([line for line in out_buffer.getvalue().split("\n")
                                      if not line.endswith("undefined name 'var'") \
-                                     and not line.endswith("undefined name 'meta'")])
+                                     and not line.endswith("undefined name 'meta'") \
+                                     and not line.endswith("undefined name 'mymdc'")])
 
         if len(pyflakes_output) > 0:
             return ContextTestResult.WARNING, pyflakes_output

--- a/damnit/gui/kafka.py
+++ b/damnit/gui/kafka.py
@@ -1,26 +1,30 @@
 import pickle
 import logging
 
-from kafka import KafkaConsumer
+from kafka import KafkaConsumer, KafkaProducer
 from PyQt5 import QtCore
 
+from ..backend.db import MsgKind, msg_dict
 from ..definitions import UPDATE_BROKERS, UPDATE_TOPIC
 
 log = logging.getLogger(__name__)
 
 
-class UpdateReceiver(QtCore.QObject):
+class UpdateAgent(QtCore.QObject):
     message = QtCore.pyqtSignal(object)
 
     def __init__(self, db_id: str) -> None:
         QtCore.QObject.__init__(self)
+        self.update_topic = UPDATE_TOPIC.format(db_id)
 
         self.kafka_cns = KafkaConsumer(
-            UPDATE_TOPIC.format(db_id), bootstrap_servers=UPDATE_BROKERS
+            self.update_topic, bootstrap_servers=UPDATE_BROKERS
         )
+        self.kafka_prd = KafkaProducer(bootstrap_servers=UPDATE_BROKERS,
+                                       value_serializer=lambda d: pickle.dumps(d))
         self.running = False
 
-    def loop(self) -> None:
+    def listen_loop(self) -> None:
         self.running = True
 
         while self.running:
@@ -38,12 +42,38 @@ class UpdateReceiver(QtCore.QObject):
 
                     self.message.emit(unpickled_msg)
 
+    def run_values_updated(self, proposal, run, name, value):
+        message = msg_dict(MsgKind.run_values_updated,
+                           {
+                               "proposal": proposal,
+                               "run": run,
+                               "values": {
+                                   name: value
+                               }
+                           })
+
+        # Note: the send() function returns a future that we don't await
+        # immediately, but we call kafka_prd.flush() in stop() which will ensure
+        # that all messages are sent.
+        self.kafka_prd.send(self.update_topic, message)
+
+    def variable_set(self, name, title, description, variable_type):
+        message = msg_dict(MsgKind.variable_set,
+                           {
+                               "name": name,
+                               "title": title,
+                               "attributes": None,
+                               "type": variable_type
+                           })
+        self.kafka_prd.send(self.update_topic, message)
+
     def stop(self):
         self.running = False
+        self.kafka_prd.flush(timeout=10)
 
 
 if __name__ == "__main__":
-    recevier = UpdateReceiver("tcp://localhost:5556")
+    monitor = UpdateAgent("tcp://localhost:5556")
 
-    for record in recevier.kafka_cns:
+    for record in monitor.kafka_cns:
         print(record.value.decode())

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -84,6 +84,12 @@ arguments if they have the right _annotations_:
 - `meta#proposal_dir`: The root
   [Path](https://docs.python.org/3/library/pathlib.html) to the current
   proposal.
+- `mymdc#sample_name`: The sample name from myMdC.
+- `mymdc#run_type`: The run type from myMdC.
+
+!!! warning
+    The myMdC integration requires a special token to work properly, please
+    contact the DA group if you would like to use this for your experiment.
 
 You can also use annotations to express a dependency between `Variable`'s using
 the `var#<name>` annotation:
@@ -195,6 +201,8 @@ $ amore-proto db-config context_python /path/to/your/python
 The environment *must* have these dependencies installed for DAMNIT to work:
 
 - `extra_data`
+- `pyyaml`
+- `requests`
 - `scipy`
 
 ## Managing the backend

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,11 @@ dependencies = [
     "numpy",
     "pandas<2",
     "xarray",
+    "requests",
     "scipy",
     "supervisor",
     "termcolor",
+    "pyyaml"
 ]
 
 [project.optional-dependencies]
@@ -34,7 +36,6 @@ gui = [
     "PyQt5",
     "pyflakes",  # for checking context file in editor
     "QScintilla==2.13",
-    "requests",
     "tabulate",  # used in pandas to make markdown tables (for Zulip)
 ]
 test = [

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -37,13 +37,17 @@ def test_connect_to_kafka(mock_db, qtbot):
     db_dir, db = mock_db
     pkg = "damnit.gui.kafka"
 
-    with patch(f"{pkg}.KafkaConsumer") as kafka_cns:
+    with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
+         patch(f"{pkg}.KafkaProducer") as kafka_prd:
         MainWindow(db_dir, False).close()
         kafka_cns.assert_not_called()
+        kafka_prd.assert_not_called()
 
-    with patch(f"{pkg}.KafkaConsumer") as kafka_cns:
+    with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
+         patch(f"{pkg}.KafkaProducer") as kafka_prd:
         MainWindow(db_dir, True).close()
         kafka_cns.assert_called_once()
+        kafka_prd.assert_called_once()
 
 def test_editor(mock_db, mock_ctx, qtbot):
     db_dir, db = mock_db


### PR DESCRIPTION
In a nutshell, DAMNIT will now look for mymdc credentials in `usr/mymdc-credentials.yml` whenever a `mymdc#...` argument is used in a variable, and use them to retrieve mymdc fields (currently just the sample and run type are allowed).

The credentials file must have the format:
```yaml
token: <token>
server: <server-url>
```

Fixes #34.