### PR TITLE
Register widgets with qtbot in another test

### DIFF
--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -42,13 +42,17 @@ def test_connect_to_kafka(mock_db, qtbot):
 
     with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
-        MainWindow(db_dir, False).close()
+        win = MainWindow(db_dir, False)
+        qtbot.addWidget(win)
+        win.close()
         kafka_cns.assert_not_called()
         kafka_prd.assert_not_called()
 
     with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
-        MainWindow(db_dir, True).close()
+        win = MainWindow(db_dir, True)
+        qtbot.addWidget(win)
+        win.close()
         kafka_cns.assert_called_once()
         kafka_prd.assert_called_once()
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -44,7 +44,6 @@ def test_connect_to_kafka(mock_db, qtbot):
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
         win = MainWindow(db_dir, False)
         qtbot.addWidget(win)
-        win.close()
         kafka_cns.assert_not_called()
         kafka_prd.assert_not_called()
 
@@ -52,7 +51,6 @@ def test_connect_to_kafka(mock_db, qtbot):
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
         win = MainWindow(db_dir, True)
         qtbot.addWidget(win)
-        win.close()
         kafka_cns.assert_called_once()
         kafka_prd.assert_called_once()
 


### PR DESCRIPTION
I hope this fixes the abort during tests seen in [this CI run](https://github.com/European-XFEL/DAMNIT/actions/runs/10999646959/job/30540270978?pr=313) on PR #313:

```
Current thread 0x00007fe80e823b80 (most recent call first):
  Garbage-collecting
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/pathlib.py", line 574 in _parse_args
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/pathlib.py", line 594 in _from_parts
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/pathlib.py", line 960 in __new__
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/pathlib.py", line 1000 in home
  File "/home/runner/work/DAMNIT/DAMNIT/damnit/gui/main_window.py", line 67 in __init__
  File "/home/runner/work/DAMNIT/DAMNIT/tests/test_gui.py", line 51 in test_connect_to_kafka
  ...
```

I've also checked the rest of the tests - everywhere we create a `MainWindow` in the tests, we now register it with qtbot shortly afterwards.