### PR TITLE
Move the --concurrent-jobs argument to the database

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -134,6 +134,8 @@ class DamnitDB:
             # secure, but the secrets module is convenient to get a random string.
             self.metameta.setdefault('db_id', token_hex(20))
 
+        self.metameta.setdefault("concurrent_jobs", 15)
+
         if not db_existed:
             # If this is a new database, set the latest current version
             self.metameta["data_format_version"] = DATA_FORMAT_VERSION

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -315,11 +315,14 @@ class ExtractionSubmitter:
         return opts
 
 
-def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=False, limit_running=30):
+def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=False, limit_running=-1):
     """Called by the 'damnit reprocess' subcommand"""
     submitter = ExtractionSubmitter(Path.cwd())
     if proposal is None:
         proposal = submitter.proposal
+
+    if limit_running == -1:
+        limit_running = submitter.db.metameta["concurrent_jobs"]
 
     if runs == ['all']:
         rows = submitter.db.conn.execute("SELECT proposal, run FROM runs").fetchall()

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -114,8 +114,8 @@ def main(argv=None):
         help="Run processing in subprocesses on this node, instead of via Slurm"
     )
     reprocess_ap.add_argument(
-        '--concurrent-jobs', type=int, default=15,
-        help="The maximum number of jobs that will run at once (default 15)"
+        '--concurrent-jobs', type=int, default=-1,
+        help="The maximum number of jobs that will run at once (default is the `concurrent_jobs` database setting)"
     )
     reprocess_ap.add_argument(
         'run', nargs='+',

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -15,6 +15,8 @@ Added:
 - GUI: add a visual indicator on columns with active filter (!392)
 - GUI: Enhance the filter for numerical data with a slider to select filter
   ranges and a line plot to visualize the data distribution (!400).
+- It's now possible to specify the number of runs that will be processed
+  concurrently with the `concurrent_jobs` database setting (!408).
 
 Changed:
 

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -7,9 +7,10 @@ def test_metameta(mock_db):
     _, db = mock_db
 
     # Test various parts of the mutable mapping API
-    assert set(db.metameta.keys()) == {'db_id', 'data_format_version'}
+    assert set(db.metameta.keys()) == {'db_id', 'data_format_version', 'concurrent_jobs'}
     del db.metameta['db_id']
     del db.metameta['data_format_version']
+    del db.metameta['concurrent_jobs']
     assert len(db.metameta) == 0
 
     db.metameta['a'] = 12


### PR DESCRIPTION
This keeps the previous default of 15, but allows setting it globally. I'm not entirely sold on the name `concurrent_jobs` since it only applies to non-cluster jobs, but maybe that's ok? :shrug: 

CC @turkot 