### PR TITLE
Add a database config option to skip starting a listener

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -142,6 +142,10 @@ def main():
         help="Delete the specified key",
     )
     config_ap.add_argument(
+        '--num', action='store_true',
+        help="Set the given value as a number instead of a string"
+    )
+    config_ap.add_argument(
         'key', nargs='?',
         help="The config key to see/change. If not given, list all config"
     )
@@ -253,7 +257,14 @@ def main():
                 sys.exit("Error: no key specified to delete")
             del db.metameta[args.key]
         elif args.key and (args.value is not None):
-            db.metameta[args.key] = args.value
+            if args.num:
+                try:
+                    value = int(args.value)
+                except ValueError:
+                    value = float(args.value)
+            else:
+                value = args.value
+            db.metameta[args.key] = value
         elif args.key:
             try:
                 print(repr(db.metameta[args.key]))

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -971,9 +971,14 @@ def prompt_setup_db_and_backend(context_dir: Path, prop_no=None, parent=None):
             if not ok:
                 return False
         initialize_and_start_backend(context_dir, prop_no, context_file_src)
+        return True
+
+    # The folder already contains a database
+    db = DamnitDB.from_dir(context_dir)
 
     # Check if the backend is running
-    elif not backend_is_running(context_dir):
+    expect_listener = not db.metameta.get('no_listener', 0)
+    if expect_listener and not backend_is_running(context_dir):
         button = QMessageBox.question(
             parent, "Backend not running",
             "The DAMNIT backend is not running, would you like to start it? "

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -17,7 +17,7 @@ from PyQt5.QtWidgets import QMessageBox, QFileDialog, QDialog, QInputDialog, \
 
 import damnit
 from damnit.ctxsupport.ctxrunner import ContextFile, Results
-from damnit.backend.db import db_path, ReducedData
+from damnit.backend.db import DamnitDB, ReducedData
 from damnit.backend.extract_data import add_to_db
 from damnit.gui.editor import ContextTestResult
 from damnit.gui.main_window import MainWindow, AddUserVariableDialog
@@ -354,7 +354,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
 
     # Create the directory and database file to fake the database already existing
     db_dir.mkdir(parents=True)
-    db_path(db_dir).touch()
+    DamnitDB.from_dir(db_dir)
 
     # Autoconfigure with database present & backend 'running':
     with (helper_patch() as initialize_and_start_backend,


### PR DESCRIPTION
This skips the 'backend not running' dialog in the GUI, and the listener also checks for this after 10 minutes with no messages, to shut itself down.

I see two use cases for this:

1. Working with old proposals where you know no new runs are coming, so there's no point running a listener.
2. As part of migration from per-proposal listeners to one central listener, set this for proposals where the central listener will process new runs.