### PR TITLE
Refactor the listener to allow for being centralized

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -19,18 +19,12 @@ class DataType(Enum):
     Timestamp = "timestamp"
     PlotlyFigure = "PlotlyFigure"
 
-
-DATA_ROOT_DIR = os.environ.get('EXTRA_DATA_DATA_ROOT', '/gpfs/exfel/exp')
-
 # Also copied, this time from extra_data.read_machinery
 def find_proposal(propno):
-    """Find the proposal directory for a given proposal on Maxwell"""
-    if '/' in propno:
-        # Already passed a proposal directory
-        return propno
-
-    for d in iglob(osp.join(DATA_ROOT_DIR, '*/*/{}'.format(propno))):
-        return d
+    root_dir = os.environ.get('XFEL_DATA_ROOT', '/gpfs/exfel/exp')
+    dir_name = f"p{propno:06}"
+    for d in iglob(osp.join(root_dir, '*/*/{}'.format(dir_name))):
+        return Path(d)
 
     raise FileNotFoundError("Couldn't find proposal dir for {!r}".format(propno))
 
@@ -314,8 +308,8 @@ class Damnit:
                 a path to a database directory.
         """
         if isinstance(location, int):
-            proposal_path = find_proposal(f"p{location:06}")
-            self._db_dir = Path(proposal_path) / "usr/Shared/amore"
+            proposal_path = find_proposal(location)
+            self._db_dir = proposal_path / "usr/Shared/amore"
         elif isinstance(location, (Path, str)):
             self._db_dir = Path(location)
         else:

--- a/damnit/backend/__init__.py
+++ b/damnit/backend/__init__.py
@@ -1,1 +1,2 @@
-from .supervisord import initialize_and_start_backend, backend_is_running
+from .supervisord import listener_is_running, start_listener
+from .db import initialize_proposal

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -114,7 +114,7 @@ class DamnitDB:
             os.chmod(path, 0o666)
 
         self.conn.row_factory = sqlite3.Row
-        self.metameta = MetametaMapping(self.conn)
+        self.metameta = KeyValueMapping(self.conn, "metameta")
 
         # Only execute the schema if we wouldn't overwrite a previous version
         can_apply_schema = True
@@ -457,13 +457,14 @@ class DamnitDB:
         cursor.execute("SELECT name FROM tags ORDER BY name")
         return [row[0] for row in cursor.fetchall()]
 
-class MetametaMapping(MutableMapping):
-    def __init__(self, conn):
+class KeyValueMapping(MutableMapping):
+    def __init__(self, conn, table, allowed_keys=[]):
         self.conn = conn
+        self.table = table
 
     def __getitem__(self, key):
         row = self.conn.execute(
-            "SELECT value FROM metameta WHERE key=?", (key,)
+            f"SELECT value FROM {self.table} WHERE key=?", (key,)
         ).fetchone()
         if row is not None:
             return row[0]
@@ -472,7 +473,7 @@ class MetametaMapping(MutableMapping):
     def __setitem__(self, key, value):
         with self.conn:
             self.conn.execute(
-                "INSERT INTO metameta VALUES (:key, :value)"
+                f"INSERT INTO {self.table} VALUES (:key, :value)"
                 "ON CONFLICT (key) DO UPDATE SET value=:value",
                 {'key': key, 'value': value}
             )
@@ -484,28 +485,28 @@ class MetametaMapping(MutableMapping):
 
         with self.conn:
             self.conn.executemany(
-                "INSERT INTO metameta VALUES (:key, :value)"
+                f"INSERT INTO {self.table} VALUES (:key, :value)"
                 "ON CONFLICT (key) DO UPDATE SET value=:value",
                 [{'key': k, 'value': v} for (k, v) in d.items()]
             )
 
     def __delitem__(self, key):
         with self.conn:
-            c = self.conn.execute("DELETE FROM metameta WHERE key=?", (key,))
+            c = self.conn.execute(f"DELETE FROM {self.table} WHERE key=?", (key,))
             if c.rowcount == 0:
                 raise KeyError(key)
 
     def __iter__(self):
-        return (r[0] for r in self.conn.execute("SELECT key FROM metameta"))
+        return (r[0] for r in self.conn.execute(f"SELECT key FROM {self.table}"))
 
     def __len__(self):
-        return self.conn.execute("SELECT count(*) FROM metameta").fetchone()[0]
+        return self.conn.execute(f"SELECT count(*) FROM {self.table}").fetchone()[0]
 
     def setdefault(self, key, default=None):
         with self.conn:
             try:
                 self.conn.execute(
-                    "INSERT INTO metameta VALUES (:key, :value)",
+                    f"INSERT INTO {self.table} VALUES (:key, :value)",
                     {'key': key, 'value': default}
                 )
                 value = default
@@ -516,7 +517,7 @@ class MetametaMapping(MutableMapping):
         return value
 
     def to_dict(self):
-        return dict(self.conn.execute("SELECT * FROM metameta"))
+        return dict(self.conn.execute(f"SELECT * FROM {self.table}"))
 
     # Reimplement .values() and .items() to use just one query.
     def values(self):

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -104,7 +104,7 @@ MIN_OPENABLE_VERSION = 1  # DBs from this version will be upgraded on opening
 
 class DamnitDB:
     def __init__(self, path=DB_NAME, allow_old=False):
-        self.path = path.absolute()
+        self._path = path.absolute()
 
         db_existed = path.exists()
         log.debug("Opening database at %s", path)
@@ -157,6 +157,10 @@ class DamnitDB:
     @property
     def kafka_topic(self):
         return UPDATE_TOPIC.format(self.metameta['db_id'])
+
+    @property
+    def path(self):
+        return self._path
 
     def upgrade_schema(self, from_version):
         log.info("Upgrading database format from v%d to v%d",
@@ -546,6 +550,34 @@ class MsgKind(Enum):
 def msg_dict(kind: MsgKind, data: dict):
     return {'msg_kind': kind.value, 'data': data}
 
+def initialize_proposal(root_path, proposal=None, context_file_src=None):
+    # Ensure the directory exists
+    root_path.mkdir(parents=True, exist_ok=True)
+    if root_path.stat().st_uid == os.getuid():
+        os.chmod(root_path, 0o777)
+
+    # If the database doesn't exist, create it
+    if not db_path(root_path).is_file():
+        if proposal is None:
+            raise ValueError("Must pass a proposal number to `initialize_proposal()` if the database doesn't exist yet.")
+
+        # Initialize database
+        db = DamnitDB.from_dir(root_path)
+        db.metameta["proposal"] = proposal
+        db.metameta["context_python"] = "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/bin/python"
+    else:
+        # Otherwise, load the proposal number
+        db = DamnitDB.from_dir(root_path)
+        proposal = db.metameta["proposal"]
+
+    context_path = root_path / "context.py"
+    # Copy initial context file if necessary
+    if not context_path.is_file():
+        if context_file_src is not None:
+            shutil.copyfile(context_file_src, context_path)
+        else:
+            context_path.touch()
+        os.chmod(context_path, 0o666)
 
 # Old schemas for reference and migration
 

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -3,6 +3,8 @@ import json
 import logging
 import os
 import platform
+import sqlite3
+import traceback
 from pathlib import Path
 from socket import gethostname
 from threading import Thread
@@ -10,12 +12,13 @@ from threading import Thread
 from kafka import KafkaConsumer
 
 from ..context import RunData
-from .db import DamnitDB
+from ..api import find_proposal
+from .db import DamnitDB, KeyValueMapping
 from .extraction_control import ExtractionRequest, ExtractionSubmitter
 
 # For now, the migration & calibration events come via DESY's Kafka brokers,
-# but the AMORE updates go via XFEL's test instance.
-CONSUMER_ID = 'xfel-da-amore-prototype-{}'
+# but the DAMNIT updates go via XFEL's test instance.
+CONSUMER_ID = 'xfel-da-damnit-{}'
 KAFKA_CONF = {
     'maxwell': {
         'brokers': ['exflwgs06:9091'],
@@ -28,6 +31,13 @@ KAFKA_CONF = {
         'events': ['daq_run_complete', 'online_correction_complete'],
     }
 }
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS proposal_databases(proposal, db_dir UNIQUE, official);
+
+-- Settings for the listener
+CREATE TABLE IF NOT EXISTS settings(key PRIMARY KEY NOT NULL, value)
+"""
 
 log = logging.getLogger(__name__)
 
