### PR TITLE
Show when runs are being processed

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -522,6 +522,8 @@ class MsgKind(Enum):
     #run_deleted = 'run_deleted'
     #standalone_comment_set = 'standalone_comment_set'
     #standalone_comment_deleted = 'standalone_comment_deleted'
+    processing_started = 'processing_started'   # Supports status indicators
+    processing_finished = 'processing_finished'
     # Commented out options are not implemented yet
 
 def msg_dict(kind: MsgKind, data: dict):

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -522,7 +522,7 @@ class MsgKind(Enum):
     #run_deleted = 'run_deleted'
     #standalone_comment_set = 'standalone_comment_set'
     #standalone_comment_deleted = 'standalone_comment_deleted'
-    processing_running = 'processing_running'   # Supports status indicators
+    processing_state_set = 'processing_state_set'   # Supports status indicators
     processing_finished = 'processing_finished'
     # Commented out options are not implemented yet
 

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -522,7 +522,7 @@ class MsgKind(Enum):
     #run_deleted = 'run_deleted'
     #standalone_comment_set = 'standalone_comment_set'
     #standalone_comment_deleted = 'standalone_comment_deleted'
-    processing_started = 'processing_started'   # Supports status indicators
+    processing_running = 'processing_running'   # Supports status indicators
     processing_finished = 'processing_finished'
     # Commented out options are not implemented yet
 

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -190,7 +190,7 @@ class RunExtractor(Extractor):
             'hostname': socket.gethostname(),
             'username': getuser(),
             'slurm_cluster': self._slurm_cluster(),
-            'slurm_job_id': os.environ.get('SLURM_JOB_ID', ''),
+            'slurm_job_id': self._slurm_job_id(),
         })
 
     @staticmethod
@@ -200,6 +200,18 @@ class RunExtractor(Extractor):
             return None
         partition = os.environ.get('SLURM_JOB_PARTITION', '')
         return 'solaris' if (partition == 'solcpu') else 'maxwell'
+
+    @staticmethod
+    def _slurm_job_id():
+        # Get Slurm job ID in the same format that squeue uses
+        array_job_id = os.environ.get('SLURM_ARRAY_JOB_ID', '')
+        array_task_id = os.environ.get('SLURM_ARRAY_TASK_ID', '')
+        if array_job_id and array_task_id:
+            # In an array job, e.g. '12380337_308'
+            return f"{array_job_id}_{array_task_id}"
+        else:
+            # Not an array job - just use the regular job ID
+            slurm_job_id = os.environ.get('SLURM_JOB_ID', '')
 
     @property
     def out_path(self):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -187,9 +187,17 @@ class RunExtractor(Extractor):
             'run': run,
             'data': run_data.value,
             'hostname': socket.gethostname(),
-            'slurm_cluster': os.environ.get('SLURM_CLUSTER_NAME', ''),
+            'slurm_cluster': self._slurm_cluster(),
             'slurm_job_id': os.environ.get('SLURM_JOB_ID', ''),
         })
+
+    @staticmethod
+    def _slurm_cluster():
+        # For some reason, SLURM_CLUSTER_NAME is '(null)'. This is a workaround:
+        if not os.environ.get('SLURM_JOB_ID', ''):
+            return None
+        partition = os.environ.get('SLURM_JOB_PARTITION', '')
+        return 'solaris' if (partition == 'solcpu') else 'maxwell'
 
     @property
     def out_path(self):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -14,6 +14,7 @@ import re
 import socket
 import subprocess
 import sys
+from getpass import getuser
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from uuid import uuid4
@@ -187,6 +188,7 @@ class RunExtractor(Extractor):
             'run': run,
             'data': run_data.value,
             'hostname': socket.gethostname(),
+            'username': getuser(),
             'slurm_cluster': self._slurm_cluster(),
             'slurm_job_id': os.environ.get('SLURM_JOB_ID', ''),
         })

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -212,7 +212,7 @@ class RunExtractor(Extractor):
             return f"{array_job_id}_{array_task_id}"
         else:
             # Not an array job - just use the regular job ID
-            slurm_job_id = os.environ.get('SLURM_JOB_ID', '')
+            return os.environ.get('SLURM_JOB_ID', '')
 
     @property
     def out_path(self):

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -10,10 +10,11 @@ import subprocess
 import sys
 from contextlib import contextmanager
 from ctypes import CDLL
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from secrets import token_hex
 from threading import Thread
