### PR TITLE
Update the default `context_python` for the 202502 environment

### DIFF
--- a/damnit/backend/supervisord.py
+++ b/damnit/backend/supervisord.py
@@ -157,7 +157,7 @@ def initialize_and_start_backend(root_path, proposal=None, context_file_src=None
         # Initialize database
         db = DamnitDB.from_dir(root_path)
         db.metameta["proposal"] = proposal
-        db.metameta["context_python"] = "/gpfs/exfel/sw/software/mambaforge/22.11/envs/202501/bin/python"
+        db.metameta["context_python"] = "/gpfs/exfel/sw/software/euxfel-environment-management/environments/202502/.pixi/envs/default/bin/python"
     else:
         # Otherwise, load the proposal number
         db = DamnitDB.from_dir(root_path)


### PR DESCRIPTION
Tested by changing the environment of a database and reprocessing some variables.