### PR TITLE
Defer imports for context file runner code

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -210,10 +210,11 @@ $ amore-proto db-config context_python /path/to/your/python
 The environment *must* have these dependencies installed for DAMNIT to work:
 
 - `extra_data`
-- `kaleido`
-- `plotly`
 - `pyyaml`
 - `requests`
+
+If your variables return [plotly](https://plotly.com/python/) plots, the
+environment must also have the `kaleido` package.
 
 ## Managing the backend
 The backend is a process running under [Supervisor](http://supervisord.org/). In


### PR DESCRIPTION
This uses the `isinstance_no_import` trick, avoiding loading modules just to check if objects belong to their types.

This reduces the list of packages required for the context Python environment. It can also reduce the overhead of launching the context runner process, although it still loads everything that the context file imports, so the change probably isn't dramatic for most real scenarios.