@@ -51,38 +61,79 @@ def execute_direct(submitter, request):
     local_extraction_threads.append(extr)
     extr.start()
 
+class ListenerDB:
+    def __init__(self, db_dir):
+        self.conn = sqlite3.connect(db_dir.absolute() / "listener.sqlite")
+        self.conn.executescript(SCHEMA)
+        self._settings = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.conn.close()
+
+    @property
+    def settings(self):
+        if self._settings is None:
+            self._settings = KeyValueMapping(self.conn, "settings")
+
+        return self._settings
+
+    def proposal_db_dirs(self, proposal):
+        official_path = find_proposal(proposal) / "usr/Shared/amore"
+        if (official_path / "runs.sqlite").is_file():
+            with self.conn:
+                self.conn.execute("""
+                    INSERT INTO proposal_databases (proposal, db_dir, official) VALUES (?, ?, ?)
+                    ON CONFLICT (db_dir) DO NOTHING
+                """, (proposal, str(official_path), True))
+
+        rows = self.conn.execute("SELECT db_dir from proposal_databases WHERE proposal=?",
+                                 (proposal,)).fetchall()
+        return [Path(row[0]) for row in rows]
+
+    def add_proposal_db(self, proposal: int, db_dir, official: bool):
+        with self.conn:
+            self.conn.execute("""
+                INSERT INTO proposal_databases (proposal, db_dir, official) VALUES (?, ?, ?)
+            """, (proposal, str(db_dir), official))
+
+    def remove_proposal_db(self, db_dir):
+        with self.conn:
+            self.conn.execute("DELETE FROM proposal_databases WHERE db_dir=?", (str(db_dir),))
 
 class EventProcessor:
+    def __init__(self, listener_dir: Path):
+        self.submitters = dict()
 
