### PR TITLE
Add back log message on successful variable computation

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -337,6 +337,8 @@ class ContextFile:
             except Exception:
                 log.error("Could not get data for %s", name, exc_info=True)
             else:
+                t1 = time.perf_counter()
+                log.info("Computed %s in %.03f s", name, t1 - t0)
                 res[name] = data
         return Results(res, self)
 


### PR DESCRIPTION
I added this in #247, but it must have got lost when I was rebasing #221.

This is just adding back what was already there, so I'll merge it once the CI passes.