### PR TITLE
Gui reprocessing: update variable list from file content

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -81,8 +81,8 @@ class ContextFileUnpickler(pickle.Unpickler):
         else:
             return super().find_class(module, name)
 
-def get_context_file(ctx_path: Path, context_python=None):
-    ctx_path = ctx_path.absolute()
+def get_context_file(ctx_path: str | Path, context_python=None):
+    ctx_path = Path(ctx_path).absolute()
     db_dir = ctx_path.parent
 
     if context_python is None:

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -345,6 +345,7 @@ da-dev@xfel.eu"""
         self.context_dir_changed.connect(lambda _: self.action_export.setEnabled(True))
         self.action_export.triggered.connect(self.export_table)
         self.action_process = QtWidgets.QAction("Reprocess runs", self)
+        self.action_process.setShortcut("Shift+R")
         self.action_process.triggered.connect(self.process_runs)
 
         action_adeqt = QtWidgets.QAction("Python console", self)
@@ -924,10 +925,7 @@ da-dev@xfel.eu"""
             prop = self.db.metameta.get("proposal", "")
             sel_runs = []
 
-        var_ids_titles = zip(self.table.computed_columns(),
-                             self.table.computed_columns(by_title=True))
-
-        dlg = ProcessingDialog(str(prop), sel_runs, var_ids_titles, parent=self)
+        dlg = ProcessingDialog(str(prop), sel_runs, parent=self)
         if dlg.exec() == QtWidgets.QDialog.Accepted:
             submitter = ExtractionSubmitter(self.context_dir, self.db)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,13 @@ gui = [
     "adeqt",
     "mplcursors",
     "mpl-pan-zoom",
+    "natsort",
     "openpyxl",  # for spreadsheet export
     "PyQt5",
     "PyQtWebEngine",
     "pyflakes",  # for checking context file in editor
     "QScintilla==2.13",
+    "superqt",
     "tabulate",  # used in pandas to make markdown tables (for Zulip)
 ]
 test = [


### PR DESCRIPTION
After testing #304 it was a bit unpractical to use for mainly 2 reasons:
- people often modify the context file with other editors
- the list would still contain variables present in the table, but not in the file.

So with this PR, we check the context file when we open the reprocess dialog.
It takes a few seconds in practice, but is loading only if we detect that the context file was modified. We could later add that saving the file from the GUI would also update that list.
I additionaly added a filter for the variable list which helps a lot when the context file contains many vars.

![reprocess](https://github.com/user-attachments/assets/6293c8c6-9daa-4881-82b5-744832c0c4d5)