-    def __init__(self, context_dir=Path('.')):
-        self.context_dir = context_dir
-        self.db = DamnitDB.from_dir(context_dir)
-        self.submitter = ExtractionSubmitter(context_dir, self.db)
-        # Fail fast if read-only - https://stackoverflow.com/a/44707371/434217
-        self.db.conn.execute("pragma user_version=0;")
-        self.proposal = self.db.metameta['proposal']
-        log.info(f"Will watch for events from proposal {self.proposal}")
+        self.db = ListenerDB(listener_dir)
 
-        if gethostname().startswith('exflonc'):
+        # To help prevent accidentally starting multiple listeners we default to
+        # disabling it entirely.
+        self.db.settings.setdefault("proposal", -1)
+
+        hostname = gethostname()
+        if hostname.startswith('exflonc'):
             # running on the online cluster
             kafka_conf = KAFKA_CONF['onc']
         else:
             kafka_conf = KAFKA_CONF['maxwell']
 
-        consumer_id = CONSUMER_ID.format(self.db.metameta['db_id'])
+        consumer_id = CONSUMER_ID.format(f"{hostname}-{os.getpid()}")
         self.kafka_cns = KafkaConsumer(*kafka_conf['topics'],
                                        bootstrap_servers=kafka_conf['brokers'],
                                        group_id=consumer_id,
                                        consumer_timeout_ms=600_000,
                                        )
         self.events = kafka_conf['events']
+        log.info("Started listener")
 
     def __enter__(self):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.kafka_cns.close()
-        self.db.close()
         return False
 
     def run(self):
@@ -92,11 +143,6 @@ class EventProcessor:
                     self._process_kafka_event(record)
                 except Exception:
                     log.error("Unepected error handling Kafka event.", exc_info=True)
-
-            # After 10 minutes with no messages, check if the listener should stop
-            if self.db.metameta.get('no_listener', 0):
-                log.info("Found no_listener flag in database, shutting down.")
-                return
 
     def _process_kafka_event(self, record):
         msg = json.loads(record.value.decode())
@@ -123,38 +169,49 @@ class EventProcessor:
         proposal = int(msg['proposal'])
         run = int(msg['run'])
 
-        if proposal != self.proposal:
+        # If a specific proposal is requested and this event isn't for it, do nothing
+        if self.db.settings["proposal"] != "all" and self.db.settings["proposal"] != proposal:
             return
 
-        self.db.ensure_run(proposal, run, record.timestamp / 1000)
-        log.info(f"Added p%d r%d ({run_data.value} data) to database", proposal, run)
+        for path in self.db.proposal_db_dirs(proposal):
+            try:
+                db = DamnitDB(path / "runs.sqlite")
 
-        req = ExtractionRequest(run, proposal, run_data)
-        try:
-            self.submitter.submit(req)
-        except FileNotFoundError:
-            log.warning('Slurm not available, starting process locally.')
-            execute_direct(self.submitter, req)
-        except Exception:
-            log.error("Slurm job submission failed, starting process locally.", exc_info=True)
-            execute_direct(self.submitter, req)
+                # Fail fast if read-only - https://stackoverflow.com/a/44707371/434217
+                db.conn.execute("pragma user_version=0;")
 
+                db.ensure_run(proposal, run, record.timestamp / 1000)
+                log.info(f"Added p%d r%d ({run_data.value} data) to database", proposal, run)
 
-def listen():
+                if path not in self.submitters:
+                    self.submitters[path] = ExtractionSubmitter(db.path.parent, db)
+                submitter = self.submitters[path]
+
+                req = ExtractionRequest(run, proposal, run_data)
+                try:
+                    submitter.submit(req)
+                except FileNotFoundError:
+                    log.warning('Slurm not available, starting process locally.')
+                    execute_direct(submitter, req)
+                except Exception:
+                    log.error("Slurm job submission failed, starting process locally.", exc_info=True)
+                    execute_direct(submitter, req)
+
+                db.close()
+            except:
+                log.error(f"Processing p{proposal}, r{run} for {path} failed:")
+                log.error(traceback.format_exc())
+
+def listen(db_path):
     # Set up logging to a file
-    file_handler = logging.FileHandler("amore.log")
+    file_handler = logging.FileHandler("damnit.log")
     formatter = logging.root.handlers[0].formatter
     file_handler.setFormatter(formatter)
     logging.root.addHandler(file_handler)
 
-    # Ensure that the log file is writable by everyone (so that different users
-    # can start the backend).
-    if os.stat("amore.log").st_uid == os.getuid():
-        os.chmod("amore.log", 0o666)
-
     log.info(f"Running on {platform.node()} under user {getpass.getuser()}, PID {os.getpid()}")
     try:
-        with EventProcessor() as processor:
+        with EventProcessor(db_path) as processor:
             processor.run()
     except KeyboardInterrupt:
         log.error("Stopping on Ctrl + C")

--- a/damnit/backend/supervisord.py
+++ b/damnit/backend/supervisord.py
@@ -48,7 +48,7 @@ def get_supervisord_address(default_port=2322):
 
     return hostname, port
 
-def backend_is_running(root_path: Path, timeout=1):
+def listener_is_running(root_path: Path, timeout=1):
     config_path = root_path / "supervisord.conf"
     supervisorctl_status = ["supervisorctl", "-c", str(config_path), "status", "damnit"]
 
@@ -94,7 +94,7 @@ def write_supervisord_conf(root_path):
     if config_path.stat().st_uid == os.getuid():
         os.chmod(config_path, 0o666)
 
