### PR TITLE
Prevent variable results with dtypes that cannot be converted to HDF5

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -345,6 +345,16 @@ class ContextFile:
                             name, type(data)
                         )
                         data = None
+                    elif not np.issubdtype(arr.dtype, np.number):
+                        try:
+                            h5py.h5t.py_create(arr.dtype, logical=True)
+                        except TypeError:
+                            log.error(
+                                "Variable %s returned %s whose native "
+                                "array type %s cannot be saved",
+                                name, type(data), arr.dtype
+                            )
+                            data = None
                     else:
                         data = arr
             except Exception:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -420,6 +420,10 @@ def test_results_bad_obj(mock_run, tmp_path):
     @Variable()
     def bad(run):
         return object()
+
+    @Variable()
+    def also_bad(run):
+        return np.datetime64('1987-03-20')
     """
     bad_obj_ctx = mkcontext(bad_obj_code)
     results = bad_obj_ctx.execute(mock_run, 1000, 123, {})


### PR DESCRIPTION
SQS tried to directly return the result of `DataCollection.train_timestamps()` from a variable, which is a dtype not convertable to HDF5 datatype IDs, thus failing when the dataset is written. The current code only prevents `object` arrays, this PR adds a check for convertability for anything that is not an `np.number`.

As a side note, throwing an unchecked exception in the writing code also created some hard to read stack traces full of red herings.