### PR TITLE
Don't pass DISPLAY environment variable to Slurm jobs

### DIFF
--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -155,6 +155,8 @@ class ExtractionSubmitter:
         # variables if they're not cleared.
         for v in ['SLURM_ARRAY_JOB_ID', 'SLURM_ARRAY_TASK_ID']:
             env.pop(v, None)
+        # Slurm jobs shouldn't attempt to use your X session
+        env.pop('DISPLAY', None)
         return env
 
     def submit(self, req: ExtractionRequest):


### PR DESCRIPTION
Should fix issues with interactive plots from jobs popping up in FastX, and hopefully also issues with jobs from the listener hanging.