### PR TITLE
Use Slurm jobs for reprocessing

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -464,7 +464,7 @@ def submit_slurm(
     return job_id
 
 
-if __name__ == '__main__':
+def main(argv=None):
     # This runs inside the Slurm job
     ap = argparse.ArgumentParser()
     ap.add_argument('proposal', type=int)
@@ -475,7 +475,7 @@ if __name__ == '__main__':
     ap.add_argument('--cluster-job', action="store_true")
     ap.add_argument('--match', action="append", default=[])
     ap.add_argument('--mock', action='store_true')
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
     logging.basicConfig(level=logging.INFO,
                         format="%(asctime)s %(levelname)s %(name)s: %(message)s")
     # Hide some logging from Kafka to make things more readable
@@ -494,3 +494,7 @@ if __name__ == '__main__':
                                    run_data=RunData(args.run_data),
                                    match=args.match,
                                    mock=args.mock)
+
+
+if __name__ == '__main__':
+    main()

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -119,7 +119,9 @@ class ExtractionSubmitter:
 
         Returns the job ID & cluster
         """
-        res = subprocess.run(self.sbatch_cmd(req), stdout=subprocess.PIPE, text=True)
+        res = subprocess.run(
+            self.sbatch_cmd(req), stdout=subprocess.PIPE, text=True, check=True
+        )
         job_id, _, cluster = res.stdout.partition(';')
         job_id = job_id.strip()
         cluster = cluster.strip() or 'maxwell'

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -151,7 +151,9 @@ class ExtractionSubmitter:
 
         # Duplicate output to the log file
         with tee(log_path) as pipe:
-            subprocess.run(self.srun_cmd(req), stdout=pipe, stderr=subprocess.STDOUT)
+            subprocess.run(
+                self.srun_cmd(req), stdout=pipe, stderr=subprocess.STDOUT, check=True
+            )
 
     def srun_cmd(self, req: ExtractionRequest):
         return [

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -207,14 +207,17 @@ def reprocess(runs, proposal=None, match=(), mock=False, watch=False):
         props_runs = []
         unavailable_runs = []
 
-        for proposal, run in rows:
-            if not mock and proposal not in available_runs:
-                available_runs[proposal] = proposal_runs(proposal)
+        if mock:
+            props_runs = rows
+        else:
+            for proposal, run in rows:
+                if proposal not in available_runs:
+                    available_runs[proposal] = proposal_runs(proposal)
 
-            if mock or run in available_runs[proposal]:
-                props_runs.append((proposal, run))
-            else:
-                unavailable_runs.append((proposal, run))
+                if run in available_runs[proposal]:
+                    props_runs.append((proposal, run))
+                else:
+                    unavailable_runs.append((proposal, run))
 
         print(f"Reprocessing {len(props_runs)} runs already recorded, skipping {len(unavailable_runs)}...")
     else:

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -1,0 +1,245 @@
+"""Machinery to run Slurm jobs for extracting data
+
+See extract_data.py for what happens inside the jobs this launches.
+"""
+import getpass
+import logging
+import os
+import shlex
+import subprocess
+import sys
+from contextlib import contextmanager
+from ctypes import CDLL
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Thread
+
+from extra_data.read_machinery import find_proposal
+
+from .db import DamnitDB
+from ..context import RunData
+
+log = logging.getLogger(__name__)
+
+
+# Python innetgr wrapper after https://github.com/wcooley/netgroup-python/
+def innetgr(netgroup: bytes, host=None, user=None, domain=None):
+    libc = CDLL("libc.so.6")
+    return bool(libc.innetgr(netgroup, host, user, domain))
+
+
+def default_slurm_partition():
+    username = getpass.getuser().encode()
+    if innetgr(b'exfel-wgs-users', user=username):
+        return 'exfel'
+    elif innetgr(b'upex-users', user=username):
+        return 'upex'
+    return 'all'
+
+
+def process_log_path(run, proposal, ctx_dir=Path('.'), create=True):
+    p = ctx_dir.absolute() / 'process_logs' / f"r{run}-p{proposal}.out"
+    if create:
+        p.parent.mkdir(exist_ok=True)
+        if p.parent.stat().st_uid == os.getuid():
+            p.parent.chmod(0o777)
+        p.touch(exist_ok=True)
+        if p.stat().st_uid == os.getuid():
+            p.chmod(0o666)
+    return p
+
+
+@contextmanager
+def tee(path: Path):
+    with path.open('ab') as fout:
+        r, w = os.pipe()
+        def loop():
+            while b := os.read(r, 4096):
+                fout.write(b)
+                sys.stdout.buffer.write(b)
+                sys.stdout.flush()
+
+        thread = Thread(target=loop)
+        thread.start()
+        try:
+            yield w
+        finally:
+            os.close(w)
+            thread.join()
+            os.close(r)
+
+
+def proposal_runs(proposal):
+    proposal_name = f"p{int(proposal):06d}"
+    raw_dir = Path(find_proposal(proposal_name)) / "raw"
+    return set(int(p.stem[1:]) for p in raw_dir.glob("*"))
+
+
+@dataclass
+class ExtractionRequest:
+    """Description of some data we want to extract"""
+    run: int
+    proposal: int
+    run_data: RunData
+    cluster: bool = False
+    match: tuple = ()
+    mock: bool = False
+
+    def python_cmd(self):
+        """Creates the command for a process to do this extraction"""
+        cmd = [
+            sys.executable, '-m', 'damnit.backend.extract_data',
+            str(self.proposal), str(self.run), self.run_data.value
+        ]
+        if self.cluster:
+            cmd.append('--cluster-job')
+        for m in self.match:
+            cmd.extend(['--match', m])
+        if self.mock:
+            cmd.append('--mock')
+        return cmd
+
+
+class ExtractionSubmitter:
+    """Submits extraction jobs to Slurm"""
+    def __init__(self, context_dir: Path, db=None):
+        self.context_dir = context_dir
+        self.db = db or DamnitDB.from_dir(context_dir)
+
+    _proposal = None
+
+    @property
+    def proposal(self):
+        if self._proposal is None:
+            self._proposal = self.db.metameta['proposal']
+        return self._proposal
+
+    def submit(self, req: ExtractionRequest):
+        """Submit a Slurm job to extract data from a run
+
+        Returns the job ID & cluster
+        """
+        res = subprocess.run(self.sbatch_cmd(req), stdout=subprocess.PIPE, text=True)
+        job_id, _, cluster = res.stdout.partition(';')
+        job_id = job_id.strip()
+        cluster = cluster.strip() or 'maxwell'
+        log.info("Launched Slurm (%s) job %s to run context file", cluster, job_id)
+        return job_id, cluster
+
+    def sbatch_cmd(self, req: ExtractionRequest):
+        """Make the sbatch command to extract data from a run"""
+        log_path = process_log_path(req.run, req.proposal, self.context_dir)
+        log.info("Processing output will be written to %s",
+                 log_path.relative_to(self.context_dir.absolute()))
+
+        return [
+            'sbatch', '--parsable',
+            *self._resource_opts(req.cluster),
+            '-o', log_path,
+            '--open-mode=append',
+            # Note: we put the run number first so that it's visible in
+            # squeue's default 11-character column for the JobName.
+            '--job-name', f"r{req.run}-p{req.proposal}-damnit",
+            '--wrap', shlex.join(req.python_cmd())
+        ]
+
+    def execute(self, req: ExtractionRequest):
+        """Run an extraction job in srun with live output"""
+        log_path = process_log_path(req.run, req.proposal, self.context_dir)
+        log.info("Processing output will be written to %s",
+                 log_path.relative_to(self.context_dir.absolute()))
+
+        # Duplicate output to the log file
+        with tee(log_path) as pipe:
+            subprocess.run(self.srun_cmd(req), stdout=pipe, stderr=subprocess.STDOUT)
+
+    def srun_cmd(self, req: ExtractionRequest):
+        return [
+            'srun', *self._resource_opts(req.cluster),
+            '--job-name', f"r{req.run}-p{req.proposal}-damnit",
+            *req.python_cmd()
+        ]
+
+    def _resource_opts(self, cluster: bool):
+        if cluster:
+            return self._slurm_cluster_opts()
+        else:
+            return self._slurm_shared_opts()
+
+    def _slurm_shared_opts(self):
+        return [
+            "--clusters", "solaris",
+            # Default 4 CPU cores & 25 GB memory, can be overridden
+            '--cpus-per-task', str(self.db.metameta.get('noncluster_cpus', '4')),
+            '--mem', self.db.metameta.get('noncluster_mem', '25G'),
+        ]
+
+    def _slurm_cluster_opts(self):
+        # Maxwell (dedicated node)
+        opts = [
+            "--clusters", "maxwell",
+            "--time", self.db.metameta.get("slurm_time", "02:00:00")
+        ]
+
+        if reservation := self.db.metameta.get('slurm_reservation', ''):
+            opts.extend(['--reservation', reservation])
+        else:
+            partition = self.db.metameta.get('slurm_partition', '') or default_slurm_partition()
+            opts.extend(['--partition', partition])
+
+        return opts
+
+
+def reprocess(runs, proposal=None, match=(), mock=False, watch=False):
+    """Called by the 'amore-proto reprocess' subcommand"""
+    submitter = ExtractionSubmitter(Path.cwd())
+    if proposal is None:
+        proposal = submitter.proposal
+
+    if runs == ['all']:
+        rows = submitter.db.conn.execute("SELECT proposal, run FROM runs").fetchall()
+
+        # Dictionary of proposal numbers to sets of available runs
+        available_runs = {}
+        # Lists of (proposal, run) tuples
+        props_runs = []
+        unavailable_runs = []
+
+        for proposal, run in rows:
+            if not mock and proposal not in available_runs:
+                available_runs[proposal] = proposal_runs(proposal)
+
+            if mock or run in available_runs[proposal]:
+                props_runs.append((proposal, run))
+            else:
+                unavailable_runs.append((proposal, run))
+
+        print(f"Reprocessing {len(props_runs)} runs already recorded, skipping {len(unavailable_runs)}...")
+    else:
+        try:
+            runs = set([int(r) for r in runs])
+        except ValueError as e:
+            sys.exit(f"Run numbers must be integers ({e})")
+
+        if mock:
+            available_runs = runs
+        else:
+            available_runs = proposal_runs(proposal)
+
+        unavailable_runs = runs - available_runs
+        if len(unavailable_runs) > 0:
+            # Note that we print unavailable_runs as a list so it's enclosed
+            # in [] brackets, which is more recognizable than the {} braces
+            # that sets are enclosed in.
+            print(
+                f"Warning: skipping {len(unavailable_runs)} runs because they don't exist: {sorted(unavailable_runs)}")
+
+        props_runs = [(proposal, r) for r in sorted(runs & available_runs)]
+
+
+    for prop, run in props_runs:
+        req = ExtractionRequest(run, prop, RunData.ALL, match=match, mock=mock)
+        if watch:
+            submitter.execute(req)
+        else:
+            submitter.submit(req)

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -3,16 +3,13 @@ import json
 import logging
 import os
 import platform
-import shlex
-import subprocess
-import sys
 from pathlib import Path
 from socket import gethostname
 
 from kafka import KafkaConsumer
 
 from .db import DamnitDB
-from .extract_data import RunData, process_log_path
+from .extract_data import RunData, ExtractionRequest, ExtractionSubmitter
 
 # For now, the migration & calibration events come via DESY's Kafka brokers,
 # but the AMORE updates go via XFEL's test instance.
@@ -38,6 +35,7 @@ class EventProcessor:
     def __init__(self, context_dir=Path('.')):
         self.context_dir = context_dir
         self.db = DamnitDB.from_dir(context_dir)
+        self.submitter = ExtractionSubmitter(context_dir, self.db)
         # Fail fast if read-only - https://stackoverflow.com/a/44707371/434217
         self.db.conn.execute("pragma user_version=0;")
         self.proposal = self.db.metameta['proposal']
@@ -102,30 +100,8 @@ class EventProcessor:
         self.db.ensure_run(proposal, run, record.timestamp / 1000)
         log.info(f"Added p%d r%d ({run_data.value} data) to database", proposal, run)
 
-        log_path = process_log_path(run, proposal, self.context_dir)
-        log.info("Processing output will be written to %s",
-                 log_path.relative_to(self.context_dir.absolute()))
-
-        python_cmd = [
-            sys.executable, '-m', 'damnit.backend.extract_data',
-            str(proposal), str(run), run_data.value
-        ]
-
-        res = subprocess.run([
-            'sbatch', '--parsable',
-            '--cluster=solaris',
-            '-o', log_path,
-            # Default 4 CPU cores & 25 GB memory, can be overridden
-            '--cpus-per-task', str(self.db.metameta.get('noncluster_cpus', '4')),
-            '--mem', self.db.metameta.get('noncluster_mem', '25G'),
-            '--open-mode=append',
-            # Note: we put the run number first so that it's visible in
-            # squeue's default 11-character column for the JobName.
-            '--job-name', f"r{run}-p{proposal}-damnit",
-            '--wrap', shlex.join(python_cmd)
-        ], stdout=subprocess.PIPE, text=True)
-        job_id = res.stdout.partition(';')[0].strip()
-        log.info("Launched Slurm (solaris) job %s to run context file", job_id)
+        req = ExtractionRequest(run, proposal, run_data)
+        self.submitter.submit(req)
 
 
 def listen():

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -8,8 +8,9 @@ from socket import gethostname
 
 from kafka import KafkaConsumer
 
+from ..context import RunData
 from .db import DamnitDB
-from .extract_data import RunData, ExtractionRequest, ExtractionSubmitter
+from .extraction_control import ExtractionRequest, ExtractionSubmitter
 
 # For now, the migration & calibration events come via DESY's Kafka brokers,
 # but the AMORE updates go via XFEL's test instance.

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -97,6 +97,10 @@ def main():
         help="String to match against variable titles (case-insensitive). Not a regex, simply `str in var.title`."
     )
     reprocess_ap.add_argument(
+        '--watch', action='store_true',
+        help="Run jobs one-by-one with live output in the terminal"
+    )
+    reprocess_ap.add_argument(
         'run', nargs='+',
         help="Run number, e.g. 96. Multiple runs can be specified at once, "
              "or pass 'all' to reprocess all runs in the database."
@@ -205,8 +209,8 @@ def main():
         # Hide some logging from Kafka to make things more readable
         logging.getLogger('kafka').setLevel(logging.WARNING)
 
-        from .backend.extract_data import reprocess
-        reprocess(args.run, args.proposal, args.match, args.mock)
+        from .backend.extraction_control import reprocess
+        reprocess(args.run, args.proposal, args.match, args.mock, args.watch)
 
     elif args.subcmd == 'read-context':
         from .backend.extract_data import Extractor

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -24,7 +24,8 @@ from PyQt5.QtWidgets import QFileDialog, QMessageBox, QTabWidget
 from ..api import DataType, RunVariables
 from ..backend import backend_is_running, initialize_and_start_backend
 from ..backend.db import BlobTypes, DamnitDB, MsgKind, ReducedData, db_path
-from ..backend.extract_data import get_context_file, process_log_path
+from ..backend.extract_data import get_context_file
+from ..backend.extraction_control import process_log_path
 from ..backend.user_variables import UserEditableVariable
 from ..definitions import UPDATE_BROKERS
 from ..util import StatusbarStylesheet, fix_data_for_plotting, icon_path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ test = [
     "pytest-xvfb",
     "pytest-timeout",
     "pytest-virtualenv",
+    "testpath",
 ]
 docs = [
     "mkdocs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,8 +4,9 @@ from unittest.mock import MagicMock
 import pytest
 import numpy as np
 
-from damnit.backend.user_variables import value_types_by_name, UserEditableVariable
 from damnit.backend.db import DamnitDB
+from damnit.backend.extract_data import main as extract_main
+from damnit.backend.user_variables import value_types_by_name, UserEditableVariable
 
 from .helpers import amore_proto, mkcontext
 
@@ -150,7 +151,7 @@ def mock_db_with_data(mock_ctx, mock_db, monkeypatch):
     with monkeypatch.context() as m:
         m.chdir(db_dir)
         amore_proto(["proposal", "1234"])
-        amore_proto(["reprocess", "1", "--mock"])
+        extract_main(["1234", "1", "all", "--mock"])
 
     yield mock_db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,13 @@
 import socket
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import numpy as np
 
 from damnit.backend.db import DamnitDB
-from damnit.backend.extract_data import main as extract_main
 from damnit.backend.user_variables import value_types_by_name, UserEditableVariable
 
-from .helpers import amore_proto, mkcontext
+from .helpers import amore_proto, mkcontext, extract_mock_run
 
 
 @pytest.fixture
@@ -151,7 +150,7 @@ def mock_db_with_data(mock_ctx, mock_db, monkeypatch):
     with monkeypatch.context() as m:
         m.chdir(db_dir)
         amore_proto(["proposal", "1234"])
-        extract_main(["1234", "1", "all", "--mock"])
+        extract_mock_run(1)
 
     yield mock_db
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -6,8 +6,8 @@ import xarray as xr
 from matplotlib.figure import Figure
 
 from damnit.cli import main
-from damnit.context import ContextFile
-from damnit.backend.extract_data import ReducedData
+from damnit.context import ContextFile, RunData
+from damnit.backend.extract_data import ReducedData, Extractor
 
 
 def reduced_data_from_dict(input_dict):
@@ -30,6 +30,14 @@ def amore_proto(args):
     with (patch("sys.argv", ["amore-proto", *args]),
           patch("damnit.backend.extract_data.KafkaProducer")):
         main()
+
+def extract_mock_run(run_num: int, match=()):
+    """Run the context file in the CWD on the specified run"""
+    with patch("damnit.backend.extract_data.KafkaProducer"):
+        extr = Extractor()
+        prop = extr.db.metameta['proposal']
+        extr.extract_and_ingest(prop, run_num, match=match, mock=True)
+
 
 def mkcontext(code):
     return ContextFile.from_str(textwrap.dedent(code))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,8 +10,7 @@ from plotly.graph_objects import Figure as PlotlyFigure
 
 from damnit import Damnit, RunVariables
 from damnit.context import ContextFile
-
-from .helpers import amore_proto
+from damnit.backend.extract_data import main as extract_main
 
 
 def test_damnit(mock_db_with_data):
@@ -60,7 +59,7 @@ def test_run_variables(mock_db_with_data, monkeypatch):
     assert set(rv.keys()) == set(ctx.vars.keys()) | set(["start_time"])
 
     # Reprocess a single variable for another run
-    amore_proto(["reprocess", "100", "--match", "scalar1", "--mock"])
+    extract_main([str(db.metameta['proposal']), "100", "all", "--match", "scalar1", "--mock"])
     assert damnit.runs() == [1, 100]
     # We should only see variables for which data is actually available
     assert damnit[100].keys() == ["scalar1", "start_time"]
@@ -101,7 +100,7 @@ def test_variable_data(mock_db_with_data, monkeypatch):
         return xr.Dataset(data_vars={ "foo": xr.DataArray([1, 2, 3]) })
     """
     (db_dir / "context.py").write_text(dedent(dataset_code))
