### PR TITLE
Fix API support for comments and timestamps

### DIFF
--- a/damnit/__init__.py
+++ b/damnit/__init__.py
@@ -1,5 +1,5 @@
 """Prototype for extracting and showing metadata (AMORE project)"""
 
-__version__ = '0.1.1'
+__version__ = '0.1.2'
 
 from .api import Damnit, RunVariables, VariableData

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -237,8 +237,20 @@ class RunVariables:
     def _var_titles(self):
         result = self._db.conn.execute("SELECT name, title FROM variables").fetchall()
         available_vars = self.keys()
-        return { row[0]: row[1] if row[1] is not None else row[0] for row in result
-                 if row[0] in available_vars }
+        titles = { row[0]: row[1] if row[1] is not None else row[0] for row in result
+                   if row[0] in available_vars }
+
+        # These variables are created automatically, but they aren't included in
+        # the `variables` table (yet) so we need to explicitly add their titles.
+        special_vars = {
+            "start_time": "Timestamp",
+            "comment": "Comment"
+        }
+        for name, title in special_vars.items():
+            if name in available_vars:
+                titles[name] = title
+
+        return titles
 
     def titles(self) -> list:
         """The titles of available variables.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -67,6 +67,19 @@ def test_run_variables(mock_db_with_data, monkeypatch):
     assert rv["scalar1"].name == "scalar1"
     assert rv["Scalar1"].name == "scalar1"
 
+    # Test getting the start_time. This one's a bit special because we create it
+    # automatically, it's a proper variable except for the fact that we don't
+    # insert it into the `variables` table.
+    assert isinstance(rv["start_time"].read(), float)
+    assert "Timestamp" in rv.titles()
+
+    # Test getting comments. This is also special because it doesn't appear in
+    # the `variables` table.
+    assert "comment" not in rv.keys()
+    db.change_run_comment(damnit.proposal, 1, "foo")
+    assert "Comment" in rv.titles()
+    assert rv["comment"].read() == "foo"
+
     with pytest.raises(KeyError):
         rv["foo"]
 


### PR DESCRIPTION
See the comments for details, but TL;DR they're special and aren't inserted in the `variables` table yet so retrieving them would cause errors because we didn't have titles for them.

I also bumped the version, I'm going to roguishly deploy it now because it's a bit annoying to work around in production :see_no_evil: 

The fix will need to stay for the sake of backwards compatibility, but in the future we should add the comment and timestamp to `variables`.