### PR TITLE
Fix Dockerfile that was missing LICENSE file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,18 +18,10 @@ RUN set -eux; \
     ; \
     apt list --installed $(apt-mark showmanual) > /.apt-deps-build
 
-COPY pyproject.toml /src/pyproject.toml
-# We need to copy the README too because it's used in pyproject.toml when
-# building the package.
-COPY README.md /src/README.md
+COPY . /src
 
 # set up venv and python dependencies
 RUN set -eux; \
-    mkdir -p /src/damnit; \
-    # install dependencies w/o installing package itself
-    # https://github.com/pypa/pip/issues/11440
-    echo '"""Hello"""' > /src/damnit/__init__.py; \
-    echo '__version__="0.0.0"' >> /src/damnit/__init__.py; \
     python3 -m venv --system-site-packages /app; \
     /app/bin/python3 -m pip install "/src[gui,backend]"; \
     /app/bin/python3 -m pip uninstall -y damnit; \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["flit_core >=3.2,<3.11"]
+requires = ["flit_core >=3.2,<4"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
The `build` stage of the Dockerfile was trying to create just enough of the source folder to install the dependencies. This broke on a new version of Flit because the LICENSE file wasn't included. But I don't think there's any problem with just copying the whole git repo folder in, like the app stage does later. So this simplfiies it.

@RobertRosca what do we gain by installing all the dependencies in the build stage and then installing DAMNIT itself separately in the app stage? Could we just install it in the build stage and then copy it across as part of `/app`?