-def start_backend(root_path: Path, try_again=True):
+def start_listener(root_path: Path, try_again=True):
     config_path = root_path / "supervisord.conf"
     if not config_path.is_file():
         write_supervisord_conf(root_path)
@@ -120,7 +120,7 @@ def start_backend(root_path: Path, try_again=True):
             return False
 
         if try_again:
-            return start_backend(root_path, try_again=False)
+            return start_listener(root_path, try_again=False)
     elif rc == 3:
         # 3 means it's stopped and we need to start the program
         cmd = subprocess.run([*supervisorctl, "start", "damnit"])
@@ -147,35 +147,3 @@ def start_backend(root_path: Path, try_again=True):
         os.chmod(log_path, 0o666)
 
     return True
-
-def initialize_and_start_backend(root_path, proposal=None, context_file_src=None):
-    # Ensure the directory exists
-    root_path.mkdir(parents=True, exist_ok=True)
-    if root_path.stat().st_uid == os.getuid():
-        os.chmod(root_path, 0o777)
-
-    # If the database doesn't exist, create it
-    if not db_path(root_path).is_file():
-        if proposal is None:
-            raise ValueError("Must pass a proposal number to `initialize_and_start_backend()` if the database doesn't exist yet.")
-
-        # Initialize database
-        db = DamnitDB.from_dir(root_path)
-        db.metameta["proposal"] = proposal
-        db.metameta["context_python"] = "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/bin/python"
-    else:
-        # Otherwise, load the proposal number
-        db = DamnitDB.from_dir(root_path)
-        proposal = db.metameta["proposal"]
-
-    context_path = root_path / "context.py"
-    # Copy initial context file if necessary
-    if not context_path.is_file():
-        if context_file_src is not None:
-            shutil.copyfile(context_file_src, context_path)
-        else:
-            context_path.touch()
-        os.chmod(context_path, 0o666)
-
-    # Start backend
-    return start_backend(root_path)

--- a/damnit/backend/test_listener.py
+++ b/damnit/backend/test_listener.py
@@ -21,23 +21,24 @@ class TestEventProcessor(EventProcessor):
 
         while True:
             try:
-                run_and_data = input(f'Run for proposal {self.proposal}: ')
+                run_and_data = input("Enter a '<proposal> <run> [raw|proc]' string: ")
                 # If the user presses 'Enter' without typing the input will be empty
                 if len(run_and_data) == 0:
                     continue
 
-                # Extract the run number, and optionally the run data source
+                # Extract the proposal and run number, and optionally the run data source
                 input_split = run_and_data.split()
-                run = input_split[0]
-                if len(input_split) == 2:
-                    run_data = RunData(input_split[1])
+                proposal = input_split[0]
+                run = input_split[1]
+                if len(input_split) == 3:
+                    run_data = RunData(input_split[2])
                 else:
                     run_data = RunData.ALL
 
                 # Create the fake Kafka message
-                path = glob(f'/gpfs/exfel/exp/*/*/p{self.proposal:>06}/raw/r{run:>04}')[0]
+                path = glob(f'/gpfs/exfel/exp/*/*/p{proposal:>06}/raw/r{run:>04}')[0]
                 inst, cycle = path.split('/')[4:6]
-                msg = {'proposal': self.proposal, 'run': run, 'path': path,
+                msg = {'proposal': proposal, 'run': run, 'path': path,
                        'instrument': inst, 'cycle': cycle}
                 record = DummyRecord(timestamp=int(datetime.utcnow().timestamp() * 1000))
 
@@ -55,9 +56,9 @@ class TestEventProcessor(EventProcessor):
                 log.error("Error processing event", exc_info=True)
 
 
-def listen():
+def listen(db_path):
     try:
-        with TestEventProcessor() as processor:
+        with TestEventProcessor(db_path) as processor:
             processor.run()
     except KeyboardInterrupt:
         print("Stopping on Ctrl-C")

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -42,6 +42,32 @@ def excepthook(exc_type, value, tb):
     IPython.start_ipython(argv=[], display_banner=False,
                           user_ns=target_frame.f_locals | target_frame.f_globals | {"__tb": lambda: print(tb_msg)})
 
+def handle_config_args(args, kv):
+    key = args.key
+    if key:
+        key = key.replace('-', '_')
+
+    if args.delete:
+        if not key:
+            sys.exit("Error: no key specified to delete")
+        del kv[key]
+    elif key and (args.value is not None):
+        if args.num:
+            try:
+                value = int(args.value)
+            except ValueError:
+                value = float(args.value)
+        else:
+            value = args.value
+        kv[key] = value
+    elif key:
+        try:
+            print(repr(kv[key]))
+        except KeyError:
+            sys.exit(f"Error: key {key} not found")
+    else:
+        for k, v in kv.items():
+            print(f"{k}={v!r}")
 
 def main(argv=None):
     # Check if script was called as amore-proto and show deprecation warning
@@ -83,8 +109,28 @@ def main(argv=None):
         help="Start the listener under a separate process managed by supervisord."
     )
     listen_ap.add_argument(
-        'context_dir', type=Path, nargs='?', default='.',
-        help="Directory to store summarised results"
+        '--listener-db', type=Path, default='listener.db',
+        help="Path to the listener database"
+    )
+
+    listener_config_ap = subparsers.add_parser(
+        "listener-config", help="See or change the config for the DAMNIT listener"
+    )
+    listener_config_ap.add_argument(
+        '-d', '--delete', action='store_true',
+        help="Delete the specified key",
+    )
+    listener_config_ap.add_argument(
+        '--num', action='store_true',
+        help="Set the given value as a number instead of a string"
+    )
+    listener_config_ap.add_argument(
+        'key', nargs='?',
+        help="The config key to see/change. If not given, list the whole configuration"
+    )
+    listener_config_ap.add_argument(
+        'value', nargs='?',
+        help="A new value for the given key"
     )
 
     reprocess_ap = subparsers.add_parser(
@@ -211,22 +257,27 @@ def main(argv=None):
                        connect_to_kafka=not args.no_kafka)
 
     elif args.subcmd == 'listen':
