### PR TITLE
Check context file without blocking GUI thread

### DIFF
--- a/damnit/gui/editor.py
+++ b/damnit/gui/editor.py
@@ -4,8 +4,8 @@ from io import StringIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
-from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QColor, QFont, QGuiApplication, QCursor
+from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtGui import QColor, QFont
 from PyQt5.Qsci import QsciScintilla, QsciLexerPython, QsciCommand
 
 from pyflakes.reporter import Reporter
@@ -21,7 +21,64 @@ class ContextTestResult(Enum):
     WARNING = 1
     ERROR = 2
 
+
+class ContextFileCheckerThread(QThread):
+    # ContextTestResult, traceback, lineno, offset, checked_code
+    check_result = pyqtSignal(object, str, int, int, str)
+
+    def __init__(self, code, context_python, parent=None):
+        super().__init__(parent)
+        self.code = code
+        self.context_python = context_python
+
+    def run(self):
+        error_info = None
+
+        # If a different environment is not specified, we can evaluate the
+        # context file directly.
+        if self.context_python is None:
+            try:
+                ContextFile.from_str(self.code)
+            except:
+                # Extract the error information
+                error_info = extract_error_info(*sys.exc_info())
+
+        # Otherwise, write it to a temporary file to evaluate it from another
+        # process.
+        else:
+            with NamedTemporaryFile(prefix=".tmp_ctx") as ctx_file:
+                ctx_path = Path(ctx_file.name)
+                ctx_path.write_text(self.code)
+
+                ctx, error_info = get_context_file(ctx_path, self.context_python)
+
+        if error_info is not None:
+            stacktrace, lineno, offset = error_info
+            self.check_result.emit(ContextTestResult.ERROR, stacktrace, lineno, offset, self.code)
+            return
+
+        # If that worked, try pyflakes
+        out_buffer = StringIO()
+        reporter = Reporter(out_buffer, out_buffer)
+        pyflakes_check(self.code, "<ctx>", reporter)
+        # Disgusting hack to avoid getting warnings for "var#foo", "meta#foo",
+        # and "mymdc#foo" type annotations. This needs some tweaking to avoid
+        # missing real errors.
+        pyflakes_output = "\n".join([line for line in out_buffer.getvalue().split("\n")
+                                     if not line.endswith("undefined name 'var'") \
+                                     and not line.endswith("undefined name 'meta'") \
+                                     and not line.endswith("undefined name 'mymdc'")])
+
+        if len(pyflakes_output) > 0:
+            res, info = ContextTestResult.WARNING, pyflakes_output
+        else:
+            res, info = ContextTestResult.OK, None
+        self.check_result.emit(res, info, -1, -1, self.code)
+
+
 class Editor(QsciScintilla):
+    check_result = pyqtSignal(object, str, str)  # result, info, checked_code
+
     def __init__(self):
         super().__init__()
 
@@ -50,38 +107,15 @@ class Editor(QsciScintilla):
         line_del = commands.find(QsciCommand.LineDelete)
         line_del.setKey(Qt.ControlModifier | Qt.Key_D)
 
-    def test_context(self, db, db_dir):
-        """
-        Check if the current context file is valid.
-
-        Returns a tuple of (result, output_msg).
-        """
-        error_info = None
+    def launch_test_context(self, db):
         context_python = db.metameta.get("context_python")
+        thread = ContextFileCheckerThread(self.text(), context_python, parent=self)
+        thread.check_result.connect(self.on_test_result)
+        thread.finished.connect(thread.deleteLater)
+        thread.start()
 
-        # If a different environment is not specified, we can evaluate the
-        # context file directly.
-        if context_python is None:
-            try:
-                ContextFile.from_str(self.text())
-            except:
-                # Extract the error information
-                error_info = extract_error_info(*sys.exc_info())
-
-        # Otherwise, write it to a temporary file to evaluate it from another
-        # process.
-        else:
-            with NamedTemporaryFile(prefix=".tmp_ctx", dir=db_dir) as ctx_file:
-                ctx_path = Path(ctx_file.name)
-                ctx_path.write_text(self.text())
-
-                QGuiApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
-                ctx, error_info = get_context_file(ctx_path, context_python)
-                QGuiApplication.restoreOverrideCursor()
-
-        if error_info is not None:
-            stacktrace, lineno, offset = error_info
-
+    def on_test_result(self, res, info, lineno, offset, checked_code):
+        if res is ContextTestResult.ERROR:
             if lineno != -1:
                 # The line numbers reported by Python are 1-indexed so we
                 # decrement before passing them to scintilla.
@@ -93,21 +127,4 @@ class Editor(QsciScintilla):
                 if lineno != self.getCursorPosition()[0]:
                     self.setCursorPosition(lineno, offset)
 
-            return ContextTestResult.ERROR, stacktrace
-
-        # If that worked, try pyflakes
-        out_buffer = StringIO()
-        reporter = Reporter(out_buffer, out_buffer)
-        pyflakes_check(self.text(), "<ctx>", reporter)
-        # Disgusting hack to avoid getting warnings for "var#foo", "meta#foo",
-        # and "mymdc#foo" type annotations. This needs some tweaking to avoid
-        # missing real errors.
-        pyflakes_output = "\n".join([line for line in out_buffer.getvalue().split("\n")
-                                     if not line.endswith("undefined name 'var'") \
-                                     and not line.endswith("undefined name 'meta'") \
-                                     and not line.endswith("undefined name 'mymdc'")])
-
-        if len(pyflakes_output) > 0:
-            return ContextTestResult.WARNING, pyflakes_output
-        else:
-            return ContextTestResult.OK, None
+        self.check_result.emit(res, info, checked_code)

