### PR TITLE
fix: prevent the gui to crash if there are no selected rows in the table

### DIFF
--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -322,7 +322,11 @@ class TableView(QtWidgets.QTableView):
         try:
             row = self.selected_rows()[0].row()
         except IndexError:
-            # not sure how this happens but it does
+            self.damnit_model._main_window.show_status_message(
+                "No row selected",
+                timeout=7000,
+                stylesheet=StatusbarStylesheet.ERROR
+            )
             return
         prop, run = self.damnit_model.row_to_proposal_run(row)
         self.log_view_requested.emit(prop, run)

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -319,7 +319,11 @@ class TableView(QtWidgets.QTableView):
 
     def show_run_logs(self):
         # Get first selected row
-        row = self.selected_rows()[0].row()
+        try:
+            row = self.selected_rows()[0].row()
+        except IndexError:
+            # not sure how this happens but it does
+            return
         prop, run = self.damnit_model.row_to_proposal_run(row)
         self.log_view_requested.emit(prop, run)
 


### PR DESCRIPTION
@philsmt reported this in zulip some while ago, and it has happened to me this week as well.
So we just catch the error here to prevent the gui to crash when we right click on a row (to reprocess/view logs).