### PR TITLE
Activate software opengl by default on maxwell nodes.

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -63,6 +63,7 @@ def main(argv=None):
     gui_ap.add_argument(
         "--software-opengl", action="store_true",
         help="Force software OpenGL. Use this if displaying interactive Plotly plots shows a black screen."
+             "Active by default on Maxwell if not started on a display node."
     )
 
     listen_ap = subparsers.add_parser(

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 import shelve
 import sys
 import time
@@ -7,6 +8,7 @@ from argparse import ArgumentParser
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
+from socket import gethostname
 
 import h5py
 import numpy as np
@@ -1046,7 +1048,8 @@ def run_app(context_dir, software_opengl=False, connect_to_kafka=True):
     # Required for the WebViewer to load pages
     os.environ['QTWEBENGINE_CHROMIUM_FLAGS'] = '--no-sandbox'
 
-    if software_opengl:
+    if software_opengl or re.match(r'^max-exfl\d{3}.desy.de$', gethostname()):
+        log.info('Use software OpenGL.')
         QtWidgets.QApplication.setAttribute(
             Qt.AA_UseSoftwareOpenGL
         )


### PR DESCRIPTION
Since this cause a few support request already, this activates software openGL by default on maxwell when starting the gui on a non-display node.