### PR TITLE
Add option to reprocess runs in parallel

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -97,6 +97,10 @@ def main():
         help="String to match against variable titles (case-insensitive). Not a regex, simply `str in var.title`."
     )
     reprocess_ap.add_argument(
+        '-j', '--parallel', type=int, default=1,
+        help="Maximum number of runs to process in parallel (default 1)"
+    )
+    reprocess_ap.add_argument(
         'run', nargs='+',
         help="Run number, e.g. 96. Multiple runs can be specified at once, "
              "or pass 'all' to reprocess all runs in the database."
@@ -206,7 +210,7 @@ def main():
         logging.getLogger('kafka').setLevel(logging.WARNING)
 
         from .backend.extract_data import reprocess
-        reprocess(args.run, args.proposal, args.match, args.mock)
+        reprocess(args.run, args.proposal, args.match, args.mock, args.parallel)
 
     elif args.subcmd == 'read-context':
         from .backend.extract_data import Extractor


### PR DESCRIPTION
To address #240.

This isn't particularly elegant code, but it does work, at least in a quick test. The most awkward bit is with the extractor object: I can't just use the same one across all threads, because at least the sqlite database connection shouldn't be shared across threads. But I also don't want to create a new Extractor for each individual run, so I didn't just `map()` over the available runs. I'm still thinking about how to handle this better.

I wanted to show less output when processing in parallel, because the usual output would probably be too fast and too jumbled up to be much use. The longer output is still directed to the relevant file in the `process_logs` folder.