### PR TITLE
Store & show preview data as well as summary value

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -240,7 +240,7 @@ class VariableData:
         This is intended for use in Jupyter notebooks
         """
         if (obj := self.preview_data()) is None:
-            return
+            raise ValueError("No preview available")
 
         if isinstance_no_import(obj, 'plotly.graph_objs', 'Figure'):
             obj.show()

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -171,11 +171,12 @@ class VariableData:
                 return blob2complex(value)
             return value
 
-    def preview(self):
+    def preview(self, deserialize_plotly=True):
         """Get the preview data for the variable
 
-        May return a 1D or 2D data array, a 3D RGB(A) arrray, a plotly figure object,
-        or None if no preview is available.
+        May return a 1D or 2D data array, a 3D RGB(A) arrray, a plotly figure
+        object, a str of plotly JSON (with deserialize_plotly=False) or None
+        if no preview is available.
         """
         with h5py.File(self._h5_path) as f:
             xarray_group = dset = None
@@ -214,7 +215,8 @@ class VariableData:
 
                 if type_hint is DataType.PlotlyFigure:
                     import plotly.io as pio
-                    return pio.from_json(value.tobytes())
+                    b = value.tobytes()
+                    return pio.from_json(b) if deserialize_plotly else b.decode()
                 else:
                     return value
 

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -176,8 +176,8 @@ class VariableData:
     def preview_data(self, *, data_fallback=True, deserialize_plotly=True):
         """Get the preview data for the variable
 
-        May return a 1D or 2D data array, a 3D RGB(A) arrray, a plotly figure
-        object, a str of plotly JSON (with deserialize_plotly=False) or None
+        May return a 1D or 2D data array, a 3D RGB(A) arrray, a Plotly figure
+        object, a str of Plotly JSON (with deserialize_plotly=False) or None
         if no preview is available.
 
         If no preview was specified in the context file, but the returned data

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -244,8 +244,9 @@ class VariableData:
 
         if isinstance_no_import(obj, 'plotly.graph_objs', 'Figure'):
             obj.show()
+            return obj
         elif isinstance_no_import(obj, 'xarray', 'DataArray'):
-            obj.plot()  # Let Xarray decide what to plot
+            return obj.plot()  # Let Xarray decide what to plot
         else:  # ndarray
             import matplotlib.pyplot as plt
             obj = obj.squeeze()
@@ -254,23 +255,27 @@ class VariableData:
 
             match obj.ndim:
                 case 3:  # Colour image
-                    ax.imshow(obj, interpolation="antialiased")
+                    res = ax.imshow(obj, interpolation="antialiased")
                     ax.tick_params(left=False, bottom=False,
                                    labelleft=False, labelbottom=False)
                     ax.set_xlabel("")
                     ax.set_ylabel("")
                 case 2:
-                    img = ax.imshow(obj, interpolation="antialiased")
+                    res = ax.imshow(obj, interpolation="antialiased")
                     vmin = np.nanquantile(obj, 0.01, method='nearest')
                     vmax = np.nanquantile(obj, 0.99, method='nearest')
-                    img.set_clim(vmin, vmax)
-                    fig.colorbar(img, ax=ax)
+                    res.set_clim(vmin, vmax)
+                    fig.colorbar(res, ax=ax)
                 case 1:
-                    ax.plot(obj, fmt='o')
+                    res = ax.plot(obj, fmt='o')
                     ax.set_ylabel(self.title)
+                case _:
+                    return None
 
             if obj.ndim != 3:
                 ax.set_title(f'{self.title} (run {self.run})')
+
+            return res
 
     def __repr__(self):
         return f"<VariableData for '{self.name}' in p{self.proposal}, r{self.run}>"

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -214,7 +214,7 @@ class VariableData:
 
                 if type_hint is DataType.PlotlyFigure:
                     import plotly.io as pio
-                    return pio.from_json(value.data)
+                    return pio.from_json(value.tobytes())
                 else:
                     return value
 
@@ -281,10 +281,8 @@ class RunVariables:
     def _key_locations(self):
         # Read keys from the HDF5 file
         with h5py.File(self.file) as f:
