### PR TITLE
Evaluate non-cluster variables in Slurm using Solaris cluster

### DIFF
--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -115,6 +115,8 @@ class EventProcessor:
             'sbatch', '--parsable',
             '--cluster=solaris',
             '-o', log_path,
+            '--cpus-per-task', '4',
+            '--mem', '25G',
             '--open-mode=append',
             # Note: we put the run number first so that it's visible in
             # squeue's default 11-character column for the JobName.

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -3,13 +3,11 @@ import json
 import logging
 import os
 import platform
-import queue
 import shlex
 import subprocess
 import sys
 from pathlib import Path
 from socket import gethostname
-from threading import Thread
 
 from kafka import KafkaConsumer
 
@@ -35,37 +33,6 @@ KAFKA_CONF = {
 log = logging.getLogger(__name__)
 
 
-def watch_processes_finish(q: queue.Queue):
-    procs_by_prop_run = {}
-    while True:
-        # Get new subprocesses from the main thread
-        try:
-            prop, run, popen = q.get(timeout=1)
-            procs_by_prop_run[prop, run] = popen
-        except queue.Empty:
-            pass
-
-        # Check if any of the subprocesses we're tracking have finished
-        to_delete = set()
-        for (prop, run), popen in procs_by_prop_run.items():
-            returncode = popen.poll()
-            if returncode is None:
-                continue  # Still running
-
-            # Can't delete from a dict while iterating over it
-            to_delete.add((prop, run))
-            if returncode == 0:
-                log.info("Data extraction for p%d r%d succeeded", prop, run)
-            else:
-                log.error(
-                    "Data extraction for p%d, r%d failed with exit code %d",
-                    prop, run, returncode
-                )
-
-        for prop, run in to_delete:
-            del procs_by_prop_run[prop, run]
-
-
 class EventProcessor:
 
     def __init__(self, context_dir=Path('.')):
@@ -88,13 +55,6 @@ class EventProcessor:
                                        group_id=consumer_id)
         self.events = kafka_conf['events']
 
-        self.extract_procs_queue = queue.Queue()
-        self.extract_procs_watcher = Thread(
-            target=watch_processes_finish,
-            args=(self.extract_procs_queue,),
-            daemon=True
-        )
-        self.extract_procs_watcher.start()
 
     def __enter__(self):
         return self

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -115,8 +115,9 @@ class EventProcessor:
             'sbatch', '--parsable',
             '--cluster=solaris',
             '-o', log_path,
-            '--cpus-per-task', '4',
-            '--mem', '25G',
+            # Default 4 CPU cores & 25 GB memory, can be overridden
+            '--cpus-per-task', str(self.db.metameta.get('noncluster_cpus', '4')),
+            '--mem', self.db.metameta.get('noncluster_mem', '25G'),
             '--open-mode=append',
             # Note: we put the run number first so that it's visible in
             # squeue's default 11-character column for the JobName.

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -114,7 +114,7 @@ def baz(run, value: "var#foo"=42):
 Variable functions can use up to 4 CPU cores and 25 GB of RAM by default.
 If more resources are needed, use `cluster=True` (described below) to access all
 of the cores & memory of an assigned cluster node. If required, you can also
-change the limits for non-cluster variables :
+change the limits for non-cluster variables:
 
 ```bash
 # Allow 8 CPU cores

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -111,6 +111,19 @@ def baz(run, value: "var#foo"=42):
     return value
 ```
 
+Variable functions can use up to 4 CPU cores and 25 GB of RAM by default.
+If more resources are needed, use `cluster=True` (described below) to access all
+of the cores & memory of an assigned cluster node. If required, you can also
+change the limits for non-cluster variables :
+
+```bash
+# Allow 8 CPU cores
+$ amore-proto db-config noncluster_cpus 8
+
+# Allow 50 GB memory
+$ amore-proto db-config noncluster_mem 50G
+```
+
 ## Using Slurm
 As mentioned in the previous section, variables can be marked for execution in a
 Slurm job with the `cluster=True` argument to the decorator:


### PR DESCRIPTION
Instead of running extraction as a subprocess of the listener on the login node (or wherever the listener was started), this would run it in the [Solaris cluster](https://confluence.desy.de/display/MXW/Running-single-core-batch-job_302030316.html), which consists of relatively low-powered nodes configured to allow multiple small jobs at once. The `cluster=True` variables are still run on a dedicated node in the main cluster, as before.

The default settings seem to give jobs 2 CPU cores and 4 GB of RAM. We can specify different limits if we want - the nodes seem to have 20 physical cores (40 with hyperthreading) and 256 GB RAM. I'm still figuring out how the different options interact (e.g. `--mem` and `--mem-per-cpu`).

Going over the specified memory limit can get the job killed, whereas on a login node we might get away with using more RAM for a while, but cause problems unpredictably. In the long run, I think having a consistent rule about what variables need `cluster=True` is probably preferable, but it might be frustrating while we adapt.

I've only done this for the listener at the moment - reprocessing still runs on whatever node you run `amore-proto reprocess` on. If we do want to go in this direction, I'll make that use the solaris cluster too.