### PR TITLE
Add support for optionally returning the Plotly JSON string

### DIFF
--- a/damnit/__init__.py
+++ b/damnit/__init__.py
@@ -1,5 +1,5 @@
 """Prototype for extracting and showing metadata (AMORE project)"""
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 from .api import Damnit, RunVariables, VariableData

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -113,8 +113,13 @@ class VariableData:
                      if not k.startswith('_damnit_')}
         return obj
 
-    def read(self):
-        """Read the data for the variable."""
+    def read(self, deserialize_plotly=True):
+        """Read the data for the variable.
+
+        Args:
+            deserialize_plotly (bool): Whether to deserialize Plotly figures
+                into `Figure` objects. If this is `False` the JSON string will be returned.
+        """
         if self._db_only:
             return self.summary()
 
@@ -130,7 +135,8 @@ class VariableData:
                 import plotly.io as pio
                 # plotly figures are json serialized and saved as uint8 arrays
                 # to enable compression in HDF5
-                return pio.from_json(dset[()].tobytes())
+                byte_array = dset[()].tobytes()
+                return pio.from_json(byte_array) if deserialize_plotly else byte_array.decode()
             elif h5py.check_string_dtype(dset.dtype) is not None:
                 # Strings. Scalar/non-scalar strings need to be read differently.
                 if dset.ndim == 0:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -130,6 +130,9 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     assert isinstance(fig, PlotlyFigure)
     assert fig == px.bar(x=["a", "b", "c"], y=[1, 3, 2])
 
+    json_str = rv["plotly_mc_plotface"].read(deserialize_plotly=False)
+    assert isinstance(json_str, str)
+
 def test_api_dependencies(venv):
     package_path = Path(__file__).parent.parent
     venv.install(package_path)


### PR DESCRIPTION
This is useful for the web interface because the JSON string needs to be sent to the browser.

CC @CammilleCC 