### PR TITLE
Use Slurm array jobs to limit concurrent extraction jobs

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -265,11 +265,7 @@ def main(argv=None):
     # Hide some logging from Kafka to make things more readable
     logging.getLogger('kafka').setLevel(logging.WARNING)
 
-    if (run := args.run) == -1:
-        log.debug("Getting run number from Slurm array task ID")
-        run = int(os.environ['SLURM_ARRAY_TASK_ID'])
-
-    print(f"\n----- Processing r{run} (p{args.proposal}) -----", file=sys.stderr)
+    print(f"\n----- Processing r{args.run} (p{args.proposal}) -----", file=sys.stderr)
     log.info(f"run_data={args.run_data}, match={args.match}")
     if args.mock:
         log.info("Using mock run object for testing")
@@ -281,7 +277,7 @@ def main(argv=None):
     if args.update_vars:
         extr.update_db_vars()
 
-    extr.extract_and_ingest(args.proposal, run,
+    extr.extract_and_ingest(args.proposal, args.run,
                             cluster=args.cluster_job,
                             run_data=RunData(args.run_data),
                             match=args.match,

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -265,7 +265,11 @@ def main(argv=None):
     # Hide some logging from Kafka to make things more readable
     logging.getLogger('kafka').setLevel(logging.WARNING)
 
-    print(f"\n----- Processing r{args.run} (p{args.proposal}) -----", file=sys.stderr)
+    if (run := args.run) == -1:
+        log.debug("Getting run number from Slurm array task ID")
+        run = int(os.environ['SLURM_ARRAY_TASK_ID'])
+
+    print(f"\n----- Processing r{run} (p{args.proposal}) -----", file=sys.stderr)
     log.info(f"run_data={args.run_data}, match={args.match}")
     if args.mock:
         log.info("Using mock run object for testing")
@@ -277,7 +281,7 @@ def main(argv=None):
     if args.update_vars:
         extr.update_db_vars()
 
-    extr.extract_and_ingest(args.proposal, args.run,
+    extr.extract_and_ingest(args.proposal, run,
                             cluster=args.cluster_job,
                             run_data=RunData(args.run_data),
                             match=args.match,

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -196,6 +196,10 @@ class ExtractionSubmitter:
 
             script_expr = f".tmp/launch-{grpid}-$SLURM_ARRAY_TASK_ID.sh"
             cmd = self.sbatch_array_cmd(script_expr, req_group, limit_running)
+            if out:
+                # 1 batch at a time, to simplify limiting concurrent jobs
+                prev_job = out[-1][0]
+                cmd.append(f"--dependency=afterany:{prev_job}")
             res = subprocess.run(
                 cmd, stdout=subprocess.PIPE, text=True, check=True, cwd=self.context_dir,
             )

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -288,7 +288,7 @@ class ExtractionSubmitter:
         return opts
 
 
-def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=False):
+def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=False, limit_running=30):
     """Called by the 'amore-proto reprocess' subcommand"""
     submitter = ExtractionSubmitter(Path.cwd())
     if proposal is None:
@@ -354,4 +354,4 @@ def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=Fal
         for req in reqs:
             submitter.execute_in_slurm(req)
     else:
-        submitter.submit_multi(reqs)
+        submitter.submit_multi(reqs, limit_running=limit_running)

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -109,6 +109,10 @@ def main(argv=None):
         help="Run processing in subprocesses on this node, instead of via Slurm"
     )
     reprocess_ap.add_argument(
+        '--concurrent-jobs', type=int, default=30,
+        help="The maximum number of jobs that will run at once (default 30)"
+    )
+    reprocess_ap.add_argument(
         'run', nargs='+',
         help="Run number, e.g. 96. Multiple runs can be specified at once, "
              "or pass 'all' to reprocess all runs in the database."
@@ -225,7 +229,8 @@ def main(argv=None):
 
         from .backend.extraction_control import reprocess
         reprocess(
-            args.run, args.proposal, args.match, args.mock, args.watch, args.direct
+            args.run, args.proposal, args.match, args.mock, args.watch, args.direct,
+            limit_running=args.concurrent_jobs,
         )
 
     elif args.subcmd == 'read-context':

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -929,8 +929,7 @@ da-dev@xfel.eu"""
 
             try:
                 reqs = dlg.extraction_requests()
-                for req in reqs:
-                    submitter.submit(req)
+                submitter.submit_multi(reqs)
             except Exception as e:
                 log.error("Error launching processing", exc_info=True)
                 self.show_status_message(f"Error launching processing: {e}",


### PR DESCRIPTION
When reprocessing a whole bunch of runs at once, submit them as a Slurm array job, and ask Slurm to limit how many will run at once. This should mitigate the 'database locked' errors, without requiring people to manually batch their jobs and monitor their progress.

The limit is set at 30 concurrent jobs for now. Obviously we can make that configurable.

I've taken the shortcut of using the array task IDs for the run numbers. This avoids having to define a way to communicate 'array task 1 -> run 53', but it does mean that only the run numbers can vary within an array. So the one job we ask to update the variables table in the DB is submitted separately, and if you do `reprocess all` on a database spanning multiple proposals, each proposal would be submitted separately, raising the effective limit to N * 30 jobs. That's not ideal, but so far it's largely theoretical.

Closes #96.