--- a/damnit/gui/ico/wait_circle.svg
+++ b/damnit/gui/ico/wait_circle.svg
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="52.311573mm"
+   height="52.311573mm"
+   viewBox="0 0 52.311573 52.311573"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="wait_circle.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="4.0715576"
+     inkscape:cx="98.856516"
+     inkscape:cy="98.856516"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient1002">
+      <stop
+         style="stop-color:#6b7a95;stop-opacity:1;"
+         offset="0"
+         id="stop998" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1"
+         offset="1"
+         id="stop1000" />
+    </linearGradient>
+    <radialGradient
+       xlink:href="#linearGradient1002"
+       id="radialGradient3831"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(3.0219389,0,0,3.021939,-116.81034,-140.40591)"
+       cx="57.931114"
+       cy="67.978645"
+       fx="54.575932"
+       fy="67.538017"
+       r="26.155787" />
+  </defs>
+  <g
+     id="layer1"
+     transform="translate(-31.925234,-43.26235)">
+    <circle
+       style="fill:url(#radialGradient3831);fill-opacity:1;fill-rule:evenodd;stroke-width:0.264583"
+       id="path31"
+       cx="58.08102"
+       cy="69.418137"
+       r="26.155787" />
+    <g
+       id="g1"
+       transform="translate(0.02145592)">
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.665001"
+         id="path1"
+         cx="58.059563"
+         cy="69.418137"
+         r="1.6603746" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.665001"
+         id="path1-6"
+         cx="70.098106"
+         cy="69.418137"
+         r="1.6603746" />
+      <circle
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.665001"
+         id="path1-5"
+         cx="46.021023"
+         cy="69.418137"
+         r="1.6603746" />
+    </g>
+  </g>
+</svg>

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -49,6 +49,7 @@ class Settings(Enum):
 class MainWindow(QtWidgets.QMainWindow):
 
     context_dir_changed = QtCore.pyqtSignal(str)
+    save_context_finished = QtCore.pyqtSignal(bool)  # True if saved
 
     db = None
     db_id = None
@@ -62,6 +63,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self._received_update = False
         self._context_path = None
         self._context_is_saved = True
+        self._context_code_to_save = None
 
         self._settings_db_path = Path.home() / ".local" / "state" / "damnit" / "settings.db"
 
@@ -109,13 +111,11 @@ class MainWindow(QtWidgets.QMainWindow):
         if not self._context_is_saved:
             dialog = QMessageBox(QMessageBox.Warning,
                                  "Warning - unsaved changes",
-                                 "There are unsaved changes to the context, do you want to save before exiting?",
-                                 QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel)
+                                 "There are unsaved changes to the context, do you want to go back and save?",
+                                 QMessageBox.Discard | QMessageBox.Cancel)
             result = dialog.exec()
 
-            if result == QMessageBox.Save:
-                self.save_context()
-            elif result == QMessageBox.Cancel:
+            if result == QMessageBox.Cancel:
                 event.ignore()
                 return
 
@@ -741,6 +741,7 @@ da-dev@xfel.eu"""
         test_widget = QtWidgets.QWidget()
 
         self._editor.textChanged.connect(self.on_context_changed)
+        self._editor.check_result.connect(self.test_context_result)
 
         vbox = QtWidgets.QGridLayout()
         test_widget.setLayout(vbox)
@@ -796,7 +797,17 @@ da-dev@xfel.eu"""
         self.mark_context_saved()
 
     def test_context(self):
-        test_result, output = self._editor.test_context(self.db, self._context_path.parent)
+        self.set_error_icon('wait')
+        self._editor.launch_test_context(self.db)
+
+    def test_context_result(self, test_result, output, checked_code):
+        # want_save, self._context_save_wanted = self._context_save_wanted, False
+        if self._context_code_to_save == checked_code:
+            if saving := test_result is not ContextTestResult.ERROR:
+                self._context_path.write_text(self._context_code_to_save)
+                self.mark_context_saved()
+            self._context_code_to_save = None
+            self.save_context_finished.emit(saving)
 
         if test_result == ContextTestResult.ERROR:
             self.set_error_widget_text(output)
@@ -822,7 +833,6 @@ da-dev@xfel.eu"""
                 self.set_error_icon("green")
 
         self._editor.setFocus()
-        return test_result
 
     def set_error_icon(self, icon):
         self._context_status_icon.load(icon_path(f"{icon}_circle.svg"))
@@ -835,12 +845,9 @@ da-dev@xfel.eu"""
         QtCore.QTimer.singleShot(100, lambda: self._error_widget.setText(text))
 
     def save_context(self):
-        if self.test_context() == ContextTestResult.ERROR:
-            return
-
-        self._context_path.write_text(self._editor.text())
-        self.mark_context_saved()
-        self._editor.setFocus()
+        self._context_code_to_save = self._editor.text()
+        self.test_context()
+        # If the check passes, .test_context_result() saves the file
 
     def mark_context_saved(self):
         self._context_is_saved = True


### PR DESCRIPTION
I noticed some time ago that a large part of what makes starting the GUI slow is waiting for the context file check, which usually involves starting a subprocess with a different Python, and often also doing some fairly heavy imports in the context file.

This pushes these operations into a separate thread, so we can start using the GUI before the context file check finishes. It also means saving the context file doesn't block the GUI.

Naturally, more async makes the tests a bit more complicated, but I think it's manageable.