### PR TITLE
Use xarray's plotting methods to generate image thumbnails

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -414,7 +414,11 @@ def generate_thumbnail(image):
     fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
     vmin = np.nanquantile(image, 0.01)
     vmax = np.nanquantile(image, 0.99)
-    ax.imshow(image, vmin=vmin, vmax=vmax, extent=(0, 1, 1, 0))
+    if isinstance(image, np.ndarray):
+        ax.imshow(image, vmin=vmin, vmax=vmax)
+    else:
+        # Use DataArray's own plotting method
+        image.plot(ax=ax, vmin=vmin, vmax=vmax, add_colorbar=False)
     ax.axis('tight')
     ax.axis('off')
     ax.margins(0, 0)
@@ -518,7 +522,12 @@ class Results:
             if data.ndim == 0:
                 return data
             elif data.ndim == 2:
-                return generate_thumbnail(np.nan_to_num(data))
+                if isinstance(data, np.ndarray):
+                    data = np.nan_to_num(data)
+                else:
+                    data = data.fillna(0)
+
+                return generate_thumbnail(data)
             else:
                 return f"{data.dtype}: {data.shape}"
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,8 @@
 Fixed:
 
 - Added back grid lines for plots of `DataArray`'s (!334).
+- Fixed thumbnails of 2D `DataArray`'s to match what is displayed when the
+  variable is plotted (!355).
 
 ## [0.1.4]
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -325,12 +325,17 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
 
     figure_code = """
     import numpy as np
+    import xarray as xr
     from damnit_ctx import Variable
     from matplotlib import pyplot as plt
 
-    @Variable("2D array")
+    @Variable("2D ndarray")
     def twodarray(run):
         return np.random.rand(1000, 1000)
+
+    @Variable("2D xarray")
+    def twodxarray(run):
+        return xr.DataArray(np.random.rand(100, 100))
 
     @Variable(title="Axes")
     def axes(run):
@@ -359,8 +364,9 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
         assert f["axes/data"].ndim == 3
 
         # Test that the summaries are the right size
-        twodarray_png = Image.open(io.BytesIO(f[".reduced/twodarray"][()]))
-        assert np.asarray(twodarray_png).shape == (THUMBNAIL_SIZE, THUMBNAIL_SIZE, 4)
+        for var in ["twodarray", "twodxarray"]:
+            png = Image.open(io.BytesIO(f[f".reduced/{var}"][()]))
+            assert np.asarray(png).shape == (THUMBNAIL_SIZE, THUMBNAIL_SIZE, 4)
 
         figure_png = Image.open(io.BytesIO(f[".reduced/figure"][()]))
         assert max(np.asarray(figure_png).shape) == THUMBNAIL_SIZE


### PR DESCRIPTION
This makes the thumbnails match what's displayed when the variable is plotted, particularly when there are coordinates being used as ticks along the axes.

Before (thumbnail is upside down):
![image](https://github.com/user-attachments/assets/82f203bc-39b9-4004-97cd-dd21fdb0bb9e)

After:
![image](https://github.com/user-attachments/assets/aa0c7e25-3eb1-42a7-a589-4d733d0ae340)