### PR TITLE
Fix filtering of non-cluster variables

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -251,7 +251,7 @@ class ContextFile:
             if not v.transient or inc_transient
         }
 
-    def filter(self, run_data=RunData.ALL, cluster=True, name_matches=(), variables=()):
+    def filter(self, run_data=RunData.ALL, cluster=None, name_matches=(), variables=()):
         new_vars = {}
         for name, var in self.vars.items():
 
@@ -264,7 +264,7 @@ class ContextFile:
             # raw/proc data, then only process the Variable's that require that data.
             data_match = run_data == RunData.ALL or var.data == run_data
             # Skip data tagged cluster unless we're in a dedicated Slurm job
-            cluster_match = cluster or not var.cluster
+            cluster_match = True if cluster is None else cluster == var.cluster
 
             if variables:  # --var: exact variable names (not titles)
                 name_match = name in variables

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -35,6 +35,8 @@ Fixed:
 - Fixed getting the run timestamps from very old proposals where only proc files
   are used (!399).
 - Fixed creation of thumbnails for 2D `DataArray`'s with shape `(1, n)` (!401).
+- Fixed execution of behaviour of non-cluster variables, previously they were
+  incorrectly also executed in cluster jobs (!403).
 
 Deprecated:
 - GUI: Standalone comments are no longer supported in the run table(!362).

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -648,6 +648,24 @@ def test_filtering(mock_ctx, mock_run, caplog):
     assert set(results.cells) == { "scalar1", "scalar2", "timestamp", "array", "meta_array", "start_time" }
     assert results.cells["timestamp"].data > ts
 
+    # Test cluster filtering
+    ctx_code = """
+    from damnit_ctx import Variable
+
+    @Variable("foo", cluster=True)
+    def foo(run):
+        return 1
+
+    @Variable("bar")
+    def bar(run):
+        return 1
+    """
+    ctx = mkcontext(ctx_code)
+    assert set(ctx.filter().vars) == { "foo", "bar" }
+    assert set(ctx.filter(cluster=True).vars) == { "foo" }
+    assert set(ctx.filter(cluster=False).vars) == { "bar" }
+
+
 def test_add_to_db(mock_db):
     db_dir, db = mock_db
 


### PR DESCRIPTION
Previously these would be included even when `cluster=True`, causing them to be executed twice (once in the non-cluster job and again in the cluster job).

I changed the default value of the `cluster` argument in `Context.filter` to make the tests pass, that should be a safe change because every other caller explicitly passes `cluster`.