+from uuid import uuid4
 
 from extra_data.read_machinery import find_proposal
 
@@ -97,12 +98,14 @@ class ExtractionRequest:
     variables: tuple = ()   # Overrides match if present
     mock: bool = False
     update_vars: bool = True
+    processing_id: str = field(default_factory=lambda : str(uuid4()))
 
     def python_cmd(self):
         """Creates the command for a process to do this extraction"""
         cmd = [
             sys.executable, '-m', 'damnit.backend.extract_data',
-            str(self.proposal), str(self.run), self.run_data.value
+            str(self.proposal), str(self.run), self.run_data.value,
+            '--processing-id', self.processing_id,
         ]
         if self.cluster:
             cmd.append('--cluster-job')
@@ -117,6 +120,19 @@ class ExtractionRequest:
         if self.update_vars:
             cmd.append('--update-vars')
         return cmd
+
+    def submitted_info(self, cluster, job_id):
+        return {
+            'processing_id': self.processing_id,
+            'proposal': self.proposal,
+            'run': self.run,
+            'data': self.run_data.value,
+            'status': 'PENDING',
+            'hostname': '',
+            'username': '',
+            'slurm_cluster': cluster,
+            'slurm_job_id': job_id,
+        }
 
 
 class ExtractionSubmitter:
@@ -133,6 +149,14 @@ class ExtractionSubmitter:
             self._proposal = self.db.metameta['proposal']
         return self._proposal
 
+    def _filter_env(self):
+        env = os.environ.copy()
+        # A non-array job submitted from an array job will inherit these
+        # variables if they're not cleared.
+        for v in ['SLURM_ARRAY_JOB_ID', 'SLURM_ARRAY_TASK_ID']:
+            env.pop(v, None)
+        return env
+
     def submit(self, req: ExtractionRequest):
         """Submit a Slurm job to extract data from a run
 
@@ -140,7 +164,7 @@ class ExtractionSubmitter:
         """
         res = subprocess.run(
             self.sbatch_cmd(req), stdout=subprocess.PIPE, text=True, check=True,
-            cwd=self.context_dir,
+            cwd=self.context_dir, env=self._filter_env()
         )
         job_id, _, cluster = res.stdout.partition(';')
         job_id = job_id.strip()
@@ -201,14 +225,15 @@ class ExtractionSubmitter:
                 prev_job = out[-1][0]
                 cmd.append(f"--dependency=afterany:{prev_job}")
             res = subprocess.run(
-                cmd, stdout=subprocess.PIPE, text=True, check=True, cwd=self.context_dir,
+                cmd, stdout=subprocess.PIPE, text=True, check=True,
+                cwd=self.context_dir, env=self._filter_env(),
             )
             job_id, _, cluster = res.stdout.partition(';')
             job_id = job_id.strip()
             cluster = cluster.strip() or 'maxwell'
             log.info("Launched Slurm (%s) job array %s (%d runs) to run context file",
                      cluster, job_id, len(req_group))
-            out.append((job_id, cluster))
+            out.extend([(f"{job_id}_{i}", cluster) for i in range(len(req_group))])
 
         return out
 
@@ -236,7 +261,7 @@ class ExtractionSubmitter:
         with tee(log_path) as pipe:
             subprocess.run(
                 self.srun_cmd(req), stdout=pipe, stderr=subprocess.STDOUT, check=True,
-                cwd=self.context_dir,
+                cwd=self.context_dir, env=self._filter_env(),
             )
 
     def execute_direct(self, req: ExtractionRequest):
@@ -362,13 +387,13 @@ class ExtractionJobTracker:
     def __init__(self):
         self.jobs = {}  # keyed by processing_id
 
-    def on_processing_running(self, info):
+    def on_processing_state_set(self, info):
         proc_id = info['processing_id']
         if info != self.jobs.get(proc_id, None):
             self.jobs[proc_id] = info
             self.on_run_jobs_changed(info['proposal'], info['run'])
-            log.debug("Processing running for p%s r%s on %s (%s)",
-                      info['proposal'], info['run'], info['hostname'], proc_id)
+            log.debug("Processing %s for p%s r%s on %s (%s)",
+                      info['status'], info['proposal'], info['run'], info['hostname'], proc_id)
 
     def on_processing_finished(self, info):
         proc_id = info['processing_id']

