### PR TITLE
Fix mkdocs config for mkdocstrings 1.0

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,7 +66,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          import:
+          inventories:
           - https://docs.python.org/3/objects.inv
           - https://pandas.pydata.org/docs/objects.inv
           options:


### PR DESCRIPTION
To fix [broken](https://app.readthedocs.org/projects/damnit/builds/30490797/) docs build.