### PR TITLE
Allow variable functions to return Cell(data=None)

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -324,7 +324,7 @@ class RunVariables:
         titles_to_names = { title: name for name, title in names_to_titles.items() }
 
         if name not in key_locs and name not in titles_to_names:
-            raise KeyError(f"Variable data for '{name!r}' not found for p{self.proposal}, r{self.run}")
+            raise KeyError(f"Variable data for {name!r} not found for p{self.proposal}, r{self.run}")
 
         if name in titles_to_names:
             name = titles_to_names[name]
@@ -339,6 +339,10 @@ class RunVariables:
         with h5py.File(self.file) as f:
             all_keys = { name: False for name in f.keys()
                          if not name.startswith('.')}
+
+            # Add keys with summary but not data in file
+            all_keys.update({ name: False for name in f['.reduced'].keys()
+                              if name not in all_keys})
 
         # And the keys from the database
         user_vars = list(self._db.get_user_variables().keys())

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -106,6 +106,27 @@ class Variable:
         """
         return getattr(self.func, '__annotations__', {})
 
+    def evaluate(self, run_data, kwargs):
+        cell = self.func(run_data, **kwargs)
+
+        if self.transient:
+            if not isinstance(cell, Cell):
+                cell = _DummyCell(cell)
+        else:
+            if not isinstance(cell, Cell):
+                cell = Cell(cell)
+
+            if cell.summary is None:
+                cell.summary = self.summary
+
+        return cell
+
+
+class _DummyCell:
+    """For transient results, holds data with no type checks"""
+    def __init__(self, data):
+        self.data = data
+
 
 class Cell:
     """A container for data with customizable table display options.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -103,6 +103,10 @@ def test_variable_data(mock_db_with_data, monkeypatch):
             "bar/baz": xr.DataArray([1+2j, 3-4j, 5+6j]),
         })
         return Cell(data, summary_value=data['bar/baz'][2])
+
+    @Variable(title="Summary only")
+    def summary_only(run):
+        return Cell(None, summary_value=7)
     """
     (db_dir / "context.py").write_text(dedent(dataset_code))
     extract_mock_run(1)
@@ -158,6 +162,8 @@ def test_variable_data(mock_db_with_data, monkeypatch):
 
     fig = rv["plotly_preview"].preview_data()
     assert isinstance(fig, PlotlyFigure)
+
+    assert rv["summary_only"].summary() == 7
 
 def test_api_dependencies(venv):
     package_path = Path(__file__).parent.parent

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -318,7 +318,8 @@ def test_results(mock_ctx, mock_run, caplog, tmp_path):
         assert caplog.records[0].levelname == "WARNING"
 
         # There should be no computed variables since we treat None as a missing dependency
-        assert tuple(results.cells.keys()) == ("start_time",)
+        assert set(results.cells.keys()) == {"start_time", "foo"}
+        assert results.cells['foo'].data is None
 
     default_value_code = """
     from damnit_ctx import Variable
@@ -1187,4 +1188,3 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
         "SELECT attributes FROM run_variables WHERE name='var4'"
     ).fetchone()[0]
     assert json.loads(attrs) == {"error": "\ndependency (var3) failed: ZeroDivisionError('division by zero')", "error_cls": "Exception"}
-


### PR DESCRIPTION
`return Cell(None)` caused a crash when saving the results. We decided this should be allowed, and it should be possible to store preview & summary without actual data. This needed a tweak to the API so it can still access such variables: `.read()` will get the summary value, like it does for user-editable variables.

For executing the context file, `return Cell(None)` has the same effect as `return None`: dependent variables will either be skipped, or use a default value if one is given.