-    amore_proto(["reprocess", "1", "--mock"])
+    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
 
     # Test properties
     assert rv["scalar1"].name == "scalar1"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,7 +10,7 @@ from plotly.graph_objects import Figure as PlotlyFigure
 
 from damnit import Damnit, RunVariables
 from damnit.context import ContextFile
-from damnit.backend.extract_data import main as extract_main
+from .helpers import extract_mock_run
 
 
 def test_damnit(mock_db_with_data):
@@ -59,7 +59,7 @@ def test_run_variables(mock_db_with_data, monkeypatch):
     assert set(rv.keys()) == set(ctx.vars.keys()) | set(["start_time"])
 
     # Reprocess a single variable for another run
-    extract_main([str(db.metameta['proposal']), "100", "all", "--match", "scalar1", "--mock"])
+    extract_mock_run(100, match=['scalar1'])
     assert damnit.runs() == [1, 100]
     # We should only see variables for which data is actually available
     assert damnit[100].keys() == ["scalar1", "start_time"]
@@ -100,7 +100,7 @@ def test_variable_data(mock_db_with_data, monkeypatch):
         return xr.Dataset(data_vars={ "foo": xr.DataArray([1, 2, 3]) })
     """
     (db_dir / "context.py").write_text(dedent(dataset_code))
-    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
+    extract_mock_run(1)
 
     # Test properties
     assert rv["scalar1"].name == "scalar1"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -18,6 +18,7 @@ import requests
 import xarray as xr
 import yaml
 from PIL import Image
+from testpath import MockCommand
 
 from damnit.backend import backend_is_running, initialize_and_start_backend
 from damnit.backend.db import DamnitDB
@@ -534,12 +535,12 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
     # Test regular variables and slurm variables are executed
     reduced_data = reduced_data_from_dict({ "n": 53 })
     with patch(f"{pkg}.extract_in_subprocess", return_value=reduced_data) as extract_in_subprocess, \
-         patch(f"{pkg}.subprocess.run") as subprocess_run:
+         MockCommand.fixed_output("sbatch", "9876; maxwell") as sbatch:
         extractor.extract_and_ingest(1234, 42, cluster=False,
                                      run_data=RunData.ALL)
         extract_in_subprocess.assert_called_once()
         extractor.kafka_prd.send.assert_called()
-        subprocess_run.assert_called_once()
+        sbatch.assert_called()
 
     # This works because we loaded damnit.context above
     from ctxrunner import main

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -145,8 +145,7 @@ def test_reprocess(mock_db_with_data, monkeypatch):
     @contextmanager
     def amore_proto(args):
         with (patch("sys.argv", ["amore-proto", *args]),
-              patch("damnit.backend.extract_data.KafkaProducer"),
-              patch("damnit.backend.extract_data.find_proposal", return_value=raw_dir.parent)):
+              patch("damnit.backend.extraction_control.find_proposal", return_value=raw_dir.parent)):
             yield
 
     def mock_sbatch():

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -16,13 +16,13 @@ from PyQt5.QtWidgets import QMessageBox, QFileDialog, QDialog, QInputDialog, \
 
 from damnit.ctxsupport.ctxrunner import ContextFile, Results
 from damnit.backend.db import db_path, ReducedData
-from damnit.backend.extract_data import add_to_db, main as extract_main
+from damnit.backend.extract_data import add_to_db
 from damnit.gui.editor import ContextTestResult
 from damnit.gui.main_window import MainWindow, AddUserVariableDialog
 from damnit.gui.open_dialog import OpenDBDialog
 from damnit.gui.zulip_messenger import ZulipConfig
 
-from .helpers import reduced_data_from_dict, mkcontext
+from .helpers import reduced_data_from_dict, mkcontext, extract_mock_run
 
 # Check if a PID exists by using `kill -0`
 def pid_dead(pid):
@@ -313,7 +313,7 @@ def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
     win.plot._button_plot_clicked(False)
     assert len(win.plot._canvas["canvas"]) == 1
 
-    extract_main([str(db.metameta['proposal']), "2", "all", "--mock"])
+    extract_mock_run(2)
     msg = {
         "Proposal": 1234,
         "Run": 2,
@@ -674,7 +674,7 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     ctx_code = mock_ctx.code + "\n\n" + textwrap.dedent(const_array_code)
     (db_dir / "context.py").write_text(ctx_code)
     ctx = ContextFile.from_str(ctx_code)
-    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
+    extract_mock_run(1)
 
     # Create window
     win = MainWindow(db_dir, False)
@@ -851,7 +851,7 @@ def test_exporting(mock_db_with_data, qtbot, monkeypatch, extension):
     """
     ctx = mkcontext(code)
     (db_dir / "context.py").write_text(ctx.code)
