### PR TITLE
Improve error handling when opening variables in the GUI

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -570,8 +570,15 @@ da-dev@xfel.eu"""
 
         try:
             variable = RunVariables(self._context_path.parent, run)[quantity]
+        except FileNotFoundError:
+            self.show_status_message(f"Couldn't get run variables for p{proposal}, r{run}",
+                                     timeout=7000,
+                                     stylesheet=StatusbarStylesheet.ERROR)
+            return
         except KeyError:
-            log.warning(f"Unrecognized variable: '{quantity}'")
+            self.show_status_message(f"Unrecognized variable: '{quantity}'",
+                                     timeout=7000,
+                                     stylesheet=StatusbarStylesheet.ERROR)
             return
 
         try:


### PR DESCRIPTION
Two changes:
- Handle the case where the HDF5 file isn't found. This may happen if there are multiple proposals in the same database, then `RunVariables` will attempt to look for an HDF5 file for the currently configured proposal and not be able to find it. We should fix this properly by adding support to the API for databases with multiple proposals.
- Show a status message if there was an error instead of just logging something to the terminal.