### PR TITLE
Rename 'GUI' to 'Getting started' and remove old web section

### DIFF
--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -35,7 +35,7 @@ these arguments:
 
 - `title` (string): title displayed for the variable's column. Titles can
   include `/` separators to build hierarchical column headers in the
-  [GUI](gui.md#exploring-variables).
+  [GUI](getting-started.md#exploring-variables).
 - `tags` (string or list of strings): tags to categorize and filter variables.
   Tags can be used to group related variables and filter the table view:
   ```python

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,4 +1,4 @@
-# GUI
+# Getting started
 
 ## Open the GUI
 
@@ -7,6 +7,8 @@
     make it easier for folks to use DAMNIT. It's not feature complete yet, but
     if you'd like to give it a try you can check it out here:
     https://damnit.xfel.eu
+
+    ![](static/damnit-web.png)
 
 1. Start by opening a [FastX](https://max-exfl-display.desy.de:3389) XFCE
    session. You can also SSH to `max-exfl-display.desy.de` with X forwarding
@@ -173,13 +175,3 @@ All the data in the run table can be exported to an Excel/CSV file, with the
 caveat that images will not be exported (they'll be replaced with an `<image>`
 string):
 ![](static/export.gif)
-
-## Experimental: the web interface
-To make accessing the GUI easier we're working on a web interface to replace the
-current PyQt GUI. This is still very much in beta, but if you're feeling brave
-you can try it out through this link: https://damnit-dev.xfel.eu/
-![](static/damnit-web.png)
-
-Currently it can only be accessed within our internal network so you'll need to
-have a VPN or proxy set up. Note that not all features have been ported from the
-PyQt GUI yet.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,11 +17,11 @@ application where you'll see this name used instead of DAMNIT.
 
 ## Design overview
 There are two parts to DAMNIT: the frontend GUI and the backend. The GUI is
-currently written in PyQt and will be moved to a [web
-interface](gui.md#experimental-the-web-interface) at some point. The backend is
-a service that runs on XFEL's offline cluster for each proposal, so one instance
-of the backend for one proposal is completely separate from any others and can
-be started by any user.
+currently written in PyQt but we're in the process of moving to a [web
+interface](getting-started.md#open-the-gui). The backend is a service that runs
+on XFEL's offline cluster for each proposal, so one instance of the backend for
+one proposal is completely separate from any others and can be started by any
+user.
 
 To fill up the table you see in the screenshot above, the backend executes what
 we call a *context file*, which is simply a Python file that contains *variable*
@@ -29,7 +29,7 @@ definitions. A *variable* in DAMNIT is a 'thing' that you want to track during
 the experiment, and the values for each variable for each run can either be
 generated automatically [from the context
 file](configuration_and_management.md), or entered manually [into the
-GUI](gui.md#adding-user-editable-variables).
+GUI](getting-started.md#adding-user-editable-variables).
 
 When a new run is taken, the files are migrated from the online cluster to the
 offline cluster and this triggers the backend to execute any variables in the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -54,7 +54,7 @@ markdown_extensions:
 # Navigation menu order
 nav:
   - index.md
-  - gui.md
+  - getting-started.md
   - configuration_and_management.md
   - api.md
   - internals.md


### PR DESCRIPTION
Not sure how I missed that there was already a section about the web interface :facepalm: It was out of date anyway so I just deleted it.

The rename is because 'getting started' feels more descriptive of the content, and because people will likely recognize that phrase more than just 'GUI'. Renaming the file itself does have the downside of breaking links but I don't think that matters very much for this.