### PR TITLE
Let the API handle old versions of the HDF5 file without .errors

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -233,7 +233,8 @@ class RunVariables:
         with h5py.File(self.file) as f:
             all_keys = { name: False for name in f.keys() }
         del all_keys[".reduced"]
-        del all_keys[".errors"]
+        if ".errors" in all_keys:
+            del all_keys[".errors"]
 
         # And the keys from the database
         user_vars = list(self._db.get_user_variables().keys())


### PR DESCRIPTION
Previously it would unconditionally try to remove the key, which would crash on older files written without it.

This is quite a serious bug so I'm gonna merge and deploy it.