### PR TITLE
Use `run_variables` instead of `runs` in Damnit.table()

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -350,27 +350,27 @@ class Damnit:
             with_titles (bool): Whether to use variable titles instead of names
                 for the columns in the dataframe.
         """
-        df = pd.read_sql_query("SELECT * FROM runs", self._db.conn)
+        run_variables = pd.read_sql_query("SELECT run, name, value FROM run_variables WHERE typeof(value) <> 'blob'", self._db.conn)
 
-        # Convert the start_time into a datetime column
-        start_time = pd.to_datetime(df["start_time"], unit="s", utc=True)
-        df["start_time"] = start_time.dt.tz_convert("Europe/Berlin")
+        # Initialize the dataframe by pivoting from the long-narrow to a wide format
+        df = run_variables.pivot(index="run", columns="name")
+        # The columns index is set to a MultiIndex of ('values', <col_name>) by
+        # .pivot(), which is quite annoying for indexing columns so we drop that
+        # first level.
+        df.columns = df.keys().droplevel()
 
-        # Delete added_at, this is internal
-        del df["added_at"]
+        # .pivot() will insert nans in the empty cells of the dataframe, which
+        # is confusing because some variables may also return nan. To get around
+        # this we create a mask of cells that don't have data from
+        # `run_variables` and assign a fill value of pd.NA. We don't use None
+        # because that's printed by pandas in exactly the same way as the string
+        # "None".
+        run_variables["value"] = False
+        is_present_mask = run_variables.pivot(index="run", columns="name").isna()
+        df.mask(is_present_mask.to_numpy(), other=pd.NA, inplace=True)
 
-        # Ensure that there's always a comment column for consistency, it may
-        # not be present if no comments were made.
-        if "comment" not in df:
-            df.insert(3, "comment", None)
-
-        # Convert PNG blobs into a string
-        def image2str(value):
-            if isinstance(value, bytes) and BlobTypes.identify(value) is BlobTypes.png:
-                return "<image>"
-            else:
-                return value
-        df = df.applymap(image2str)
+        # TODO: need to add the missing columns: all of the image columns,
+        # start_time, added_at, and comment.
 
         # Use the full variable titles
         if with_titles:


### PR DESCRIPTION
This is a lot faster because we can filter out blobs, which we don't want to load anyway. The PR is incomplete, I'll be away for the next week but if anyone else wants to finish it off feel free :)

Breaking changes:
- The run number is now set to the index so you can `.loc` the table by run number.
- The proposal column is removed, I think it's usually not needed.
- `None` values in the old table where cells didn't have any data are now set to `pd.NA`.

TODO:
- [ ] Add missing columns to the dataframe (see code comment).
- [ ] The code currently removes the `proposal` column under the assumption that it doesn't change and the user probably isn't interested in it, but we should add an argument to keep it in case it's necessary in the future.
- [ ] Add tests.
