### PR TITLE
Fix some warnings about pandas deprecations

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -26,7 +26,7 @@ from ..backend.db import DamnitDB, MsgKind, ReducedData, db_path
 from ..backend.extraction_control import ExtractionSubmitter, process_log_path
 from ..backend.user_variables import UserEditableVariable
 from ..definitions import UPDATE_BROKERS
-from ..util import fix_data_for_plotting, isinstance_no_import
+from ..util import isinstance_no_import
 from .editor import ContextTestResult, Editor, SaveConflictDialog
 from .kafka import UpdateAgent
 from .new_context_dialog import NewContextFileDialog
@@ -677,9 +677,11 @@ da-dev@xfel.eu"""
                         self, f"Can't inspect variable {quantity}", str(exc))
                     return
             else:
+                if data.dtype == np.bool_:
+                    data = data.astype(np.float64)
                 canvas = ScatterPlotWindow(self,
                     x=[np.arange(len(data))],
-                    y=[fix_data_for_plotting(data)],
+                    y=[data],
                     xlabel=f"Event (run {run})",
                     ylabel=quantity_title,
                     title=title,

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -955,7 +955,7 @@ da-dev@xfel.eu"""
         df = self.table.dataframe_for_export(columns, selected_rows, drop_image_cols=True)
         df.sort_values('Run', axis=0, inplace=True)
 
-        df = df.applymap(prettify_notation)
+        df = df.map(prettify_notation)
         df.replace(["None", '<NA>', 'nan'], '', inplace=True)
         self.zulip_messenger.send_table(df)
 

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -15,22 +15,6 @@ def timestamp2str(timestamp):
     return dt_local.strftime("%H:%M:%S %d/%m/%Y")
 
 
-def make_finite(data):
-    if not isinstance(data, pd.Series):
-        data = pd.Series(data)
-    return data.astype('object').fillna(np.nan)
-
-
-def bool_to_numeric(data):
-    if infer_dtype(data) == 'boolean':
-        data = data.astype('float')
-    return data
-
-
-def fix_data_for_plotting(data):
-    return bool_to_numeric(make_finite(data))
-
-
 def isinstance_no_import(obj, mod: str, cls: str):
     """Check if isinstance(obj, mod.cls) without loading mod"""
     m = sys.modules.get(mod)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "h5py",
     "numpy",
     "orjson",  # used in plotly for faster json serialization
-    "pandas",
+    "pandas >=2.1.0",
     "plotly",
     "xarray"
 ]


### PR DESCRIPTION
- `df.applymap()` was renamed to `.map()` in pandas 2.1.
- The `make_finite` function raised a warning about `.fillna()` downcasting from object dtype. It's not very clear what this is doing - it doesn't get rid of infinities in the data - and it's now only used in one place, so I've simplified the code a bit.