### PR TITLE
feat: dependency pattern matching annotation

### DIFF
--- a/docs/backend.md
+++ b/docs/backend.md
@@ -111,6 +111,25 @@ def bar(run, value: "var#foo"):
     return value * 2
 ```
 
+Pattern matching using unix shell-style
+[wildcards](https://docs.python.org/3/library/fnmatch.html) is allowed in `var#`
+annotations. In such case, a `dict` is returned where keys are the name of
+matching dependencies and values are their results:
+```python
+@Variable()
+def base_1(run):
+    return 1
+
+@Variable()
+def base_2(run):
+    return 2
+
+@Variable()
+def sum_values(run, data: 'var#base_?'):
+    # data is a dict
+    return sum(data.values())
+```
+
 Dependents are not executed if a variable raises an error or returns `None`. You
 can raise `Skip` to provide a reason, which will be visible as a tooltip on the
 table cell in the GUI:

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1230,6 +1230,11 @@ def test_pattern_matching_dependency(mock_run):
         return ','.join(sorted(data.keys()))
 
     @Variable()
+    def res3(run, data: 'var#bar?'):
+        # no match on data, this variable won't execute
+        return 1
+
+    @Variable()
     def var1(run):
         return 7
 
@@ -1253,3 +1258,4 @@ def test_pattern_matching_dependency(mock_run):
         print(f'{k=}:{v.data}')
     assert results.cells['res1'].data.tolist() == [175, 3]
     assert results.cells['res2'].data == 'var1,var10,var2,var3'
+    assert 'res3' not in results.cells

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -1213,3 +1213,43 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
         "SELECT attributes FROM run_variables WHERE name='var4'"
     ).fetchone()[0]
     assert json.loads(attrs) == {"error": "\ndependency (var3) failed: ZeroDivisionError('division by zero')", "error_cls": "Exception"}
+
+
+def test_pattern_matching_dependency(mock_run):
+    ctx_code = """
+    from damnit_ctx import Variable
+    import numpy as np
+
+    @Variable()
+    def res1(run, data: 'var#var?'):
+        result = data['var1'] + data['var2'].sum() + data['var3'].sum()
+        return [result, len(data)]
+
+    @Variable()
+    def res2(run, data: 'var#var*'):
+        return ','.join(sorted(data.keys()))
+
+    @Variable()
+    def var1(run):
+        return 7
+
+    @Variable()
+    def var2(run, data: 'var#var1'):
+        # transient vars can return any data type
+        return np.arange(data)
+
+    @Variable()
+    def var3(run, data: 'var#var2'):
+        return data.size * data
+
+    @Variable()
+    def var10(run):
+        return 10
+    """
+    ctx = mkcontext(ctx_code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+
+    for k, v in results.cells.items():
+        print(f'{k=}:{v.data}')
+    assert results.cells['res1'].data.tolist() == [175, 3]
+    assert results.cells['res2'].data == 'var1,var10,var2,var3'


### PR DESCRIPTION
Allow unix shell style pattern matching in variable dependency annotation to match multiple deps, e.g.

```python3
@Variable()
def my_var(run, data: 'var#xgm_[123]'):
    # data is a dict[str, Any] where the keys are dependency names
    return sum(data.values())
```