-        from .backend.db import db_path
-        from .backend import initialize_and_start_backend
+        from .backend import start_listener
 
         if args.daemonize:
-            if not db_path(args.context_dir).is_file():
-                sys.exit("You must create a database with `damnit proposal` before starting the listener.")
-
-            return initialize_and_start_backend(args.context_dir)
+            return start_listener(Path.cwd())
         else:
             if args.test:
                 from .backend.test_listener import listen
             else:
                 from .backend.listener import listen
 
-            os.chdir(args.context_dir)
-            return listen()
+            return listen(args.listener_db)
+
+    elif args.subcmd == "listener-config":
+        from .backend.listener import ListenerDB
+
+        # Convert the `proposal` to an integer if necessary
+        if args.key and args.key == "proposal" and args.value and args.value != "all":
+            args.value = int(args.value)
+
+        db = ListenerDB(Path.cwd())
+        handle_config_args(args, db.settings)
 
     elif args.subcmd == 'reprocess':
         # Hide some logging from Kafka to make things more readable
@@ -264,31 +315,8 @@ def main(argv=None):
     elif args.subcmd == 'db-config':
         from .backend.db import DamnitDB
 
-        if args.key:
-            args.key = args.key.replace('-', '_')
-
         db = DamnitDB()
-        if args.delete:
-            if not args.key:
-                sys.exit("Error: no key specified to delete")
-            del db.metameta[args.key]
-        elif args.key and (args.value is not None):
-            if args.num:
-                try:
-                    value = int(args.value)
-                except ValueError:
-                    value = float(args.value)
-            else:
-                value = args.value
-            db.metameta[args.key] = value
-        elif args.key:
-            try:
-                print(repr(db.metameta[args.key]))
-            except KeyError:
-                sys.exit(f"Error: key {args.key} not found")
-        else:
-            for k, v in db.metameta.items():
-                print(f"{k}={v!r}")
+        handle_config_args(args, db.metameta)
 
     elif args.subcmd == "migrate":
         from .backend.db import DamnitDB

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -22,7 +22,7 @@ from PyQt5.QtWebEngineWidgets import QWebEngineProfile
 from PyQt5.QtWidgets import QAction, QFileDialog, QMessageBox, QTabWidget
 
 from ..api import DataType, RunVariables
-from ..backend import backend_is_running, initialize_and_start_backend
+from ..backend import initialize_proposal
 from ..backend.db import DamnitDB, MsgKind, ReducedData, db_path
 from ..backend.extraction_control import ExtractionSubmitter, process_log_path
 from ..backend.user_variables import UserEditableVariable
