### PR TITLE
Simplify testing CLI by passing argv in

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -43,7 +43,7 @@ def excepthook(exc_type, value, tb):
                           user_ns=target_frame.f_locals | target_frame.f_globals | {"__tb": lambda: print(tb_msg)})
 
 
-def main():
+def main(argv=None):
     ap = ArgumentParser()
     ap.add_argument('--debug', action='store_true',
                     help="Show debug logs.")
@@ -172,7 +172,7 @@ def main():
              " v1. Don't use this unless you know what you're doing."
     )
 
-    args = ap.parse_args()
+    args = ap.parse_args(argv)
     logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
                         format="%(asctime)s %(levelname)-8s %(name)-38s %(message)s",
                         datefmt="%Y-%m-%d %H:%M:%S")

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -27,9 +27,8 @@ def amore_proto(args):
     It is the callers responsibility to make sure the PWD is a database
     directory.
     """
-    with (patch("sys.argv", ["amore-proto", *args]),
-          patch("damnit.backend.extract_data.KafkaProducer")):
-        main()
+    with patch("damnit.backend.extract_data.KafkaProducer"):
+        main(args)
 
 def extract_mock_run(run_num: int, match=()):
     """Run the context file in the CWD on the specified run"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,4 @@
 import sys
-import subprocess
 from pathlib import Path
 from unittest.mock import patch, ANY
 from contextlib import contextmanager
@@ -16,42 +15,35 @@ def test_new_id(mock_db, monkeypatch):
     old_id = db.metameta["db_id"]
 
     # Test setting the ID with an explicit path
-    with patch("sys.argv", ["amore-proto", "new-id", str(db_dir)]):
-        main()
+    main(["new-id", str(db_dir)])
     assert old_id != db.metameta["db_id"]
 
     # Test with the default path (PWD)
     monkeypatch.chdir(db_dir)
     old_id = db.metameta["db_id"]
-    with patch("sys.argv", ["amore-proto", "new-id"]):
-        main()
+    main(["new-id"])
     assert old_id != db.metameta["db_id"]
 
 def test_debug_repl(mock_db, monkeypatch):
     import IPython
 
-    # Helper context manager that mocks sys.argv, run_app(), and the sys module
-    @contextmanager
-    def amore_proto(args):
-        pkg = "damnit"
-        with (patch("sys.argv", ["amore-proto", *args]),
-              patch(f"{pkg}.gui.main_window.run_app"),
-              patch(f"{pkg}.cli.sys") as mock_sys):
-            yield mock_sys
+    pkg = "damnit"
 
     # We use sys.excepthook, but this function is only used for unhandled
     # exceptions, and pytest will always catch unhandled exceptions from our
     # code, which means that our hook will never be called during tests. So
     # instead, we check that the hook is not set when not asked for:
-    with amore_proto(["gui"]) as mock_sys:
+    with (patch(f"{pkg}.gui.main_window.run_app"),
+          patch(f"{pkg}.cli.sys") as mock_sys):
         old_excepthook = mock_sys.excepthook
-        main()
+        main(["gui"])
         assert mock_sys.excepthook == old_excepthook
 
     # And that it is set when asked for:
-    with amore_proto(["--debug-repl", "gui"]) as mock_sys:
+    with (patch(f"{pkg}.gui.main_window.run_app"),
+          patch(f"{pkg}.cli.sys") as mock_sys):
         assert mock_sys.excepthook != ipython_excepthook
-        main()
+        main(["--debug-repl", "gui"])
         assert mock_sys.excepthook == ipython_excepthook
 
     # And then test the hook separately
@@ -64,72 +56,57 @@ def test_debug_repl(mock_db, monkeypatch):
         ipython_excepthook(exc_type, value, tb)
         repl.assert_called_once()
 
-def test_gui():
-    @contextmanager
-    def helper_patch(args=[]):
-        with (patch("sys.argv", ["amore-proto", "gui", *args]),
-              patch("damnit.cli.find_proposal", return_value="/tmp"),
-              patch("damnit.gui.main_window.run_app") as run_app):
-            yield run_app
+def test_gui(monkeypatch):
+    monkeypatch.setattr("damnit.cli.find_proposal", lambda p: "/tmp")
 
     # Check passing neither a proposal number or directory
-    with helper_patch() as run_app:
-        main()
+    with patch("damnit.gui.main_window.run_app") as run_app:
+        main(["gui"])
         run_app.assert_called_with(None, software_opengl=False, connect_to_kafka=ANY)
 
     # Check passing a proposal number
-    with helper_patch(["1234"]) as run_app:
-        main()
+    with patch("damnit.gui.main_window.run_app") as run_app:
+        main(["gui", "1234"])
         run_app.assert_called_with(Path("/tmp/usr/Shared/amore"), software_opengl=False, connect_to_kafka=ANY)
 
     # Check passing a directory
