### PR TITLE
Bump version of the apt caching action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Cache APT Packages
-      uses: awalsh128/cache-apt-pkgs-action@v1.4.1
+      uses: awalsh128/cache-apt-pkgs-action@v1.4.3
       with:
         packages: ${{ env.SYSTEM_PACKAGES }}
 


### PR DESCRIPTION
Needed because older versions were using a soon-to-be-deprecated action: https://github.com/awalsh128/cache-apt-pkgs-action/issues/141