### PR TITLE
Show errors from executing variables as tooltips on table cells

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -233,6 +233,7 @@ class RunVariables:
         with h5py.File(self.file) as f:
             all_keys = { name: False for name in f.keys() }
         del all_keys[".reduced"]
+        del all_keys[".errors"]
 
         # And the keys from the database
         user_vars = list(self._db.get_user_variables().keys())

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -217,3 +217,7 @@ class Cell:
         if (max_diff := self._max_diff()) is not None:
             d['max_diff'] = max_diff
         return d
+
+
+class Skip(Exception):
+    pass

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -534,6 +534,19 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         item.setEditable(True)
         return item
 
+    def error_item(self, attrs):
+        item = self.itemPrototype().clone()
+        item.setToolTip(attrs['error'])
+        match attrs.get('error_cls', ''):
+            case 'Skip':
+                colour = 'lightgrey'
+            case 'SourceNameError':  # Typically an issue with data, not code
+                colour = 'grey'
+            case _:
+                colour = 'darkorange'
+        item.setBackground(QtGui.QBrush(QtGui.QColor(colour)))
+        return item
+
     def new_item(self, value, column_id, max_diff, attrs):
         if is_png_bytes(value):
             return self.image_item(value)
@@ -541,6 +554,8 @@ class DamnitTableModel(QtGui.QStandardItemModel):
             return self.comment_item(value)
         elif column_id == 'start_time':
             return self.text_item(value, timestamp2str(value))
+        elif 'error' in attrs:
+            return self.error_item(attrs)
         else:
             item = self.text_item(value)
             item.setEditable(column_id in self.editable_columns)

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -543,9 +543,9 @@ class DamnitTableModel(QtGui.QStandardItemModel):
                 msg = "Skipped: " + msg
             case 'SourceNameError':  # Typically an issue with data, not code
                 colour = 'lightgrey'
-            case _:
+            case cls:
                 colour = 'orange'
-                msg += " (see processing log for details)"
+                msg = f"{cls}: {msg} (see processing log for details)"
         item.setToolTip(msg)
         item.setData(QtGui.QColor(colour), Qt.ItemDataRole.DecorationRole)
         return item

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -536,15 +536,18 @@ class DamnitTableModel(QtGui.QStandardItemModel):
 
     def error_item(self, attrs):
         item = self.itemPrototype().clone()
-        item.setToolTip(attrs['error'])
+        msg = attrs['error']
         match attrs.get('error_cls', ''):
             case 'Skip':
                 colour = 'lightgrey'
+                msg = "Skipped: " + msg
             case 'SourceNameError':  # Typically an issue with data, not code
-                colour = 'grey'
+                colour = 'lightgrey'
             case _:
-                colour = 'darkorange'
-        item.setBackground(QtGui.QBrush(QtGui.QColor(colour)))
+                colour = 'orange'
+                msg += " (see processing log for details)"
+        item.setToolTip(msg)
+        item.setData(QtGui.QColor(colour), Qt.ItemDataRole.DecorationRole)
         return item
 
     def new_item(self, value, column_id, max_diff, attrs):

--- a/damnit/gui/table_filter.py
+++ b/damnit/gui/table_filter.py
@@ -7,7 +7,7 @@ from fonticon_fa6 import FA6S
 from natsort import natsorted
 from PyQt5 import QtCore
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPixmap
+from PyQt5.QtGui import QColor, QPixmap
 from PyQt5.QtWidgets import (
     QAction,
     QCheckBox,
@@ -254,7 +254,9 @@ class FilterMenu(QMenu):
             item = model.sourceModel().index(row, column)
 
             if thumb := item.data(Qt.DecorationRole):
-                decos.add(type(thumb))
+                # QColor decoration is used for errors (no value)
+                if not isinstance(thumb, QColor):
+                    decos.add(type(thumb))
 
             if (value := item.data(Qt.UserRole)) is None:
                 continue

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -123,6 +123,20 @@ def bar(run, value: "var#foo"):
     return value * 2
 ```
 
+Dependents are not executed if a variable raises an error or returns `None`. You
+can raise `Skip` to provide a reason, visible as a tooltip on the table cell:
+
+```python
+from damnit_ctx import Variable, Skip
+
+@Variable()
+def binned_by_scan_step(run):
+    scan = Scantool(run)
+    if not scan.active:
+        raise Skip("Run is not a scan")
+    ...
+```
+
 Dependencies with default values are also allowed, the default value will be
 passed to the function if the dependency did not complete execution for some
 reason:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "The Data And Metadata iNspection Interactive Thing"
 license = {file = "LICENSE"}
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version"]
 readme = "README.md"

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -541,7 +541,7 @@ def test_results_bad_obj(mock_run, tmp_path):
     results_hdf5_path = tmp_path / 'results.h5'
     results.save_hdf5(results_hdf5_path)
     with h5py.File(results_hdf5_path) as f:
-        assert set(f) == {".reduced", "good", "start_time"}
+        assert set(f) == {".errors", ".reduced", "good", "start_time"}
         assert set(f[".reduced"]) == {"good", "start_time"}
 
 def test_results_cell(mock_run, tmp_path):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QPalette, QPixmap
+from PyQt5.QtGui import QColor, QPalette, QPixmap
 from PyQt5.QtWidgets import (QDialog, QFileDialog, QInputDialog, QLineEdit,
                              QMessageBox, QStyledItemDelegate)
 
@@ -725,6 +725,10 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     def complex_xr_1d(run):
         import xarray as xr
         return xr.DataArray(np.array([1+1j, 2+2j, 3+3j, 4+4j]))
+
+    @Variable()
+    def error(run):
+        1/0
     """
     ctx_code = mock_ctx.code + "\n\n" + textwrap.dedent(const_array_code)
     (db_dir / "context.py").write_text(ctx_code)
@@ -806,6 +810,10 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     with patch.object(QMessageBox, "warning") as warning:
         win.inspect_data(complex_xr_1d)
         warning.assert_called_once()
+
+    assert isinstance(  # Errors evaluating variables get a coloured decoration
+        win.table.data(get_index('error'), role=Qt.DecorationRole), QColor
+    )
 
 
 def test_open_dialog(mock_db, qtbot):


### PR DESCRIPTION
Revised presentation:

![image](https://github.com/user-attachments/assets/2fe4abf7-480b-45bb-ad9c-330662153ea5)

The colours distinguish general errors (orange) from `raise Skip("some reason")` and extra_data SourceNameError (light grey). The latter comes up a fair bit when sources aren't saved, so I want coding errors to stand out a bit more.