### PR TITLE
Lower the default slurm concurrency limit to 15

### DIFF
--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -170,7 +170,7 @@ class ExtractionSubmitter:
             '--wrap', shlex.join(req.python_cmd())
         ]
 
-    def submit_multi(self, reqs: list[ExtractionRequest], limit_running=30):
+    def submit_multi(self, reqs: list[ExtractionRequest], limit_running=15):
         """Submit multiple requests using Slurm job arrays.
         """
         out = []

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -110,8 +110,8 @@ def main(argv=None):
         help="Run processing in subprocesses on this node, instead of via Slurm"
     )
     reprocess_ap.add_argument(
-        '--concurrent-jobs', type=int, default=30,
-        help="The maximum number of jobs that will run at once (default 30)"
+        '--concurrent-jobs', type=int, default=15,
+        help="The maximum number of jobs that will run at once (default 15)"
     )
     reprocess_ap.add_argument(
         'run', nargs='+',


### PR DESCRIPTION
With 30 I still observe some SQLite locking errors, including from the GUI (which crashed it).