-            all_keys = { name: False for name in f.keys() }
-        del all_keys[".reduced"]
-        if ".errors" in all_keys:
-            del all_keys[".errors"]
+            all_keys = { name: False for name in f.keys()
+                         if not name.startswith('.')}
 
         # And the keys from the database
         user_vars = list(self._db.get_user_variables().keys())

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -6,6 +6,7 @@ from glob import iglob
 from pathlib import Path
 
 import h5py
+import numpy as np
 
 from .backend.db import BlobTypes, DamnitDB, blob2complex
 
@@ -207,10 +208,12 @@ class VariableData:
                 arr = xr.load_dataarray(
                     self._h5_path, group=xarray_group, engine="h5netcdf"
                 )
-                if arr.ndim != 0:
+                if arr.ndim != 0 and np.issubdtype(arr.dtype, np.number):
                     return arr
 
-            elif dset.ndim in (1, 2) or (dset.ndim == 3 and dset.shape[-1] in (3, 4)):
+            elif np.issubdtype(dset.dtype, np.number) and (
+                    dset.ndim in (1, 2) or (dset.ndim == 3 and dset.shape[-1] in (3, 4))
+            ):
                 value = dset[()]
 
                 if type_hint is DataType.PlotlyFigure:

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -157,6 +157,8 @@ class ExtractionSubmitter:
             env.pop(v, None)
         # Slurm jobs shouldn't attempt to use your X session
         env.pop('DISPLAY', None)
+        # Some LD_PRELOAD entries from FastX (?) cause spurious warnings
+        env.pop('LD_PRELOAD', None)
         return env
 
     def submit(self, req: ExtractionRequest):

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -657,10 +657,10 @@ class Results:
                     attrs = {}
                     if isinstance_no_import(obj, 'matplotlib.figure', 'Figure'):
                         obj = figure2array(obj)
-                        attrs['_damnit_objtype'] = DataType.Image
+                        attrs['_damnit_objtype'] = DataType.Image.value
                     elif isinstance_no_import(obj, 'plotly.graph_objs', 'Figure'):
                         obj = np.frombuffer(obj.to_json().encode('utf-8'), dtype=np.uint8)
-                        attrs['_damnit_objtype'] = DataType.PlotlyFigure
+                        attrs['_damnit_objtype'] = DataType.PlotlyFigure.value
                     dsets.append((f'.preview/{name}', obj, attrs))
 
         for name, exc in self.errors.items():

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -473,6 +473,27 @@ def generate_thumbnail(image):
     return figure2png(fig, dpi=THUMBNAIL_SIZE)
 
 
+def line_thumbnail(arr):
+    from matplotlib.figure import Figure
+
+    # width = 3 * height; roughly fits table cells
+    fig = Figure(figsize=(2, 2/3))
+    ax = fig.add_subplot()
+    fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
+
+    if isinstance(arr, np.ndarray):
+        ax.plot(arr)
+    else:
+        # Use DataArray's own plotting method
+        arr.plot(ax=ax)
+
+    ax.axis('tight')
+    ax.axis('off')
+    ax.margins(0, 0)
+
+    return figure2png(fig, dpi=THUMBNAIL_SIZE)
+
+
 def extract_error_info(exc_type, e, tb):
     lineno = -1
     offset = 0
@@ -571,6 +592,12 @@ class Results:
         elif isinstance(data, (np.ndarray, xr.DataArray)):
             if data.ndim == 0:
                 return data
+            elif data.ndim == 1:
+                try:
+                    return line_thumbnail(data)
+                except:
+                    logging.error("Error generating thumbnail for %s", name, exc_info=True)
+                    return "<thumbnail error>"
             elif data.ndim == 2:
                 if isinstance(data, np.ndarray):
                     data = np.nan_to_num(data)

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -175,9 +175,12 @@ class Cell:
                     )
                 elif not np.issubdtype(preview.dtype, np.number):
                     raise TypeError("preview array should be numeric")
-            elif not isinstance_no_import(data, 'matplotlib.figure', 'Figure') or \
-                     isinstance_no_import(data, 'plotly.graph_objs', 'Figure'):
-                raise TypeError("preview must be an array or a figure object")
+            elif not (
+                    isinstance_no_import(preview, 'matplotlib.figure', 'Figure') or
+                    isinstance_no_import(preview, 'plotly.graph_objs', 'Figure')
+            ):
+                raise TypeError("preview must be an array or a figure object "
+                                f"(got {type(preview)})")
 
         self.data = data
         self.summary = summary

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -126,8 +126,11 @@ class Cell:
         Whether to display cell in bold
     background : str or sequence, optional
         Cell background color as hex string ('#ffcc00') or RGB sequence (0-255)
