### PR TITLE
Bump version

### DIFF
--- a/damnit/__init__.py
+++ b/damnit/__init__.py
@@ -1,5 +1,5 @@
 """Prototype for extracting and showing metadata (AMORE project)"""
 
-__version__ = '0.1.4'
+__version__ = '0.2.0'
 
 from .api import Damnit, RunVariables, VariableData

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## [0.1.5]
 
 Added:
 
@@ -17,6 +17,8 @@ Added:
   ranges and a line plot to visualize the data distribution (!400).
 - It's now possible to specify the number of runs that will be processed
   concurrently with the `concurrent_jobs` database setting (!408).
+- The variables list in the reprocessing dialog is now searchable (!380).
+- Errors from executing variables are displayed as tooltips on table cells (!416).
 
 Changed:
 
@@ -44,6 +46,8 @@ Fixed:
 
 Deprecated:
 - GUI: Standalone comments are no longer supported in the run table(!362).
+
+[Full Changelog](https://github.com/European-XFEL/DAMNIT/compare/0.1.4...0.1.5)
 
 ## [0.1.4]
 
@@ -194,6 +198,7 @@ Fixed:
 [Full Changelog](https://github.com/European-XFEL/DAMNIT/commits/0.1)
 
 
+[0.1.4]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.5
 [0.1.4]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.4
 [0.1.3]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.3
 [0.1.2]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.2

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.1.5]
+## [0.2]
 
 Added:
 
@@ -19,6 +19,9 @@ Added:
   concurrently with the `concurrent_jobs` database setting (!408).
 - The variables list in the reprocessing dialog is now searchable (!380).
 - Errors from executing variables are displayed as tooltips on table cells (!416).
+- Store & show preview data as well as summary value (!431).
+- GUI: LogViewWindow udpates when new lines are added to the log file (!434).
+- GUI: add toggle for plotting 2d data as lines (!449).
 
 Changed:
 
@@ -47,7 +50,7 @@ Fixed:
 Deprecated:
 - GUI: Standalone comments are no longer supported in the run table(!362).
 
-[Full Changelog](https://github.com/European-XFEL/DAMNIT/compare/0.1.4...0.1.5)
+[Full Changelog](https://github.com/European-XFEL/DAMNIT/compare/0.1.4...0.2)
 
 ## [0.1.4]
 
@@ -198,7 +201,7 @@ Fixed:
 [Full Changelog](https://github.com/European-XFEL/DAMNIT/commits/0.1)
 
 
-[0.1.4]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.5
+[0.2]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.2
 [0.1.4]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.4
 [0.1.3]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.3
 [0.1.2]: https://github.com/European-XFEL/DAMNIT/releases/tag/0.1.2


### PR DESCRIPTION
I would like this because currently the `.errors` entries are showing up when users call `run_vars.keys()`.