### PR TITLE
Handle run timestamps from old proposals with only proc files used

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -374,6 +374,12 @@ def get_start_time(xd_run):
         # If the timestamp information is not present (i.e. on old files), then
         # we take the timestamp from the oldest raw file as an approximation.
         files = sorted([f.filename for f in xd_run.files if "raw" in f.filename])
+        if len(files) == 0:
+            # Some old proposals also copy all the non-detector data into proc,
+            # in which case the DataCollection will only open the proc files. In
+            # this case we fall back to the timestamp of the proc files, which
+            # should be pretty close to the timestamp of the raw files.
+            files = sorted([f.filename for f in xd_run.files])
         first_file = Path(files[0])
 
         # Use the modified timestamp

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -31,6 +31,8 @@ Fixed:
   variable is plotted (!355).
 - Fixed crashes when the context file environment is missing dependencies (!356).
 - handle failure generating summary while writing results to file (!370).
+- Fixed getting the run timestamps from very old proposals where only proc files
+  are used (!399).
 
 Deprecated:
 - GUI: Standalone comments are no longer supported in the run table(!362).


### PR DESCRIPTION
I've sneakily already hotfixed this in the beta module :shushing_face: It would be more correct to find the raw files buuut I'm lazy and don't care much about old proposals anyway.