### PR TITLE
Fix thumbnail creation for `DataArray`'s with shape `(1, n)`

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -440,7 +440,7 @@ def generate_thumbnail(image):
         ax.imshow(image, vmin=vmin, vmax=vmax)
     else:
         # Use DataArray's own plotting method
-        image.plot(ax=ax, vmin=vmin, vmax=vmax, add_colorbar=False)
+        image.plot.imshow(ax=ax, vmin=vmin, vmax=vmax, add_colorbar=False)
     ax.axis('tight')
     ax.axis('off')
     ax.margins(0, 0)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -33,6 +33,7 @@ Fixed:
 - handle failure generating summary while writing results to file (!370).
 - Fixed getting the run timestamps from very old proposals where only proc files
   are used (!399).
+- Fixed creation of thumbnails for 2D `DataArray`'s with shape `(1, n)` (!401).
 
 Deprecated:
 - GUI: Standalone comments are no longer supported in the run table(!362).

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -355,6 +355,10 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
     def twodxarray(run):
         return xr.DataArray(np.random.rand(100, 100))
 
+    @Variable("2D-ish xarray")
+    def twod_ish_xarray(run):
+        return xr.DataArray(np.random.rand(1, 100))
+
     @Variable(title="Axes")
     def axes(run):
         _, ax = plt.subplots()
@@ -382,7 +386,7 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
         assert f["axes/data"].ndim == 3
 
         # Test that the summaries are the right size
-        for var in ["twodarray", "twodxarray"]:
+        for var in ["twodarray", "twodxarray", "twod_ish_xarray"]:
             png = Image.open(io.BytesIO(f[f".reduced/{var}"][()]))
             assert np.asarray(png).shape == (THUMBNAIL_SIZE, THUMBNAIL_SIZE, 4)
 


### PR DESCRIPTION
I opted to stick with a thumbnail for consistency, the idea being that if the users really want a 1D array they should squeeze it themselves.