+    preview : array or figure object, optional
+        A plot, 1D or 2D array to show when double-clicking the table cell.
     """
-    def __init__(self, data, summary=None, summary_value=None, bold=None, background=None):
+    def __init__(self, data, summary=None, summary_value=None, bold=None, background=None,
+                 *, preview=None):
         # If the user returns an Axes, save the whole Figure
         if isinstance_no_import(data, 'matplotlib.axes', 'Axes'):
             data = data.get_figure()
@@ -164,11 +167,24 @@ class Cell:
                     )
             summary_value = arr
 
+        if preview is not None:
+            if isinstance(preview, (np.ndarray, xr.DataArray)):
+                if preview.ndim not in (1, 2):
+                    raise TypeError(
+                        f"preview should be a 1D or 2D array (shape is {preview.shape})"
+                    )
+                elif not np.issubdtype(preview.dtype, np.number):
+                    raise TypeError("preview array should be numeric")
+            elif not isinstance_no_import(data, 'matplotlib.figure', 'Figure') or \
+                     isinstance_no_import(data, 'plotly.graph_objs', 'Figure'):
+                raise TypeError("preview must be an array or a figure object")
+
         self.data = data
         self.summary = summary
         self.summary_value = summary_value
         self.bold = bold
         self.background = self._normalize_colour(background)
+        self.preview = preview
 
     @staticmethod
     def _normalize_colour(c):

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -26,8 +26,7 @@ from ..backend.db import DamnitDB, MsgKind, ReducedData, db_path
 from ..backend.extraction_control import ExtractionSubmitter, process_log_path
 from ..backend.user_variables import UserEditableVariable
 from ..definitions import UPDATE_BROKERS
-from ..util import (StatusbarStylesheet, fix_data_for_plotting, icon_path,
-                    isinstance_no_import)
+from ..util import fix_data_for_plotting, isinstance_no_import
 from .editor import ContextTestResult, Editor, SaveConflictDialog
 from .kafka import UpdateAgent
 from .new_context_dialog import NewContextFileDialog
@@ -39,6 +38,7 @@ from .standalone_comments import TimeComment
 from .table import DamnitTableModel, TableView, prettify_notation
 from .theme import Theme, ThemeManager, set_lexer_theme
 from .user_variables import AddUserVariableDialog
+from .util import icon_path, StatusbarStylesheet
 from .web_viewer import PlotlyPlot, UrlSchemeHandler
 from .zulip_messenger import ZulipMessenger
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -637,7 +637,7 @@ da-dev@xfel.eu"""
         )
 
         try:
