### PR TITLE
Prevent editing in empty table cells

### DIFF
--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -860,6 +860,17 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         item = self.item(row, col)
         return item.data(Qt.UserRole) if item is not None else None
 
+    # QStandardItemModel assumes empty cells (no item) can be edited, regardless
+    # of itemPrototype. This override prevents editing empty cells.
+    def flags(self, model_index):
+        # Not using itemFromIndex() here, as it creates & inserts items
+        if model_index.isValid() and model_index.model() is self:
+            itm = self.item(model_index.row(), model_index.column())
+            if itm is not None:
+                return itm.flags()
+
+        return Qt.ItemIsSelectable | Qt.ItemIsEnabled | Qt.ItemIsDragEnabled |Qt.ItemIsDropEnabled
+
     def setData(self, index, value, role=None) -> bool:
         if not index.isValid():
             return False


### PR DESCRIPTION
This fixes a bug @CammilleCC noticed, where empty cells in the DAMNIT table are unexpectedly editable, and trying to accept the edit (e.g. by pressing enter) crashes the GUI.

I thought this would be a fairly quick and easy thing to fix. It was not. I'm still not sure this is the best way to fix it, but it appears to work.

The issue, as I understand it, is that QStandardItemModel claims - via its `.flags()` method - that any cell without an item already present is editable; because without subclassing it will just create a new QStandardItem on demand to store the newly entered text. We would like cells with no item to be non-editable by default. The fix in this PR should do the same as the original where an item exists, but only override the fallback.

A simpler alternative would be to use `self.itemFromIndex(model_index).flags()` in the same override, but that creates additional QStandardItems and inserts them in the table, so I went for a slightly more verbose version. :shrug: 
