### PR TITLE
fix: do not compute summary if data is None

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -231,7 +231,7 @@ class Cell:
     def get_summary(self):
         if self.summary_value is not None:
             return self.summary_value
-        elif self.summary is not None:
+        elif (self.data is not None) and (self.summary is not None):
             try:
                 return np.asarray(getattr(np, self.summary)(self.data))
             except Exception:


### PR DESCRIPTION
#448 now wraps all processed data in a cell, even if a variable returns None. the problem is that it would trying to compute a summary on `None` data, which can lead to unexpected summary values even if most case would just fail (e.g. `np.size` returns 1).

This PR prevents computing a summary value if the data is None.