@@ -210,7 +210,7 @@ da-dev@xfel.eu"""
         context_dir, prop_no = open_dialog.run_get_result()
         if context_dir is None:
             return
-        if not prompt_setup_db_and_backend(context_dir, prop_no, parent=self):
+        if not prompt_setup_db(context_dir, prop_no, parent=self):
             # User said no to setting up a new database
             return
 
@@ -1095,13 +1095,13 @@ class LogViewWindow(QtWidgets.QMainWindow):
         self.resize(1000, 800)
 
 
-def prompt_setup_db_and_backend(context_dir: Path, prop_no=None, parent=None):
+def prompt_setup_db(context_dir: Path, prop_no=None, parent=None):
     if not db_path(context_dir).is_file():
 
         button = QMessageBox.question(
             parent, "Database not found",
             f"{context_dir} does not contain a DAMNIT database, "
-            "would you like to create one and start the backend?"
+            "would you like to create one?"
         )
         if button != QMessageBox.Yes:
             return False
@@ -1120,22 +1120,8 @@ def prompt_setup_db_and_backend(context_dir: Path, prop_no=None, parent=None):
             )
             if not ok:
                 return False
-        initialize_and_start_backend(context_dir, prop_no, context_file_src)
+        initialize_proposal(context_dir, prop_no, context_file_src)
         return True
-
-    # The folder already contains a database
-    db = DamnitDB.from_dir(context_dir)
-
-    # Check if the backend is running
-    expect_listener = not db.metameta.get('no_listener', 0)
-    if expect_listener and not backend_is_running(context_dir):
-        button = QMessageBox.question(
-            parent, "Backend not running",
-            "The DAMNIT backend is not running, would you like to start it? "
-            "This is only necessary if new runs are expected."
-        )
-        if button == QMessageBox.Yes:
-            initialize_and_start_backend(context_dir, prop_no)
 
     return True
 
@@ -1164,7 +1150,7 @@ def run_app(context_dir, software_opengl=False, connect_to_kafka=True):
         context_dir, prop_no = open_dialog.run_get_result()
         if context_dir is None:
             return 0
-        if not prompt_setup_db_and_backend(context_dir, prop_no):
+        if not prompt_setup_db(context_dir, prop_no):
             # User said no to setting up a new database
             return 0
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -136,6 +136,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.stop_update_listener_thread()
         self.stop_watching_context_file()
+
         super().closeEvent(event)
 
     def stop_update_listener_thread(self):
@@ -164,7 +165,7 @@ class MainWindow(QtWidgets.QMainWindow):
     def _create_status_bar(self) -> None:
         self._status_bar = QtWidgets.QStatusBar()
 
-        self._status_bar.messageChanged.connect(lambda m: self.show_default_status_message() if m == "" else m)
+        self._status_bar.messageChanged.connect(self.on_status_message_changed)
 
         self._status_bar.setStyleSheet("QStatusBar::item {border: None;}")
         self._status_bar.showMessage("Autoconfigure AMORE.")
@@ -172,6 +173,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self._status_bar_connection_status = QtWidgets.QLabel()
         self._status_bar.addPermanentWidget(self._status_bar_connection_status)
+
+    def on_status_message_changed(self, msg):
+        if msg == "":
+            self.show_default_status_message()
 
     def show_status_message(self, message, timeout = 0, stylesheet = ''):
         if isinstance(stylesheet, StatusbarStylesheet):

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -891,7 +891,12 @@ da-dev@xfel.eu"""
         # Clear the widget and wait for a bit to visually indicate to the
         # user that something happened.
         self._error_widget.setText("")
-        QtCore.QTimer.singleShot(100, lambda: self._error_widget.setText(text))
+
+        # We use sleep() instead of a QTimer because otherwise during the tests
+        # the error widget may be free'd before the timer fires, leading to a
+        # segfault when the timer function attempts to use it.
+        time.sleep(0.1)
+        self._error_widget.setText(text)
 
     def save_context(self):
         self._context_code_to_save = self._editor.text()

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -23,7 +23,7 @@ import yaml
 from PIL import Image
 from testpath import MockCommand
 
-from damnit.backend import backend_is_running, initialize_and_start_backend
+from damnit.backend import listener_is_running, initialize_proposal, start_listener
 from damnit.backend.db import DamnitDB
 from damnit.backend.extract_data import Extractor, RunExtractor, add_to_db, load_reduced_data
 from damnit.backend.extraction_control import ExtractionJobTracker
@@ -811,9 +811,33 @@ def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
     win = MainWindow(db_dir, False)
     qtbot.addWidget(win)
 
-def test_initialize_and_start_backend(tmp_path, bound_port, request):
+def test_initialize_proposal(tmp_path):
     db_dir = tmp_path / "foo"
-    supervisord_config_path = db_dir / "supervisord.conf"
+    good_file_mode = "-rw-rw-rw-"
+    path_filemode = lambda p: stat.filemode(p.stat().st_mode)
+
+    initialize_proposal(db_dir, 1234)
+
+    # The directory should be created if it doesn't exist
+    assert db_dir.is_dir()
+    # And be writable by everyone
+    assert path_filemode(db_dir) == "drwxrwxrwx"
+
+    # Check that the database was initialized correctly
+    db_path = db_dir / "runs.sqlite"
+    assert db_path.is_file()
+    assert path_filemode(db_path) == good_file_mode
+    db = DamnitDB(db_path)
+    assert db.metameta["proposal"] == 1234
+
+    # Check the context file
+    context_path = db_dir / "context.py"
+    assert context_path.is_file()
+    assert path_filemode(context_path) == good_file_mode
+
+
+def test_start_listener(tmp_path, bound_port, request):
+    supervisord_config_path = tmp_path / "supervisord.conf"
     good_file_mode = "-rw-rw-rw-"
     path_filemode = lambda p: stat.filemode(p.stat().st_mode)
 
@@ -862,24 +886,7 @@ def test_initialize_and_start_backend(tmp_path, bound_port, request):
     pkg = "damnit.backend.supervisord"
     with patch(f"{pkg}.write_supervisord_conf",
                side_effect=mock_write_supervisord_conf):
-        assert initialize_and_start_backend(db_dir, 1234)
-
-    # The directory should be created if it doesn't exist
-    assert db_dir.is_dir()
-    # And be writable by everyone
-    assert path_filemode(db_dir) == "drwxrwxrwx"
-
-    # Check that the database was initialized correctly
-    db_path = db_dir / "runs.sqlite"
-    assert db_path.is_file()
-    assert path_filemode(db_path) == good_file_mode
-    db = DamnitDB(db_path)
-    assert db.metameta["proposal"] == 1234
-
-    # Check the context file
-    context_path = db_dir / "context.py"
-    assert context_path.is_file()
-    assert path_filemode(context_path) == good_file_mode
+        assert start_listener(tmp_path)
 
     # Check the config file
     assert supervisord_config_path.is_file()