-    with helper_patch(["/tmp"]) as run_app:
-        main()
+    with patch("damnit.gui.main_window.run_app") as run_app:
+        main(["gui", "/tmp"])
         run_app.assert_called_with(Path("/tmp"), software_opengl=False, connect_to_kafka=ANY)
 
     # Check invalid argument
-    with helper_patch(["/nope"]) as run_app:
+    with patch("damnit.gui.main_window.run_app") as run_app:
         with pytest.raises(SystemExit):
-            main()
+            main(["gui", "/nope"])
         run_app.assert_not_called()
 
 def test_listen(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     pkg = "damnit.backend"
 
-    # Helper context manager that mocks sys.argv
-    @contextmanager
-    def amore_proto(args):
-        with (patch("sys.argv", ["amore-proto", *args]),
-              patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend):
-            yield initialize_and_start_backend
-
-    with (amore_proto(["listen"]),
-          patch(f"{pkg}.listener.listen") as listen):
-        main()
+    with patch(f"{pkg}.listener.listen") as listen:
+        main(["listen"])
         listen.assert_called_once()
 
-    with (amore_proto(["listen", "--test"]),
-          patch(f"{pkg}.test_listener.listen") as listen):
-        main()
+    with patch(f"{pkg}.test_listener.listen") as listen:
+        main(["listen", "--test"])
         listen.assert_called_once()
 
     # Should fail without an existing database
-    with (amore_proto(["listen", "--daemonize"]) as initialize_and_start_backend,
+    with (patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend,
           pytest.raises(SystemExit)):
-        main()
+        main(["listen", "--daemonize"])
         initialize_and_start_backend.assert_not_called()
 
     # Should work with an existing database
     (tmp_path / "runs.sqlite").touch()
-    with amore_proto(["listen", "--daemonize"]) as initialize_and_start_backend:
-        main()
+    with patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend:
+        main(["listen", "--daemonize"])
         initialize_and_start_backend.assert_called_once()
 
     # Can't pass both --test and --daemonize
-    with (amore_proto(["listen", "--daemonize", "--test"]),
-          pytest.raises(SystemExit)):
-        main()
+    with pytest.raises(SystemExit):
+        main(["listen", "--daemonize", "--test"])
 
 def test_reprocess(mock_db_with_data, monkeypatch):
     db_dir, db = mock_db_with_data
@@ -140,39 +117,33 @@ def test_reprocess(mock_db_with_data, monkeypatch):
     raw_dir = db_dir / "mock_proposal" / "raw"
     raw_dir.mkdir(parents=True)
 
-    # Helper context manager to patch KafkaProducer to do nothing and
-    # find_proposal() to return the mock proposal directory we created.
-    @contextmanager
-    def amore_proto(args):
-        with (patch("sys.argv", ["amore-proto", *args]),
-              patch("damnit.backend.extraction_control.find_proposal", return_value=raw_dir.parent)):
-            yield
+    # patch find_proposal() to return the mock proposal directory we created.
+    monkeypatch.setattr(
+        "damnit.backend.extraction_control.find_proposal", lambda p: raw_dir.parent
+    )
 
     def mock_sbatch():
         return MockCommand.fixed_output("sbatch", "9876; maxwell")
 
     # Since none of the runs in the database exist on disk, we should skip all
     # of them (i.e. not call sbatch).
-    with amore_proto(["reprocess", "all"]):
-        with mock_sbatch() as sbatch:
-            main()
+    with mock_sbatch() as sbatch:
+        main(["reprocess", "all"])
 
-        assert sbatch.get_calls() == []
+    assert sbatch.get_calls() == []
 
     # Create raw/ directories for 10 runs
     for i in range(10):
         (raw_dir / f"r{i:04}").mkdir()
 
     # Reprocessing run 1 should call sbatch, because the run directory exists
-    with amore_proto(["reprocess", "1"]):
-        with mock_sbatch() as sbatch:
-            main()
+    with mock_sbatch() as sbatch:
+        main(["reprocess", "1"])
 
-        sbatch.assert_called()
+    sbatch.assert_called()
 
     # No directory for run 10, so this shouldn't try to submit a job
-    with amore_proto(["reprocess", "10"]):
-        with mock_sbatch() as sbatch:
-            main()
+    with mock_sbatch() as sbatch:
+        main(["reprocess", "10"])
 
-        assert sbatch.get_calls() == []
+    assert sbatch.get_calls() == []


### PR DESCRIPTION
This lets the `main()` function takes an optional list of command line args, simplifying testing because you don't need to keep modifying `sys.argv` I've used this pattern on various other projects before.