### PR TITLE
Don't treat PENDING Slurm jobs as crashed on job monitor check

### DIFF
--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -444,7 +444,7 @@ class ExtractionJobTracker:
         still_running = set()
         for line in stdout.splitlines():
             job_id, status = line.strip().split()
-            if status == 'RUNNING':
+            if status in ('RUNNING', 'PENDING'):
                 still_running.add(job_id)
 
         for info in jobs_to_check:


### PR DESCRIPTION
I noticed that when the cluster is busy and jobs have to wait a while, the 'queued' status indicator would disappear. This was because the check for jobs ending without notification was only considering 'RUNNING' state, not 'PENDING'. This should fix that.