@@ -887,8 +894,8 @@ def test_initialize_and_start_backend(tmp_path, bound_port, request):
 
     # We should have a log file and PID file. They aren't created immediately so
     # we wait a bit for it.
-    pid_path = db_dir / "supervisord.pid"
-    log_path = db_dir / "supervisord.log"
+    pid_path = tmp_path / "supervisord.pid"
+    log_path = tmp_path / "supervisord.log"
     wait_until(lambda: pid_path.is_file() and log_path.is_file())
     pid = int(pid_path.read_text())
 
@@ -899,72 +906,91 @@ def test_initialize_and_start_backend(tmp_path, bound_port, request):
     assert path_filemode(log_path) == good_file_mode
 
     # Check that it's running
-    assert backend_is_running(db_dir)
+    assert listener_is_running(tmp_path)
 
-    wait_until(lambda: (db_dir / "started").is_file(), timeout=1)
+    wait_until(lambda: (tmp_path / "started").is_file(), timeout=1)
 
     # Stop the program
     supervisorctl = ["supervisorctl", "-c", str(supervisord_config_path)]
     subprocess.run([*supervisorctl, "stop", "damnit"]).check_returncode()
 
     # Check that the subprocess was also killed
-    wait_until(lambda: (db_dir / "stopped").is_file())
-    assert not backend_is_running(db_dir)
+    wait_until(lambda: (tmp_path / "stopped").is_file())
+    assert not listener_is_running(tmp_path)
 
     # Try starting it again. This time we don't pass the proposal number, it
     # should be picked up from the existing database.
     with patch(f"{pkg}.write_supervisord_conf",
                side_effect=mock_write_supervisord_conf):
-        assert initialize_and_start_backend(db_dir)
+        assert start_listener(tmp_path)
 
-    assert backend_is_running(db_dir)
+    assert listener_is_running(tmp_path)
 
     # Now kill supervisord
     kill_pid(pid)
-    assert not backend_is_running(db_dir)
+    assert not listener_is_running(tmp_path)
 
     # Change the config to use the bound port
-    mock_write_supervisord_conf(db_dir, port=bound_port)
+    mock_write_supervisord_conf(tmp_path, port=bound_port)
 
     # And try starting it again
     with patch(f"{pkg}.write_supervisord_conf",
                side_effect=mock_write_supervisord_conf):
-        assert initialize_and_start_backend(db_dir)
+        assert start_listener(tmp_path)
 
     wait_until(lambda: pid_path.is_file() and log_path.is_file())
     pid = int(pid_path.read_text())
     request.addfinalizer(lambda: kill_pid(pid))
 
     # Check that the backend is running
-    assert backend_is_running(db_dir)
+    assert listener_is_running(tmp_path)
 
     # Trying to start it again should do nothing
     with patch(f"{pkg}.write_supervisord_conf",
                side_effect=mock_write_supervisord_conf):
-        assert initialize_and_start_backend(db_dir)
+        assert start_listener(tmp_path)
 
-    assert backend_is_running(db_dir)
+    assert listener_is_running(tmp_path)
 
 
-def test_event_processor(mock_db, caplog):
-    db_dir, db = mock_db
-    db.metameta["proposal"] = 1234
+def test_event_processor(tmp_path, caplog, monkeypatch):
+    monkeypatch.setenv("XFEL_DATA_ROOT", str(tmp_path))
 
     with patch('damnit.backend.listener.KafkaConsumer') as kcon:
-        processor = EventProcessor(db_dir)
+        processor = EventProcessor(tmp_path)
+        processor.db.settings["proposal"] = "all"
 
     kcon.assert_called_once()
     assert len(local_extraction_threads) == 0
 
+    # Test proposal_db_paths(), first without an existing database
+    proposal_dir = tmp_path / "MID" / "202501" / "p001234"
+    proposal_dir.mkdir(parents=True)
+    assert len(processor.db.proposal_db_dirs(1234)) == 0
+
+    # Now with an official database
+    db_dir = proposal_dir / "usr/Shared/amore"
+    initialize_proposal(db_dir, 1234)
+    assert processor.db.proposal_db_dirs(1234) == [db_dir]
+
+    # And an unofficial database
+    fake_db_dir = tmp_path / "fakedb"
+    processor.db.add_proposal_db(1234, fake_db_dir, False)
+    assert processor.db.proposal_db_dirs(1234) == [db_dir, fake_db_dir]
+
     # slurm not available
+    event = MagicMock(timestamp=time())
     with (
         patch('subprocess.run', side_effect=FileNotFoundError),
         patch('damnit.backend.extraction_control.ExtractionSubmitter.execute_direct', lambda *_: sleep(1))
     ):
         with caplog.at_level(logging.WARNING):
-            event = MagicMock(timestamp=time())
             processor.handle_event(event, {'proposal': 1234, 'run': 1}, RunData.RAW)
 
+        # We should have got an error about the fake database not existing
+        assert "unable to open database file"
+
+        # And about slurm not being available
         assert 'Slurm not available' in caplog.text
         assert len(local_extraction_threads) == 1
         local_extraction_threads[0].join()
@@ -976,6 +1002,14 @@ def test_event_processor(mock_db, caplog):
 
         assert len(local_extraction_threads) == MAX_CONCURRENT_THREADS
         assert 'Too many events processing' in caplog.text
