### PR TITLE
FIX: hidden header when loading a new proposal in a running GUI

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -247,6 +247,7 @@ da-dev@xfel.eu"""
         for column in ["Status", "Proposal", "Run", "Timestamp"]:
             column_index = self.table.find_column(column, by_title=True)
             header.setSectionResizeMode(column_index, QtWidgets.QHeaderView.ResizeToContents)
+        header.setVisible(True)
 
         # Update the column widget and plotting controls with the new columns
         titles = self.table.column_titles


### PR DESCRIPTION
Currently the horizontal header disappears if you load a new proposal (`SHIFT+A`):

![Screenshot from 2024-03-28 15-26-23](https://github.com/European-XFEL/DAMNIT/assets/32831491/51cce9ab-343a-46ca-8ed6-681be49c31de)
