### PR TITLE
 Gui reprocessing: take 2

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -50,6 +50,8 @@ class Variable:
     def __call__(self, func):
         self.func = func
         self.name = func.__name__
+        if self.title is None:
+            self.title = self.name
         return self
 
     def check(self):

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -50,6 +50,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
     context_dir_changed = QtCore.pyqtSignal(str)
     save_context_finished = QtCore.pyqtSignal(bool)  # True if saved
+    context_saved = QtCore.pyqtSignal()
 
     db = None
     db_id = None
@@ -87,6 +88,8 @@ class MainWindow(QtWidgets.QMainWindow):
         # Disable the main window at first since we haven't loaded any database yet
         self._tab_widget.setEnabled(False)
         self.setCentralWidget(self._tab_widget)
+
+        self.context_saved.connect(self.launch_update_computed_vars)
 
         self.table = None
         
@@ -262,6 +265,7 @@ da-dev@xfel.eu"""
         self.launch_update_computed_vars()
 
     def launch_update_computed_vars(self):
+        # Triggered when we open a proposal & when saving the context file
         log.debug("Launching subprocess to read variables from context file")
         proc = QtCore.QProcess(parent=self)
         # Show stdout & stderr with the parent process
@@ -812,6 +816,7 @@ da-dev@xfel.eu"""
                 self.mark_context_saved()
             self._context_code_to_save = None
             self.save_context_finished.emit(saving)
+            self.context_saved.emit()
 
         if test_result == ContextTestResult.ERROR:
             self.set_error_widget_text(output)

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -115,7 +115,11 @@ class TableView(QtWidgets.QTableView):
         deselected. The `for_restore` argument lets you specify which behaviour
         you want.
         """
-        column_index = self.damnit_model.find_column(name, by_title=True)
+        try:
+            column_index = self.damnit_model.find_column(name, by_title=True)
+        except KeyError:
+            log.error("Could not find column %r to set visibility", name)
+            return
 
         self.setColumnHidden(column_index, not visible)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,11 +40,13 @@ gui = [
     "adeqt",
     "mplcursors",
     "mpl-pan-zoom",
+    "natsort",
     "openpyxl",  # for spreadsheet export
     "PyQt5",
     "PyQtWebEngine",
     "pyflakes",  # for checking context file in editor
     "QScintilla==2.13",
+    "superqt",
     "tabulate",  # used in pandas to make markdown tables (for Zulip)
 ]
 test = [

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -708,7 +708,7 @@ def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
 
     pkg = "damnit.backend.extract_data"
 
-    with patch(f"{pkg}.KafkaProducer"), pytest.raises(ImportError):
+    with patch(f"{pkg}.KafkaProducer"), pytest.raises(AssertionError):
         Extractor()
 
     # Set the context_python field in the database


### PR DESCRIPTION
An alternative to #307 

Here we save the context information in the database when we either save it from the GUI or detect it has changed upon processing or context file checking.

Would that be a preferred approache?  @JamesWrigley @takluyver 
It's still fast to load if the context is saved from the editor, but will execute the context file if it has changed from an other source.
side effect: poor-man's version control for the context file.