### PR TITLE
Use anti-aliased interpolation for displaying images

### DIFF
--- a/damnit/gui/plot.py
+++ b/damnit/gui/plot.py
@@ -509,7 +509,7 @@ class ImagePlotWindow(PlotWindow):
                 vmin = np.nanquantile(image, 0.01, method='nearest')
                 vmax = np.nanquantile(image, 0.99, method='nearest')
                 image.plot.imshow(
-                    ax=self._axis, interpolation='nearest', vmin=vmin, vmax=vmax,
+                    ax=self._axis, interpolation='antialiased', vmin=vmin, vmax=vmax,
                     origin='lower'
                 )
             else:  # RGB(A) colour image
@@ -520,10 +520,8 @@ class ImagePlotWindow(PlotWindow):
             # Numpy array
             is_color_image = image.ndim == 3
 
-            interpolation = "antialiased" if is_color_image else "nearest"
-
             if self._image is None:
-                self._image = self._axis.imshow(image, interpolation=interpolation)
+                self._image = self._axis.imshow(image, interpolation="antialiased")
                 if not is_color_image:
                     self.figure.colorbar(self._image, ax=self._axis)
             else:


### PR DESCRIPTION
This quite dramatically improves the image quality, particularly on images with small features and noise.

Before and after:
![image](https://github.com/user-attachments/assets/b5f5cea0-d09b-4808-b49d-9956509c5370)
![image](https://github.com/user-attachments/assets/2c59e73b-fe45-4da9-9c59-7998eb7aa08c)

And another example:
![image](https://github.com/user-attachments/assets/244249a7-5abb-49bf-8389-fc9a7f116a91)
![image](https://github.com/user-attachments/assets/63578604-f3b3-40e7-af1c-15ecdbed9be3)

It's such a big improvement I'm gonna sneakily go ahead and merge it :eyes: 