### PR TITLE
Preserve context file path for tracebacks

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -216,12 +216,13 @@ class ContextFile:
     def from_py_file(cls, path: Path):
         code = path.read_text()
         log.debug("Loading context from %s", path)
-        return ContextFile.from_str(code)
+        return ContextFile.from_str(code, str(path.absolute()))
 
     @classmethod
-    def from_str(cls, code: str):
+    def from_str(cls, code: str, path='<string>'):
         d = {}
-        exec(code, d)
+        codeobj = compile(code, path, 'exec')
+        exec(codeobj, d)
         vars = {v.name: v for v in d.values() if isinstance(v, Variable)}
         log.debug("Loaded %d variables", len(vars))
         return cls(vars, code)


### PR DESCRIPTION
At present, tracebacks covering the context file don't know where the file is, so the relevant entry shows no code:

```
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/conda_env/lib/python3.10/site-packages/damnit/ctxsupport/ct
xrunner.py", line 330, in execute
    data = func(run_data)
  File "<string>", line 72, in rep_rate
  File "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202401/lib/python3.10/site-packages/extra/components/pulses.py"
, line 971, in __init__
    super().__init__(data, source)
...
```

This should fix it so it can show the relevant line of code from the context file as well.