--- a/damnit/gui/kafka.py
+++ b/damnit/gui/kafka.py
@@ -67,6 +67,11 @@ class UpdateAgent(QtCore.QObject):
                            })
         self.kafka_prd.send(self.update_topic, message)
 
+    def processing_submitted(self, info):
+        self.kafka_prd.send(self.update_topic, msg_dict(
+            MsgKind.processing_state_set, info,
+        ))
+
     def stop(self):
         self.running = False
         self.kafka_prd.flush(timeout=10)

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -537,8 +537,8 @@ da-dev@xfel.eu"""
             self.table_view.apply_tag_filter(
                 self.table_view._current_tag_filter
             )
-        elif msg_kind == MsgKind.processing_running:
-            self.table.handle_processing_running(data)
+        elif msg_kind == MsgKind.processing_state_set:
+            self.table.handle_processing_state_set(data)
         elif msg_kind == MsgKind.processing_finished:
             self.table.handle_processing_finished(data)
 
@@ -1006,7 +1006,7 @@ da-dev@xfel.eu"""
 
             try:
                 reqs = dlg.extraction_requests()
-                submitter.submit_multi(reqs)
+                submitted = submitter.submit_multi(reqs)
             except Exception as e:
                 log.error("Error launching processing", exc_info=True)
                 self.show_status_message(f"Error launching processing: {e}",
@@ -1015,6 +1015,11 @@ da-dev@xfel.eu"""
                 self.show_status_message(
                     f"Launched processing for {len(reqs)} runs", 10_000
                 )
+                if self._connect_to_kafka:
+                    for req, (job_id, cluster) in zip(reqs, submitted):
+                        self.update_agent.processing_submitted(
+                            req.submitted_info(cluster, job_id)
+                        )
 
     adeqt_window = None
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -537,8 +537,8 @@ da-dev@xfel.eu"""
             self.table_view.apply_tag_filter(
                 self.table_view._current_tag_filter
             )
-        elif msg_kind == MsgKind.processing_started:
-            self.table.handle_processing_started(data)
+        elif msg_kind == MsgKind.processing_running:
+            self.table.handle_processing_running(data)
         elif msg_kind == MsgKind.processing_finished:
             self.table.handle_processing_finished(data)
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -537,6 +537,10 @@ da-dev@xfel.eu"""
             self.table_view.apply_tag_filter(
                 self.table_view._current_tag_filter
             )
+        elif msg_kind == MsgKind.processing_started:
+            self.table.handle_processing_started(data)
+        elif msg_kind == MsgKind.processing_finished:
+            self.table.handle_processing_finished(data)
 
     def handle_run_values_updated(self, proposal, run, values: dict):
         self.table.handle_run_values_changed(proposal, run, values)

--- a/damnit/gui/process.py
+++ b/damnit/gui/process.py
@@ -197,7 +197,7 @@ class ProcessingDialog(QtWidgets.QDialog):
         return [itm.data(Qt.UserRole) for itm in self._var_list_items()
                 if itm.checkState() == Qt.Checked]
 
-    def extraction_requests(self):
+    def extraction_requests(self) -> list[ExtractionRequest]:
         prop = int(self.proposal_num())
         # If all variables are selected, don't specify them explicitly, so that
         # newly added functions will also be executed.

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -723,12 +723,16 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         processing_id = info['processing_id']
         self.processing_jobs[processing_id] = info
         self.update_processing_status(info['proposal'], info['run'])
+        log.debug("Processing started for p%s r%s on %s (%s)",
+                  info['proposal'], info['run'], info['hostname'], processing_id)
 
     def handle_processing_finished(self, info):
         processing_id = info['processing_id']
         info = self.processing_jobs.pop(processing_id, None)
         if info is not None:
             self.update_processing_status(info['proposal'], info['run'])
+            log.debug("Processing finished for p%s r%s (%s)",
+                      info['proposal'], info['run'], processing_id)
 
     def update_processing_status(self, proposal, run):
         """Show/hide the processing indicator for the given run"""

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -719,11 +719,11 @@ class DamnitTableModel(QtGui.QStandardItemModel):
                 self.column_titles[col_ix] = title
                 self.setHorizontalHeaderItem(col_ix, QtGui.QStandardItem(title))
 
-    def handle_processing_started(self, info):
+    def handle_processing_running(self, info):
         processing_id = info['processing_id']
         self.processing_jobs[processing_id] = info
         self.update_processing_status(info['proposal'], info['run'])
-        log.debug("Processing started for p%s r%s on %s (%s)",
+        log.debug("Processing running for p%s r%s on %s (%s)",
                   info['proposal'], info['run'], info['hostname'], processing_id)
 
     def handle_processing_finished(self, info):

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -755,7 +755,7 @@ class DamnitTableModel(QtGui.QStandardItemModel):
             runnr_item.setData(f"{run} ⚙️", Qt.ItemDataRole.DisplayRole)
             if len(jobs_for_run) == 1:
                 info = jobs_for_run[0]
-                msg = f"Processing on {info['hostname']}"
+                msg = f"Processing on {info['username']}@{info['hostname']}"
                 if job_id := info['slurm_job_id']:
                     msg += f" (Slurm job {job_id})"
                 runnr_item.setToolTip(msg)

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -7,7 +7,8 @@ from matplotlib.figure import Figure
 
 from damnit.cli import main
 from damnit.context import ContextFile, RunData
-from damnit.backend.extract_data import ReducedData, Extractor
+from damnit.backend.db import DamnitDB
+from damnit.backend.extract_data import ReducedData, RunExtractor
 
 
 def reduced_data_from_dict(input_dict):
@@ -33,10 +34,11 @@ def amore_proto(args):
 def extract_mock_run(run_num: int, match=()):
     """Run the context file in the CWD on the specified run"""
     with patch("damnit.backend.extract_data.KafkaProducer"):
-        extr = Extractor()
-        prop = extr.db.metameta['proposal']
+        db = DamnitDB()
+        prop = db.metameta['proposal']
+        extr = RunExtractor(prop, run_num, match=match, mock=True)
         extr.update_db_vars()
-        extr.extract_and_ingest(prop, run_num, match=match, mock=True)
+        extr.extract_and_ingest()
 
 
 def mkcontext(code):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -930,13 +930,13 @@ def test_job_tracker():
     tracker = ExtractionJobTracker()
 
     d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'username': '',
-         'slurm_cluster': '', 'slurm_job_id': ''}
+         'slurm_cluster': '', 'slurm_job_id': '', 'status': 'RUNNING'}
 
     prid1, prid2 = str(uuid4()), str(uuid4())
 
     # Add two running jobs
-    tracker.on_processing_running(d | {'run': 1, 'processing_id': prid1})
-    tracker.on_processing_running(d | {
+    tracker.on_processing_state_set(d | {'run': 1, 'processing_id': prid1})
+    tracker.on_processing_state_set(d | {
         'run': 2, 'processing_id': prid2,
         'slurm_cluster': 'maxwell', 'slurm_job_id': '321'
     })

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -9,6 +9,7 @@ import stat
 import subprocess
 import textwrap
 from time import sleep, time
+from uuid import uuid4
 from unittest.mock import MagicMock, patch
 
 import extra_data as ed
@@ -25,6 +26,7 @@ from testpath import MockCommand
 from damnit.backend import backend_is_running, initialize_and_start_backend
 from damnit.backend.db import DamnitDB
 from damnit.backend.extract_data import Extractor, RunExtractor, add_to_db
+from damnit.backend.extraction_control import ExtractionJobTracker
 from damnit.backend.listener import (MAX_CONCURRENT_THREADS, EventProcessor,
                                      local_extraction_threads)
 from damnit.backend.supervisord import wait_until, write_supervisord_conf
@@ -922,3 +924,32 @@ def test_event_processor(mock_db, caplog):
 
         assert len(local_extraction_threads) == MAX_CONCURRENT_THREADS
         assert 'Too many events processing' in caplog.text
+
+
+def test_job_tracker():
+    tracker = ExtractionJobTracker()
+
+    d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'username': '',
+         'slurm_cluster': '', 'slurm_job_id': ''}
+
+    prid1, prid2 = str(uuid4()), str(uuid4())
+
+    # Add two running jobs
+    tracker.on_processing_running(d | {'run': 1, 'processing_id': prid1})
+    tracker.on_processing_running(d | {
+        'run': 2, 'processing_id': prid2,
+        'slurm_cluster': 'maxwell', 'slurm_job_id': '321'
+    })
+    assert set(tracker.jobs) == {prid1, prid2}
+
+    # One job finishes normally
+    tracker.on_processing_finished({'processing_id': prid1})
+    assert set(tracker.jobs) == {prid2}
+
+    # The other one fails to send a finished message, so checking Slurm reveals
+    # that it failed.
+    with MockCommand.fixed_output('squeue', '') as fake_squeue:
+        tracker.check_slurm_jobs()
+
+    fake_squeue.assert_called()
+    assert set(tracker.jobs) == set()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1070,13 +1070,13 @@ def test_processing_status(mock_db_with_data, qtbot):
         return "⚙️" in runnr_s
 
     d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'username': '',
-         'slurm_cluster': '', 'slurm_job_id': ''}
+         'slurm_cluster': '', 'slurm_job_id': '', 'status': 'RUNNING'}
 
     # Test with an existing run
     prid1, prid2 = str(uuid4()), str(uuid4())
-    tbl.handle_processing_running(d | {'run': 1, 'processing_id': prid1})
+    tbl.handle_processing_state_set(d | {'run': 1, 'processing_id': prid1})
     assert shows_as_processing(1)
-    tbl.handle_processing_running(d | {'run': 1, 'processing_id': prid2})
+    tbl.handle_processing_state_set(d | {'run': 1, 'processing_id': prid2})
     tbl.handle_processing_finished({'processing_id': prid1})
     assert shows_as_processing(1)
     tbl.handle_processing_finished({'processing_id': prid2})
@@ -1084,6 +1084,6 @@ def test_processing_status(mock_db_with_data, qtbot):
 
     # Processing starting for a new run should add a row
     assert tbl.rowCount() == 1
-    tbl.handle_processing_running(d | {'run': 2, 'processing_id': str(uuid4())})
+    tbl.handle_processing_state_set(d | {'run': 2, 'processing_id': str(uuid4())})
     assert tbl.rowCount() == 2
     assert shows_as_processing(2)

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1066,7 +1066,7 @@ def test_processing_status(mock_db_with_data, qtbot):
 
     def shows_as_processing(run):
         row = tbl.find_row(1234, run)
-        runnr_s = tbl.item(row, 2).data(Qt.ItemDataRole.DisplayRole)
+        runnr_s = tbl.verticalHeaderItem(row).data(Qt.ItemDataRole.DisplayRole)
         return "⚙️" in runnr_s
 
     d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'username': '',

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1069,7 +1069,8 @@ def test_processing_status(mock_db_with_data, qtbot):
         runnr_s = tbl.item(row, 2).data(Qt.ItemDataRole.DisplayRole)
         return "⚙️" in runnr_s
 
-    d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'slurm_cluster': '', 'slurm_job_id': ''}
+    d = {'proposal': 1234, 'data': 'all', 'hostname': '', 'username': '',
+         'slurm_cluster': '', 'slurm_job_id': ''}
 
     # Test with an existing run
     prid1, prid2 = str(uuid4()), str(uuid4())

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1073,9 +1073,9 @@ def test_processing_status(mock_db_with_data, qtbot):
 
     # Test with an existing run
     prid1, prid2 = str(uuid4()), str(uuid4())
-    tbl.handle_processing_started(d | {'run': 1, 'processing_id': prid1})
+    tbl.handle_processing_running(d | {'run': 1, 'processing_id': prid1})
     assert shows_as_processing(1)
-    tbl.handle_processing_started(d | {'run': 1, 'processing_id': prid2})
+    tbl.handle_processing_running(d | {'run': 1, 'processing_id': prid2})
     tbl.handle_processing_finished({'processing_id': prid1})
     assert shows_as_processing(1)
     tbl.handle_processing_finished({'processing_id': prid2})
@@ -1083,6 +1083,6 @@ def test_processing_status(mock_db_with_data, qtbot):
 
     # Processing starting for a new run should add a row
     assert tbl.rowCount() == 1
-    tbl.handle_processing_started(d | {'run': 2, 'processing_id': str(uuid4())})
+    tbl.handle_processing_running(d | {'run': 2, 'processing_id': str(uuid4())})
     assert tbl.rowCount() == 2
     assert shows_as_processing(2)


### PR DESCRIPTION
Put an icon next to the run number while a processing job is working on a run. The tooltip if you hover over that cell shows more details. This will also mean that new runs appear in the table when the backend starts processing them, instead of when the first job finishes.

![Screencast from 2024-08-29 12-35-34](https://github.com/user-attachments/assets/b9fc518e-19a3-4359-9b37-1dbd50362b06)

The status column would be another option, but we recently discussed hiding that by default.