### PR TITLE
Add support for `--no-kafka` to `damnit read-context`

### DIFF
--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -198,6 +198,10 @@ def main(argv=None):
         'read-context',
         help="Re-read the context file and update variables in the database"
     )
+    readctx_ap.add_argument(
+        '--no-kafka', action='store_true',
+        help="Don't try connecting to XFEL's Kafka broker"
+    )
 
     proposal_ap = subparsers.add_parser(
         'proposal',
@@ -342,7 +346,7 @@ def main(argv=None):
 
     elif args.subcmd == 'read-context':
         from .backend.extract_data import Extractor
-        Extractor().update_db_vars()
+        Extractor(connect_to_kafka=not args.no_kafka).update_db_vars()
 
     elif args.subcmd == 'proposal':
         from .backend.db import DamnitDB

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -301,7 +301,10 @@ da-dev@xfel.eu"""
         proc.setProcessChannelMode(QtCore.QProcess.ProcessChannelMode.ForwardedChannels)
         proc.finished.connect(proc.deleteLater)
         proc.setWorkingDirectory(str(self.context_dir))
-        proc.start(sys.executable, ['-m', 'damnit.cli', 'read-context'])
+        read_context_args = ['-m', 'damnit.cli', 'read-context']
+        if not self._connect_to_kafka:
+            read_context_args.append("--no-kafka")
+        proc.start(sys.executable, read_context_args)
         proc.closeWriteChannel()
         # The subprocess will send updates for any changes: see .handle_update()
 


### PR DESCRIPTION
This is also supported by the GUI now, so if the GUI is started with `--no-kafka` the command it spawns will pass that as well.