### PR TITLE
Add support for Python 3.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ test = [
     "pytest-qt",
     "pytest-xvfb",
     "pytest-timeout",
-    "pytest-virtualenv",
+    "pytest-venv",
     "testpath",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
 backend = [
     "EXtra-data",
     "ipython",
-    "kafka-python",
+    "kafka-python-ng",
     "kaleido",  # used in plotly to convert figures to images
     "matplotlib",
     "numpy",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -130,10 +130,10 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     assert isinstance(fig, PlotlyFigure)
     assert fig == px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 
-def test_api_dependencies(virtualenv):
+def test_api_dependencies(venv):
     package_path = Path(__file__).parent.parent
-    virtualenv.install_package(package_path, installer="pip install")
+    venv.install(package_path)
 
     # Test that we can import the module successfully and don't accidentally
     # depend on other things.
-    subprocess.run([str(virtualenv.python), "-c", "import damnit"]).check_returncode()
+    subprocess.run([str(venv.python), "-c", "import damnit"], check=True)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -669,7 +669,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
 
         open_run.assert_called_with(1234, 42, data="all")
 
-def test_custom_environment(mock_db, virtualenv, monkeypatch, qtbot):
+def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
     db_dir, db = mock_db
     monkeypatch.chdir(db_dir)
 
@@ -677,8 +677,8 @@ def test_custom_environment(mock_db, virtualenv, monkeypatch, qtbot):
 
     # Install dependencies for ctxrunner and a light-weight package (sfollow)
     # that isn't in our current environment.
-    virtualenv.install_package(" ".join([*ctxrunner_deps, "sfollow"]),
-                               installer="pip install")
+    subprocess.run([venv.python, "-m", "pip", "install", *ctxrunner_deps, "sfollow"],
+                   check=True)
 
     # Write a context file that requires the new package
     new_env_code = f"""
@@ -704,7 +704,7 @@ def test_custom_environment(mock_db, virtualenv, monkeypatch, qtbot):
         Extractor()
 
     # Set the context_python field in the database
-    db.metameta["context_python"] = str(virtualenv.python)
+    db.metameta["context_python"] = str(venv.python)
 
     with patch(f"{pkg}.KafkaProducer"):
         Extractor().extract_and_ingest(1234, 42, mock=True)


### PR DESCRIPTION
See the commit messages for details. I don't think we need to switch to 3.12 now, but I'm using it locally so it's nice to have it working.

Also ran into this fun bug: https://github.com/matplotlib/matplotlib/issues/28235
Which required creating an environment with: `conda create -c conda-forge -n amore python expat==2.6.1`