### PR TITLE
Register Qt window created in backend test for cleanup

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -726,6 +726,7 @@ def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
     # Make sure that the GUI evaluates the context file correctly (which it does
     # upon opening a database directory).
     win = MainWindow(db_dir, False)
+    qtbot.addWidget(win)
 
 def test_initialize_and_start_backend(tmp_path, bound_port, request):
     db_dir = tmp_path / "foo"


### PR DESCRIPTION
I hope this will avoid the random hard crash during tests I've seen a couple of times recently. It seems to come from garbage collection just after `test_custom_environment` (e.g. [this run](https://github.com/European-XFEL/DAMNIT/actions/runs/10852847320/job/30119808537?pr=335)), so this seems like a good candidate.