### PR TITLE
Explicitly specify maxwell cluster when submitting larger jobs

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -292,6 +292,7 @@ class Extractor:
 
             res = subprocess.run([
                 'sbatch', '--parsable',
+                '--clusters', 'maxwell',
                 *self.slurm_options(),
                 '-o', process_log_path(run, proposal),
                 '--open-mode=append',


### PR DESCRIPTION
This will hopefully fix the 'invalid partition specified' errors