+
+    # With a different proposal specified handle_event() should do nothing
+    processor.db.settings["proposal"] = 1000
+    processor.handle_event(event, {'proposal': 1234, 'run': 1}, RunData.RAW)
+
+    # Test removing a database
+    processor.db.remove_proposal_db(fake_db_dir)
+    assert processor.db.proposal_db_dirs(1234) == [db_dir]
 
 
 def test_job_tracker():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import pytest
 from testpath import MockCommand
 
+from damnit.backend.listener import ListenerDB
 from damnit.cli import main, excepthook as ipython_excepthook
 
 
@@ -92,21 +93,21 @@ def test_listen(tmp_path, monkeypatch):
         main(["listen", "--test"])
         listen.assert_called_once()
 
-    # Should fail without an existing database
-    with (patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend,
-          pytest.raises(SystemExit)):
+    with patch(f"{pkg}.start_listener") as start_listener:
         main(["listen", "--daemonize"])
-        initialize_and_start_backend.assert_not_called()
-
-    # Should work with an existing database
-    (tmp_path / "runs.sqlite").touch()
-    with patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend:
-        main(["listen", "--daemonize"])
-        initialize_and_start_backend.assert_called_once()
+        start_listener.assert_called_once()
 
     # Can't pass both --test and --daemonize
     with pytest.raises(SystemExit):
         main(["listen", "--daemonize", "--test"])
+
+    listener_db_path = tmp_path / "listener.sqlite"
+    assert not listener_db_path.exists()
+    main(["listener-config", "proposal", "1234"])
+    assert listener_db_path.exists()
+
+    with ListenerDB(tmp_path) as db:
+        assert db.settings["proposal"] == 1234
 
 def test_reprocess(mock_db_with_data, monkeypatch):
     db_dir, db = mock_db_with_data

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -58,7 +58,7 @@ def test_connect_to_kafka(mock_db, qtbot):
     with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
         win = MainWindow(db_dir, True)
-        qtbot.addWidget(win)
+        qtbot.addWidget(win, before_close_func=lambda _: win.stop_update_listener_thread())
         kafka_cns.assert_called_once()
         kafka_prd.assert_called_once()
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -373,45 +373,33 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
     @contextmanager
     def helper_patch():
         # Patch things such that the GUI thinks we're on GPFS trying to open
-        # p1234, and the user always wants to create a database and start the
-        # backend.
+        # p1234, and the user always wants to create a database.
         with (patch(f"{pkg}.OpenDBDialog.run_get_result", return_value=(db_dir, 1234)),
               patch(f"{pkg}.NewContextFileDialog.run_get_result", return_value=template_path),
               patch.object(QMessageBox, "question", return_value=QMessageBox.Yes),
-              patch(f"{pkg}.initialize_and_start_backend") as initialize_and_start_backend,
+              patch(f"{pkg}.initialize_proposal") as initialize_proposal,
               patch.object(win, "autoconfigure")):
-            yield initialize_and_start_backend
+            yield initialize_proposal
 
     # Autoconfigure from scratch
-    with (helper_patch() as initialize_and_start_backend,
-          patch(f"{pkg}.backend_is_running", return_value=True)):
+    with helper_patch() as initialize_proposal:
         win._menu_bar_autoconfigure()
 
-        # We expect the database to be initialized and the backend started
+        # We expect the database to be initialized
         win.autoconfigure.assert_called_once_with(db_dir)
-        initialize_and_start_backend.assert_called_once_with(db_dir, 1234, template_path)
+        initialize_proposal.assert_called_once_with(db_dir, 1234, template_path)
 
     # Create the directory and database file to fake the database already existing
     db_dir.mkdir(parents=True)
     DamnitDB.from_dir(db_dir)
 
-    # Autoconfigure with database present & backend 'running':
-    with (helper_patch() as initialize_and_start_backend,
-          patch(f"{pkg}.backend_is_running", return_value=True)):
+    # Autoconfigure with database present
+    with helper_patch() as initialize_proposal:
         win._menu_bar_autoconfigure()
 
-        # We expect the database to be initialized and the backend started
+        # We expect the database to be initialized
         win.autoconfigure.assert_called_once_with(db_dir)
-        initialize_and_start_backend.assert_not_called()
-
-    # Autoconfigure again, the GUI should start the backend again
-    with (helper_patch() as initialize_and_start_backend,
-          patch(f"{pkg}.backend_is_running", return_value=False)):
-        win._menu_bar_autoconfigure()
-
-        # This time the database is already initialized
-        win.autoconfigure.assert_called_once_with(db_dir)
-        initialize_and_start_backend.assert_called_once_with(db_dir, 1234)
+        initialize_proposal.assert_not_called()
 
 def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
 


### PR DESCRIPTION
Important changes:
- The listener now supports triggering jobs for either all proposals or a single
  one.
- In addition to the 'official' databases under `usr/Shared/amore`, it's
  possible to add unofficial databases at any location.
- The GUI now only initializes the database and assumes a listener is already
  running.

I've tried to keep the commits atomic so I would suggest reviewing them one-by-one. @RobertRosca, @CammilleCC, I believe this is ready to be tested.