### PR TITLE
Adds mymdc techniques annotation

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -122,10 +122,10 @@ class MyMetadataClient:
 
         return response.json()["name"]
 
-    def techniques_name(self, run: int) -> str:
+    def technique_names(self, run: int) -> str:
         return ', '.join(t['name'] for t in self._techniques_info(run))
 
-    def techniques_identifier(self, run: int) -> str:
+    def technique_identifiers(self, run: int) -> str:
         return ', '.join(t['identifier'] for t in self._techniques_info(run))
 
 

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -95,7 +95,7 @@ class MyMetadataClient:
         return json["runs"][0]
 
     @_cache
-    def _techniques_info(self, run: int) -> dict[str, Any]:
+    def techniques(self, run: int) -> dict[str, Any]:
         run_info = self._run_info(run)
         response = requests.get(f'{self.server}/api/mymdc/runs/{run_info["id"]}',
                                 headers=self._headers, timeout=self.timeout)
@@ -121,12 +121,6 @@ class MyMetadataClient:
         response.raise_for_status()
 
         return response.json()["name"]
-
-    def technique_names(self, run: int) -> str:
-        return ', '.join(t['name'] for t in self._techniques_info(run))
-
-    def technique_identifiers(self, run: int) -> str:
-        return ', '.join(t['identifier'] for t in self._techniques_info(run))
 
 
 class ContextFileErrors(RuntimeError):
@@ -191,7 +185,7 @@ class ContextFile:
         for name, var in self.vars.items():
             mymdc_args = var.arg_dependencies("mymdc#")
             for arg_name, annotation in mymdc_args.items():
-                if annotation not in ["sample_name", "run_type", "techniques_name", "techniques_identifier"]:
+                if annotation not in ["sample_name", "run_type", "techniques"]:
                     problems.append(f"Argument '{arg_name}' of variable '{name}' has an invalid MyMdC dependency: '{annotation}'")
 
         if problems:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -91,12 +91,11 @@ arguments if they have the right _annotations_, currently.
 
 - `mymdc#run_type`: The run type from myMdC.
 - `mymdc#sample_name`: The sample name from myMdC.
-- `mymdc#technique_identifiers`: list of
+- `mymdc#techniques`: list of
   [technique](https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html)
-  identifiers associated with the run.
-- `mymdc#technique_names`: list of
-  [technique](https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html)
-  names associated with the run.
+  associated with the run. Each technique listed is a `dict` containing the
+  following keys: `description`, `flg_available`, `id`, `identifier`, `name`,
+  `runs_techniques_id`, `url`.
 
 You can also use annotations to express a dependency between `Variable`'s using
 the `var#<name>` annotation:

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -76,16 +76,27 @@ Variable functions can return any of:
 
 The functions must always take in one argument, `run`, to which is passed a
 [`DataCollection`](https://extra-data.readthedocs.io/en/latest/reading_files.html#data-structure)
-of the data in the run.  In addition, a function can take some other special
-arguments if they have the right _annotations_:
+of the data in the run. In addition, a function can take some other special
+arguments if they have the right _annotations_, currently.  
+`meta` accesses internal arguments:
 
 - `meta#run_number`: The number of the current run being processed.
 - `meta#proposal`: The number of the current proposal.
 - `meta#proposal_dir`: The root
   [Path](https://docs.python.org/3/library/pathlib.html) to the current
   proposal.
-- `mymdc#sample_name`: The sample name from myMdC.
+
+`mymdc` requests information from the EuXFEL data management portal
+[MyMDC](https://in.xfel.eu/metadata/):
+
 - `mymdc#run_type`: The run type from myMdC.
+- `mymdc#sample_name`: The sample name from myMdC.
+- `mymdc#technique_identifiers`: list of
+  [technique](https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html)
+  identifiers associated with the run.
+- `mymdc#technique_names`: list of
+  [technique](https://expands-eu.github.io/ExPaNDS-experimental-techniques-ontology/index-en.html)
+  names associated with the run.
 
 You can also use annotations to express a dependency between `Variable`'s using
 the `var#<name>` annotation:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -399,13 +399,9 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     def run_type(run, x: "mymdc#run_type"):
         return x
 
-    @Variable(title="Run Technique IDs")
-    def technique_ids(run, x: "mymdc#technique_identifiers"):
-        return x
-
-    @Variable(title="Run Technique names")
-    def technique_names(run, x: "mymdc#technique_names"):
-        return x
+    @Variable(title="Run Techniques")
+    def techniques(run, x: "mymdc#techniques"):
+        return ', '.join(t['name'] for t in x)
     """
     mymdc_ctx = mkcontext(mymdc_code)
 
@@ -446,8 +442,7 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
 
     assert results.cells["sample"].data == "mithril"
     assert results.cells["run_type"].data == "alchemy"
-    assert results.cells["technique_ids"].data == "PaNET01168, PaNET01188"
-    assert results.cells["technique_names"].data == "SFX, SAXS"
+    assert results.cells["techniques"].data == "SFX, SAXS"
 
 
 def test_return_bool(mock_run, tmp_path):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -399,12 +399,12 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     def run_type(run, x: "mymdc#run_type"):
         return x
 
-    @Variable(title="Run Techniques ID")
-    def techniques_id(run, x: "mymdc#techniques_identifier"):
+    @Variable(title="Run Technique IDs")
+    def technique_ids(run, x: "mymdc#technique_identifiers"):
         return x
 
-    @Variable(title="Run Techniques name")
-    def techniques_name(run, x: "mymdc#techniques_name"):
+    @Variable(title="Run Technique names")
+    def technique_names(run, x: "mymdc#technique_names"):
         return x
     """
     mymdc_ctx = mkcontext(mymdc_code)
@@ -446,8 +446,8 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
 
     assert results.cells["sample"].data == "mithril"
     assert results.cells["run_type"].data == "alchemy"
-    assert results.cells["techniques_id"].data == "PaNET01168, PaNET01188"
-    assert results.cells["techniques_name"].data == "SFX, SAXS"
+    assert results.cells["technique_ids"].data == "PaNET01168, PaNET01188"
+    assert results.cells["technique_names"].data == "SFX, SAXS"
 
 
 def test_return_bool(mock_run, tmp_path):


### PR DESCRIPTION
This adds support for requesting the techniques information from Mymdc, once @RobertRosca deploys the path in ZWOP.

A run may have multiple techniques associated to it. Here I made the choice to return a single string with all techniques rather than a list, as I think most case will only contain a unique technique (as a mater of fact, the DAQ currently support applying only one technique to a run), and it is easier to handle on the user side. But we can change that if you disagree.