### PR TITLE
FIX: handle failure generating summary data

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -4,6 +4,7 @@ We aim to maintain compatibility with older Python 3 versions (currently 3.9+)
 than the DAMNIT code in general, to allow running context files in other Python
 environments.
 """
+import logging
 import re
 import sys
 from collections.abc import Sequence
@@ -14,6 +15,8 @@ import numpy as np
 import xarray as xr
 
 __all__ = ["RunData", "Variable", "Cell"]
+
+log = logging.getLogger(__name__)
 
 
 THUMBNAIL_SIZE = 300 # px
@@ -169,7 +172,10 @@ class Cell:
         if self.summary_value is not None:
             return self.summary_value
         elif self.summary is not None:
-            return np.asarray(getattr(np, self.summary)(self.data))
+            try:
+                return np.asarray(getattr(np, self.summary)(self.data))
+            except Exception:
+                log.error("Failed to produce summary data", exc_info=True)
 
         return None
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -538,6 +538,28 @@ def test_results_cell(mock_run, tmp_path):
 
         assert f['.reduced/var3'][()] == 4
 
+
+def test_results_empty_array(mock_run, tmp_path, caplog):
+    # test failing summary
+    empty_array = """
+    from damnit_ctx import Variable
+
+    @Variable(title='Foo', summary='max')
+    def foo(run):
+        import numpy as np
+        return np.array([])
+    """
+    ctx = mkcontext(empty_array)
+    with caplog.at_level(logging.ERROR):
+        results = ctx.execute(mock_run, 1000, 123, {})
+        results.save_hdf5(tmp_path / 'results.h5', reduced_only=True)
+
+        # One warning about foo should have been logged
+        assert len(caplog.records) == 1
+        assert caplog.records[0].levelname == "ERROR"
+        assert caplog.records[0].msg == "Failed to produce summary data"
+
+
 @pytest.mark.skip(reason="Depending on user variables is currently disabled")
 def test_results_with_user_vars(mock_ctx_user, mock_user_vars, mock_run, caplog):
 


### PR DESCRIPTION
Failure to generate a summary data would fail writing the entire HDF5 file for that run.