-            preview = RunVariables(self.context_dir, run)[quantity].preview()
+            preview = RunVariables(self.context_dir, run)[quantity].preview_data()
         except FileNotFoundError:
             self.show_status_message(f"Couldn't get run variables for p{proposal}, r{run}",
                                      timeout=7000,

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -15,9 +15,9 @@ from superqt.utils import qthrottled
 from ..backend.db import BlobTypes, DamnitDB, ReducedData, blob2complex
 from ..backend.extraction_control import ExtractionJobTracker
 from ..backend.user_variables import value_types_by_name
-from ..util import delete_variable, timestamp2str
+from ..util import timestamp2str
 from .table_filter import FilterMenu, FilterProxy, FilterStatus
-from .util import StatusbarStylesheet
+from .util import delete_variable, StatusbarStylesheet
 
 log = logging.getLogger(__name__)
 

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -15,8 +15,9 @@ from superqt.utils import qthrottled
 from ..backend.db import BlobTypes, DamnitDB, ReducedData, blob2complex
 from ..backend.extraction_control import ExtractionJobTracker
 from ..backend.user_variables import value_types_by_name
-from ..util import StatusbarStylesheet, delete_variable, timestamp2str
+from ..util import delete_variable, timestamp2str
 from .table_filter import FilterMenu, FilterProxy, FilterStatus
+from .util import StatusbarStylesheet
 
 log = logging.getLogger(__name__)
 

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -21,7 +21,7 @@ from .table_filter import FilterMenu, FilterProxy, FilterStatus
 log = logging.getLogger(__name__)
 
 ROW_HEIGHT = 30
-THUMBNAIL_SIZE = 35
+THUMBNAIL_SIZE = (100, 35)  # w, h (pixels)
 
 
 class FilterHeaderView(QtWidgets.QHeaderView):
@@ -829,10 +829,8 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         """
         pixmap = QtGui.QPixmap()
         pixmap.loadFromData(data, "PNG")
-        if max(pixmap.height(), pixmap.width()) > THUMBNAIL_SIZE:
-            pixmap = pixmap.scaled(
-                THUMBNAIL_SIZE, THUMBNAIL_SIZE, Qt.KeepAspectRatio
-            )
+        if pixmap.width() > THUMBNAIL_SIZE[0] or pixmap.height() > THUMBNAIL_SIZE[1]:
+            pixmap = pixmap.scaled(*THUMBNAIL_SIZE, Qt.KeepAspectRatio)
         return pixmap
 
     def numbers_for_plotting(self, *cols, by_title=True):

--- a/damnit/gui/user_variables.py
+++ b/damnit/gui/user_variables.py
@@ -3,7 +3,7 @@ import re
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 from ..backend.user_variables import value_types_by_name
-from ..util import icon_path
+from .util import icon_path
 
 
 class AddUserVariableDialog(QtWidgets.QDialog):

--- a/damnit/gui/util.py
+++ b/damnit/gui/util.py
@@ -1,0 +1,34 @@
+from enum import Enum
+from pathlib import Path
+
+import numpy as np
+from sklearn.neighbors import KernelDensity
+
+
+class StatusbarStylesheet(Enum):
+    NORMAL = "QStatusBar {}"
+    ERROR = "QStatusBar {background: red; color: white; font-weight: bold;}"
+
+
+def icon_path(name):
+    """
+    Helper function to get the path to an icon file stored under ico/.
+    """
+    return str(Path(__file__).parent / "gui/ico" / name)
+
+
+def kde(x: np.ndarray, npoints: int = 1000) -> tuple[np.ndarray, np.ndarray]:
+    """1D kernel density estimation.
+
+    Args:
+        x (np.ndarray): 1D array of data points.
+        npoints (int, optional): Number of points to evaluate the KDE at. Defaults to 1000.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: Tuple of (x, y) coordinates of the KDE.
+    """
+    xplot = np.linspace(x.min(), x.max(), npoints)[:, np.newaxis]
+    kde = KernelDensity().fit(x[:, None])
+    log_dens = kde.score_samples(xplot)
+    y = np.exp(log_dens)
+    return xplot.squeeze(), y

--- a/damnit/gui/util.py
+++ b/damnit/gui/util.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import numpy as np
 from sklearn.neighbors import KernelDensity
 
+from ..context import add_to_h5_file
 
 class StatusbarStylesheet(Enum):
     NORMAL = "QStatusBar {}"
@@ -32,3 +33,15 @@ def kde(x: np.ndarray, npoints: int = 1000) -> tuple[np.ndarray, np.ndarray]:
     log_dens = kde.score_samples(xplot)
     y = np.exp(log_dens)
     return xplot.squeeze(), y
+
+
+def delete_variable(db, name):
+    # Remove from the database
+    db.delete_variable(name)
+
+    # And the HDF5 files
+    for h5_path in (db.path.parent / "extracted_data").glob("*.h5"):
+        with add_to_h5_file(h5_path) as f:
+            if name in f:
+                del f[f".reduced/{name}"]
+                del f[name]

--- a/damnit/gui/web_viewer.py
+++ b/damnit/gui/web_viewer.py
@@ -51,11 +51,11 @@ class UrlSchemeHandler(QWebEngineUrlSchemeHandler):
 
 
 class PlotlyPlot(QtWidgets.QWidget):
-    def __init__(self, variable, main_window):
+    def __init__(self, context_dir, proposal, run, name, main_window):
         super().__init__()
         self.main_window = main_window
 
-        self.url = f"{variable._db.path.parent}/{variable.proposal}/{variable.run}/{variable.name}"
+        self.url = f"{context_dir}/{proposal}/{run}/{name}"
 
         self.browser = QWebEngineView(self)
         profile = QWebEngineProfile.defaultProfile()

--- a/damnit/gui/web_viewer.py
+++ b/damnit/gui/web_viewer.py
@@ -37,7 +37,7 @@ class UrlSchemeHandler(QWebEngineUrlSchemeHandler):
             db_path = int(proposal)
  
         try:
-            _data = Damnit(db_path)[int(run), name].preview()
+            _data = Damnit(db_path)[int(run), name].preview_data()
         except Exception as ex:
             log.error(f"request job failed: {href!r}\n{ex}")
             job.fail(QWebEngineUrlRequestJob.Error.RequestFailed)

--- a/damnit/gui/web_viewer.py
+++ b/damnit/gui/web_viewer.py
@@ -37,7 +37,7 @@ class UrlSchemeHandler(QWebEngineUrlSchemeHandler):
             db_path = int(proposal)
  
         try:
-            _data = Damnit(db_path)[int(run), name].read()
+            _data = Damnit(db_path)[int(run), name].preview()
         except Exception as ex:
             log.error(f"request job failed: {href!r}\n{ex}")
             job.fail(QWebEngineUrlRequestJob.Error.RequestFailed)

--- a/damnit/gui/widgets.py
+++ b/damnit/gui/widgets.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import QLabel, QVBoxLayout, QWidget, QLineEdit, QHBoxLayout
 from superqt import QDoubleRangeSlider
 from superqt.utils import signals_blocked
 
-from ..util import icon_path, kde
+from .util import icon_path, kde
 
 
 class Arrow(QLabel):

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -1,5 +1,5 @@
 import glob
-import time
+import sys
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -76,3 +76,12 @@ def kde(x: np.ndarray, npoints: int = 1000) -> tuple[np.ndarray, np.ndarray]:
     log_dens = kde.score_samples(xplot)
     y = np.exp(log_dens)
     return xplot.squeeze(), y
+
+
+def isinstance_no_import(obj, mod: str, cls: str):
+    """Check if isinstance(obj, mod.cls) without loading mod"""
+    m = sys.modules.get(mod)
+    if m is None:
+        return False
+
+    return isinstance(obj, getattr(m, cls))

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -1,12 +1,9 @@
-import glob
 import sys
 from datetime import datetime, timezone
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import infer_dtype
-
-from .context import add_to_h5_file
 
 
 def timestamp2str(timestamp):
@@ -32,18 +29,6 @@ def bool_to_numeric(data):
 
 def fix_data_for_plotting(data):
     return bool_to_numeric(make_finite(data))
-
-
-def delete_variable(db, name):
-    # Remove from the database
-    db.delete_variable(name)
-
-    # And the HDF5 files
-    for h5_path in glob.glob(f"{db.path.parent}/extracted_data/*.h5"):
-        with add_to_h5_file(h5_path) as f:
-            if name in f:
-                del f[f".reduced/{name}"]
-                del f[name]
 
 
 def isinstance_no_import(obj, mod: str, cls: str):

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -1,20 +1,12 @@
 import glob
 import sys
 from datetime import datetime, timezone
-from enum import Enum
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
 from pandas.api.types import infer_dtype
-from sklearn.neighbors import KernelDensity
 
 from .context import add_to_h5_file
-
-
-class StatusbarStylesheet(Enum):
-    NORMAL = "QStatusBar {}"
-    ERROR = "QStatusBar {background: red; color: white; font-weight: bold;}"
 
 
 def timestamp2str(timestamp):
@@ -24,13 +16,6 @@ def timestamp2str(timestamp):
     dt_utc = datetime.fromtimestamp(timestamp, timezone.utc)
     dt_local = dt_utc.astimezone()
     return dt_local.strftime("%H:%M:%S %d/%m/%Y")
-
-
-def icon_path(name):
-    """
-    Helper function to get the path to an icon file stored under ico/.
-    """
-    return str(Path(__file__).parent / "gui/ico" / name)
 
 
 def make_finite(data):
@@ -59,23 +44,6 @@ def delete_variable(db, name):
             if name in f:
                 del f[f".reduced/{name}"]
                 del f[name]
-
-
-def kde(x: np.ndarray, npoints: int = 1000) -> tuple[np.ndarray, np.ndarray]:
-    """1D kernel density estimation.
-
-    Args:
-        x (np.ndarray): 1D array of data points.
-        npoints (int, optional): Number of points to evaluate the KDE at. Defaults to 1000.
-
-    Returns:
-        tuple[np.ndarray, np.ndarray]: Tuple of (x, y) coordinates of the KDE.
-    """
-    xplot = np.linspace(x.min(), x.max(), npoints)[:, np.newaxis]
-    kde = KernelDensity().fit(x[:, None])
-    log_dens = kde.score_samples(xplot)
-    y = np.exp(log_dens)
-    return xplot.squeeze(), y
 
 
 def isinstance_no_import(obj, mod: str, cls: str):

--- a/docs/backend.md
+++ b/docs/backend.md
@@ -155,7 +155,7 @@ $ damnit db-config noncluster_mem 50G
 The `Cell` object is a versatile container that allows customizing how data is
 stored and displayed in the table. When writing [Variables](#variables), you can
 return a `Cell` object to control both the full data storage and its summary
-representation. A `Cell` takes theses arguments:
+representation. A `Cell` takes these arguments:
 
 - `data`: The main data to store
 - `summary`: Function name (as string) from the `numpy` module to compute
@@ -163,9 +163,11 @@ representation. A `Cell` takes theses arguments:
 - `summary_value`: Direct value to use as summary (number or string)
 - `bold`: A boolean indicating whether the text should be rendered in a bold
   font in the table's cell
-- `background`: Cell background color as:
-    - Hex string (e.g., `#ffcc00`)
-    - RGB sequence (0-255 values)
+- `background`: Cell background color as hex string (e.g. `'#ffcc00'`)
+  or RGB sequence (0-255 values)
+- `preview`: What to show in a pop-up when the cell is double clicked.
+  This can be a 1D or 2D array, or a Matplotlib or Plotly figure.
+  If `data` is one of these types, it doesn't need to be specified again.
 
 Example Usage:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ readme = "README.md"
 dependencies = [
     "h5netcdf>=1.4.1",
     "h5py",
+    "numpy",
     "orjson",  # used in plotly for faster json serialization
     "pandas",
     "plotly",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def mock_ctx():
     import numpy as np
     import plotly.express as px
     import xarray as xr
-    from damnit.context import Variable
+    from damnit_ctx import Variable, Cell
 
     @Variable(title="Scalar1", tags=['scalar', 'integer'])
     def scalar1(run, run_nr: 'meta#run_number'):
@@ -78,6 +78,16 @@ def mock_ctx():
     def image(run, run_nr: 'meta#run_number'):
         if run_nr in (1, 1000):
             return np.random.rand(10, 10)
+
+    @Variable(title="Array preview")
+    def array_preview(run):
+        arr = np.zeros((5, 5, 5))
+        return Cell(arr, preview=arr[0])
+
+    @Variable(title="Plotly preview")
+    def plotly_preview(run):
+        fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
+        return Cell(np.zeros(4), preview=fig)
     """
 
     return mkcontext(code)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,6 +143,17 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     json_str = rv["plotly_mc_plotface"].read(deserialize_plotly=False)
     assert isinstance(json_str, str)
 
+    arr = rv["array_preview"].preview()
+    assert isinstance(arr, np.ndarray)
+    assert arr.ndim == 2
+
+    arr = rv["image"].preview()  # Implicit preview for 2D array
+    assert isinstance(arr, np.ndarray)
+    assert arr.ndim == 2
+
+    fig = rv["plotly_preview"].preview()
+    assert isinstance(fig, PlotlyFigure)
+
 def test_api_dependencies(venv):
     package_path = Path(__file__).parent.parent
     venv.install(package_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,15 +143,17 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     json_str = rv["plotly_mc_plotface"].read(deserialize_plotly=False)
     assert isinstance(json_str, str)
 
-    arr = rv["array_preview"].preview()
+    arr = rv["array_preview"].preview_data()
     assert isinstance(arr, np.ndarray)
     assert arr.ndim == 2
 
-    arr = rv["image"].preview()  # Implicit preview for 2D array
+    arr = rv["image"].preview_data()  # Implicit preview for 2D array
     assert isinstance(arr, np.ndarray)
     assert arr.ndim == 2
 
-    fig = rv["plotly_preview"].preview()
+    assert rv["image"].preview_data(data_fallback=False) is None
+
+    fig = rv["plotly_preview"].preview_data()
     assert isinstance(fig, PlotlyFigure)
 
 def test_api_dependencies(venv):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -6,6 +6,7 @@ import numpy as np
 import plotly.express as px
 import pytest
 import xarray as xr
+from matplotlib.image import AxesImage
 from plotly.graph_objects import Figure as PlotlyFigure
 
 from damnit import Damnit, RunVariables
@@ -152,6 +153,8 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     assert arr.ndim == 2
 
     assert rv["image"].preview_data(data_fallback=False) is None
+
+    assert isinstance(rv["image"].preview(), AxesImage)
 
     fig = rv["plotly_preview"].preview_data()
     assert isinstance(fig, PlotlyFigure)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -103,7 +103,13 @@ def test_context_file(mock_ctx, tmp_path):
     assert { "array", "timestamp" } == var_deps("meta_array")
 
     # Check that the ordering is correct for execution
-    assert mock_ctx.ordered_vars() == ("scalar1", "empty_string", "timestamp", "string", "plotly_mc_plotface", "results", "image", "scalar2", "array", "meta_array")
+    assert mock_ctx.ordered_vars() == (
+        # First everything without dependencies, in definition order
+        "scalar1", "empty_string", "timestamp", "string", "plotly_mc_plotface",
+        "results", "image", "array_preview", "plotly_preview",
+        # Then the dependencies
+        "scalar2", "array", "meta_array"
+    )
 
     # Check that we can retrieve direct and indirect dependencies
     assert set() == all_var_deps("scalar1")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -30,6 +30,7 @@ from damnit.gui.table_filter import (CategoricalFilter,
                                      CategoricalFilterWidget, ThumbnailFilterWidget, FilterMenu,
                                      NumericFilter, NumericFilterWidget, ThumbnailFilter)
 from damnit.gui.theme import Theme
+from damnit.gui.web_viewer import PlotlyPlot
 from damnit.gui.zulip_messenger import ZulipConfig
 
 from .helpers import extract_mock_run, mkcontext, reduced_data_from_dict
@@ -810,6 +811,13 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, 
     with patch.object(QMessageBox, "warning") as warning:
         win.inspect_data(complex_xr_1d)
         warning.assert_called_once()
+
+    # Check that objects with a preview are inspectable
+    plotly_preview = get_index('Plotly preview')
+    n_plots_before = len(win._canvas_inspect)
+    win.inspect_data(plotly_preview)
+    assert len(win._canvas_inspect) == n_plots_before + 1
+    assert isinstance(win._canvas_inspect[-1], PlotlyPlot)
 
     assert isinstance(  # Errors evaluating variables get a coloured decoration
         win.table.data(get_index('error'), role=Qt.DecorationRole), QColor


### PR DESCRIPTION
This adds another layer of partially reduced data between `data` and `summary`. Summary values are shown directly within the table cells, whereas preview data is shown when you double click. This is meant to get rid of the common pattern of paired columns, with one for data and one for a diagnostic plot. Preview can be given a 1D or 2D array, or a matplotlib/plotly figure. For simple cases, arrays are nice because the plot in the GUI can be zoomed, whereas mpl figures are saved as a static image.

Previews can be provided via `Cell`:

```python
# Option 1: within the variable function
@Variable()
def spectra(run):
    ...
    return Cell(spectra_arr, preview=spectra_arr.mean(dim=('trainId', 'pulseId'))
```

The preview function currently only gets the main result from the variable function. We could give it the run, and we could allow it to depend on other variables, but I kept it simple for now.

If a preview is provided and a summary (value or reduction function) isn't, a thumbnail of the preview is used for the summary. While working on this, I added thumbnails for 1D arrays, generating a small line plot. The thumbnail popup is not the prettiest, but I think it's useful to see these in the table, especially as rendering a line plot to an RGB image and shrinking it down to a thumbnail is almost impossible to see.

E.g. (first column & tooltip from 1D arrays, second column from matplotlib figures):

![Screenshot From 2025-04-02 16-13-35](https://github.com/user-attachments/assets/6f960bda-0bf3-460c-9d20-634e1b4fd2c7)

And here's the same data in a plot window from double clicking:

![Screenshot From 2025-04-02 16-13-50](https://github.com/user-attachments/assets/d2a84dfd-9d4d-408f-a488-3695a317bd43)