-    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
+    extract_mock_run(1)
 
     win = MainWindow(db_dir, connect_to_kafka=False)
     qtbot.addWidget(win)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -16,13 +16,13 @@ from PyQt5.QtWidgets import QMessageBox, QFileDialog, QDialog, QInputDialog, \
 
 from damnit.ctxsupport.ctxrunner import ContextFile, Results
 from damnit.backend.db import db_path, ReducedData
-from damnit.backend.extract_data import add_to_db
+from damnit.backend.extract_data import add_to_db, main as extract_main
 from damnit.gui.editor import ContextTestResult
 from damnit.gui.main_window import MainWindow, AddUserVariableDialog
 from damnit.gui.open_dialog import OpenDBDialog
 from damnit.gui.zulip_messenger import ZulipConfig
 
-from .helpers import reduced_data_from_dict, mkcontext, amore_proto
+from .helpers import reduced_data_from_dict, mkcontext
 
 # Check if a PID exists by using `kill -0`
 def pid_dead(pid):
@@ -313,7 +313,7 @@ def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
     win.plot._button_plot_clicked(False)
     assert len(win.plot._canvas["canvas"]) == 1
 
-    amore_proto(["reprocess", "2", "--mock"])
+    extract_main([str(db.metameta['proposal']), "2", "all", "--mock"])
     msg = {
         "Proposal": 1234,
         "Run": 2,
@@ -674,7 +674,7 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     ctx_code = mock_ctx.code + "\n\n" + textwrap.dedent(const_array_code)
     (db_dir / "context.py").write_text(ctx_code)
     ctx = ContextFile.from_str(ctx_code)
-    amore_proto(["reprocess", "all", "--mock"])
+    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
 
     # Create window
     win = MainWindow(db_dir, False)
@@ -851,7 +851,7 @@ def test_exporting(mock_db_with_data, qtbot, monkeypatch, extension):
     """
     ctx = mkcontext(code)
     (db_dir / "context.py").write_text(ctx.code)
-    amore_proto(["reprocess", "all", "--mock"])
+    extract_main([str(db.metameta['proposal']), "1", "all", "--mock"])
 
     win = MainWindow(db_dir, connect_to_kafka=False)
     qtbot.addWidget(win)


### PR DESCRIPTION
In #256 we made the listener submit jobs to the Solaris cluster to process data, rather than running subprocesses wherever it's running. This extends that to extraction run by `amore-proto reprocess` as well, so restrictions on CPU & memory usage apply consistently, however the processing was launched.

Reprocessing jobs now run in parallel by default (superseding #250), limited by how quickly the solaris cluster starts jobs. A new `--watch` flag switches back to processing one run at a time and showing live output directly in the terminal, but still uses Slurm with the `srun` command.

I see this as a step towards launching reprocessing from the GUI, and having the status of processing jobs visible in the GUI. But I'm leaving those features for a later PR.

I've also refactored a bit. The `extract_data` module is now only the code that runs inside a Slurm job, while `extraction_control` is the code to submit Slurm jobs.