### PR TITLE
FEAT(backend/GUI): Sparklines

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import h5py
 import numpy as np
 
-from .backend.db import BlobTypes, DamnitDB, blob2complex
+from .backend.db import BlobTypes, DamnitDB, blob2complex, blob2numpy
 from .util import isinstance_no_import
 
 
@@ -163,8 +163,13 @@ class VariableData:
             raise RuntimeError(f"Could not find value for '{self.name}' in p{self.proposal}, r{self.name}")
         else:
             value, summary_type, version = result
-            if isinstance(value, bytes) and summary_type == "complex":
-                return blob2complex(value)
+            if isinstance(value, bytes):
+                if summary_type == "complex":
+                    return blob2complex(value)
+                if summary_type in ("numpy", "trendline"):
+                    return blob2numpy(value)
+                if BlobTypes.identify(value) is BlobTypes.numpy:
+                    return blob2numpy(value)
             return value
 
     def preview_data(self, *, data_fallback=True, deserialize_plotly=True):

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -1,10 +1,11 @@
+import io
 import json
 import logging
 import os
 import shutil
 import sqlite3
-import sys
 import struct
+import sys
 from collections.abc import ItemsView, MutableMapping, ValuesView
 from dataclasses import asdict, dataclass
 from datetime import datetime, timezone
@@ -12,6 +13,8 @@ from enum import Enum
 from pathlib import Path
 from secrets import token_hex
 from typing import Any, Optional
+
+import numpy as np
 
 from ..definitions import UPDATE_TOPIC, DEFAULT_CONTEXT_PYTHON
 from .db_migrations import apply_migrations, latest_version
@@ -68,6 +71,19 @@ def blob2complex(data: bytes) -> complex:
     # convert bytes to complex
     real, imag = struct.unpack('<dd', data)
     return complex(real, imag)
+
+
+def numpy2blob(arr: np.ndarray) -> bytes:
+    """Serialize a numpy array into .npy bytes for SQLite storage."""
+    buff = io.BytesIO()
+    np.save(buff, arr, allow_pickle=False)
+    return buff.getvalue()
+
+
+def blob2numpy(data: bytes) -> np.ndarray:
+    """Deserialize .npy bytes from SQLite into a numpy array."""
+    buff = io.BytesIO(data)
+    return np.load(buff, allow_pickle=False)
 
 
 def db_path(root_path: Path):
@@ -325,6 +341,12 @@ class DamnitDB:
         elif isinstance(variable["value"], complex):
             variable["value"] = complex2blob(variable["value"])
             variable["summary_type"] = "complex"
+        elif isinstance(variable["value"], np.ndarray):
+            if variable["value"].dtype.hasobject:
+                raise TypeError("Unsupported array dtype for database storage")
+            variable["value"] = numpy2blob(variable["value"])
+            if variable["summary_type"] in (None, ""):
+                variable["summary_type"] = "numpy"
 
         variable["proposal"] = proposal
         variable["run"] = run

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -294,21 +294,11 @@ class RunExtractor(Extractor):
         add_to_db(reduced_data, self.db, self.proposal, self.run)
 
         # Send all the updates for scalars
-        image_values = { name: reduced for name, reduced in reduced_data.items()
-                         if isinstance(reduced.value, bytes) }
         update_msg = msg_dict(MsgKind.run_values_updated, {
             'run': self.run, 'proposal': self.proposal, 'values': {
-                name: reduced.value for name, reduced in reduced_data.items()
-                if name not in image_values
-            }
-        })
+                name: None for name, _ in reduced_data.items()
+            }})
         self.kafka_prd.send(self.db.kafka_topic, update_msg).get(timeout=30)
-
-        # And each image update separately so we don't hit any size limits
-        for name, reduced in image_values.items():
-            update_msg = msg_dict(MsgKind.run_values_updated, {
-                'run': self.run, 'proposal': self.proposal, 'values': { name: reduced.value }})
-            self.kafka_prd.send(self.db.kafka_topic, update_msg).get(timeout=30)
 
         log.info("Sent Kafka updates to topic %r", self.db.kafka_topic)
 

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -97,7 +97,7 @@ def load_reduced_data(h5_path):
     def get_attrs(ds):
         d = {}
         for name, value in ds.attrs.items():
-            if name in {"max_diff", "summary_method"}:
+            if name in {"max_diff", "summary_method", "summary_type"}:
                 continue  # These are stored separately
 
             if isinstance(value, np.ndarray):
@@ -113,6 +113,7 @@ def load_reduced_data(h5_path):
                 get_dset_value(dset),
                 max_diff=dset.attrs.get("max_diff", np.array(None)).item(),
                 summary_method=dset.attrs.get("summary_method", ""),
+                summary_type=dset.attrs.get("summary_type"),
                 attributes=get_attrs(dset),
             )
             for name, dset in f['.reduced'].items()
@@ -123,6 +124,7 @@ def load_reduced_data(h5_path):
             })
             for name, dset in f['.errors'].items()
         }
+
 
 def add_to_db(reduced_data, db: DamnitDB, proposal, run):
     db.ensure_run(proposal, run)
@@ -144,7 +146,7 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run):
         db.ensure_run(proposal, run, start_time=start_time.value)
 
     for name, reduced in reduced_data.items():
-        if not isinstance(reduced.value, (int, float, str, bytes, complex, type(None))):
+        if not isinstance(reduced.value, (int, float, str, bytes, complex, np.ndarray, type(None))):
             raise TypeError(f"Unsupported type for database: {type(reduced.value)}")
 
         db.set_variable(proposal, run, name, reduced)

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -428,6 +428,42 @@ def line_thumbnail(arr):
     return figure2png(fig, dpi=THUMBNAIL_SIZE)
 
 
+def downsample_line(data):
+    from fpcs import downsample
+
+    if isinstance(data, xr.DataArray):
+        y = data.values
+        x = None
+        if data.dims:
+            dim = data.dims[0]
+            if dim in data.coords:
+                x = data.coords[dim].values
+        if x is None or np.shape(x) != np.shape(y):
+            x = np.arange(y.size)
+    else:
+        y = np.asarray(data)
+        x = np.arange(y.size)
+
+    if not np.issubdtype(x.dtype, np.number):
+        if np.issubdtype(x.dtype, np.datetime64):
+            x = x.astype("datetime64[ns]").astype("int64") / 1e9
+        else:
+            x = np.arange(y.shape[0])
+
+    x = x.astype(np.float64, copy=False)
+    y = y.astype(np.float64, copy=False)
+
+    if x.size == 0:
+        return np.empty((2, 0), dtype=np.float64)
+
+    # We aim to retain ~150 samples
+    # (TODO: rather save a ratio of the data with upper bound?)
+    # the fpcs algorithm retain ~1.25 point per sampling window
+    ratio = max(1, int(x.size / (0.8 * 150)))
+    xd, yd = downsample(x, y, ratio=ratio)
+    return np.vstack((xd, yd))
+
+
 def extract_error_info(exc_type, e, tb):
     lineno = -1
     offset = 0
@@ -540,10 +576,23 @@ class Results:
                 return data
             elif data.ndim == 1:
                 try:
-                    return line_thumbnail(data)
+                    return downsample_line(data)
+                except ModuleNotFoundError:
+                    logging.warning(
+                        'Downsampling library not found for trendline generation'
+                        ', falling back to thumbnail generation for %s', name
+                    )
+                    try:
+                        # fall back to generating thumbnail
+                        return line_thumbnail(data)
+                    except:
+                        logging.error(
+                            "Error generating thumbnail for %s", name, exc_info=True)
+                        return "<thumbnail error>"
                 except:
-                    logging.error("Error generating thumbnail for %s", name, exc_info=True)
-                    return "<thumbnail error>"
+                    logging.error(
+                        "Error generating trendline for %s", name, exc_info=True)
+                    return "<trendline error>"
             elif data.ndim == 2:
                 if isinstance(data, np.ndarray):
                     data = np.nan_to_num(data)
@@ -568,7 +617,11 @@ class Results:
 
         for name, cell in self.cells.items():
             summary_val = self.summarise(name)
-            dsets.append((f'.reduced/{name}', summary_val, cell.summary_attrs()))
+            summary_attrs = cell.summary_attrs()
+            if isinstance(summary_val, np.ndarray):
+                if summary_val.ndim == 2 and summary_val.shape[0] == 2:
+                    summary_attrs["summary_type"] = "trendline"
+            dsets.append((f'.reduced/{name}', summary_val, summary_attrs))
             dsets.append((f'.errors/{name}', None, {}))  # Delete any previous error
             if not reduced_only:
                 obj = cell.data

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -456,6 +456,14 @@ def downsample_line(data):
     if x.size == 0:
         return np.empty((2, 0), dtype=np.float64)
 
+    # ensure we have a monotonic increasing coordinates
+    if x.size > 1:
+        diffs = np.diff(x)
+        if not np.all(diffs >= 0):
+            order = np.argsort(x, kind="stable")
+            x = x[order]
+            y = y[order]
+
     # We aim to retain ~150 samples
     # (TODO: rather save a ratio of the data with upper bound?)
     # the fpcs algorithm retain ~1.25 point per sampling window

--- a/damnit/gui/kafka.py
+++ b/damnit/gui/kafka.py
@@ -42,13 +42,13 @@ class UpdateAgent(QtCore.QObject):
 
                     self.message.emit(unpickled_msg)
 
-    def run_values_updated(self, proposal, run, name, value):
+    def run_values_updated(self, proposal, run, name):
         message = msg_dict(MsgKind.run_values_updated,
                            {
                                "proposal": proposal,
                                "run": run,
                                "values": {
-                                   name: value
+                                   name: None
                                }
                            })
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -578,21 +578,6 @@ da-dev@xfel.eu"""
                 f"Getting updates ({self.db_id})"
             )
 
-        if 'msg_kind' not in message:
-            # Old message format. Temporarily handled so GUIs with new code can
-            # work with listeners with older code, but can be removed soon.
-            message = message.copy()
-            proposal = message.pop("Proposal")
-            run = message.pop("Run")
-            message = {
-                'msg_kind': MsgKind.run_values_updated.value,
-                'data': {
-                    'proposal': proposal,
-                    'run': run,
-                    'values': message
-                }
-            }
-
         msg_kind = MsgKind(message['msg_kind'])
         data = message['data']
         if msg_kind == MsgKind.run_values_updated:
@@ -972,7 +957,7 @@ da-dev@xfel.eu"""
         log.debug("Saving data for variable %s for prop %d run %d", name, prop, run)
         self.db.set_variable(prop, run, name, ReducedData(value))
         if self._connect_to_kafka:
-            self.update_agent.run_values_updated(prop, run, name, value)
+            self.update_agent.run_values_updated(prop, run, name)
 
     def check_zulip_messenger(self):
         if not isinstance(self.zulip_messenger, ZulipMessenger):

--- a/damnit/gui/roles.py
+++ b/damnit/gui/roles.py
@@ -1,0 +1,4 @@
+from PyQt5.QtCore import Qt
+
+# Custom item data roles used across the GUI.
+LINE_DATA_ROLE = Qt.UserRole + 1

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -359,6 +359,7 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
         if arr is None:
             return super().paint(painter, option, index)
 
+        # Base item rendering (selection background, etc.)
         opt = QtWidgets.QStyleOptionViewItem(option)
         self.initStyleOption(opt, index)
         opt.text = ""
@@ -366,10 +367,12 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
         style = opt.widget.style() if opt.widget else QtWidgets.QApplication.style()
         style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, opt, painter, opt.widget)
 
+        # Pixel bounds for the sparkline drawing area.
         rect = opt.rect.adjusted(2, 2, -2, -2)
         if rect.width() < 4 or rect.height() < 4:
             return
 
+        # Validate/prepare data.
         if arr.ndim != 2 or arr.shape[0] != 2 or arr.shape[1] < 2:
             return
 
@@ -384,6 +387,7 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
         if x.size < 2:
             return
 
+        # Normalize data to [0,1] and map to pixel coordinates.
         x_min = float(np.nanmin(x))
         x_max = float(np.nanmax(x))
         y_min = float(np.nanmin(y))
@@ -405,14 +409,16 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
         x_pix = rect.left() + x_norm * (rect.width() - 1)
         y_pix = rect.top() + (1 - y_norm) * (rect.height() - 1)
 
+        # Build the polyline path.
         poly = QtGui.QPolygonF()
         for xi, yi in zip(x_pix, y_pix):
             poly.append(QtCore.QPointF(float(xi), float(yi)))
 
+        # Draw the sparkline.
         painter.save()
         painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
         line_color = QtGui.QColor(0, 120, 215)    # blue
-        hover_line_color = QtGui.QColor(0, 0, 0)  # black
+        hover_line_color = QtGui.QColor(181, 181, 181)  # gray
         text_color = QtGui.QColor(0, 0, 0)        # black
         dot_color = QtGui.QColor(220, 0, 0)       # red
         pen = QtGui.QPen(line_color)
@@ -420,41 +426,67 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
         painter.setPen(pen)
         painter.drawPolyline(poly)
 
+        # Hover overlay: snap to extrema if near, otherwise interpolate.
         view = opt.widget
         hover_index = view._sparkline_hover_index
         hover_t = view._sparkline_hover_t
         if hover_index is not None and hover_t is not None and hover_index == index:
             x_line = rect.left() + hover_t * (rect.width() - 1)
+
+            snap_idx = None
+            if x.size >= 3:
+                extrema = []
+                for i in range(1, x.size - 1):
+                    if (y[i] >= y[i - 1] and y[i] >= y[i + 1]) or (
+                        y[i] <= y[i - 1] and y[i] <= y[i + 1]
+                    ):
+                        extrema.append(i)
+                if extrema:
+                    extrema = np.asarray(extrema, dtype=int)
+                    dists = np.abs(x_pix[extrema] - x_line)
+                    nearest = int(extrema[np.argmin(dists)])
+                    if dists.min() <= 6.0:
+                        snap_idx = nearest
+
+            if snap_idx is not None:
+                x_line = float(x_pix[snap_idx])
+                y_val = float(y[snap_idx])
+                y_marker = float(y_pix[snap_idx])
+            else:
+                try:
+                    if span_x == 0:
+                        y_val = float(np.nanmean(y))
+                    else:
+                        x_target = x_min + hover_t * span_x
+                        order = np.argsort(x)
+                        x_sorted = x[order]
+                        y_sorted = y[order]
+                        y_val = float(np.interp(x_target, x_sorted, y_sorted))
+                except Exception:
+                    y_val = None
+
+                if y_val is not None and np.isfinite(y_val):
+                    if span_y == 0:
+                        y_norm_val = 0.5
+                    else:
+                        y_norm_val = (y_val - y_min) / span_y
+                    y_norm_val = max(0.0, min(1.0, float(y_norm_val)))
+                    y_marker = rect.top() + (1 - y_norm_val) * (rect.height() - 1)
+                else:
+                    y_marker = None
+
             painter.setPen(QtGui.QPen(hover_line_color))
             painter.drawLine(QtCore.QPointF(x_line, rect.top()),
                              QtCore.QPointF(x_line, rect.bottom()))
 
-            try:
-                if span_x == 0:
-                    y_val = float(np.nanmean(y))
-                else:
-                    x_target = x_min + hover_t * span_x
-                    order = np.argsort(x)
-                    x_sorted = x[order]
-                    y_sorted = y[order]
-                    y_val = float(np.interp(x_target, x_sorted, y_sorted))
-            except Exception:
-                y_val = None
-
-            if y_val is not None and np.isfinite(y_val):
-                if span_y == 0:
-                    y_norm_val = 0.5
-                else:
-                    y_norm_val = (y_val - y_min) / span_y
-                y_norm_val = max(0.0, min(1.0, float(y_norm_val)))
-                y_marker = rect.top() + (1 - y_norm_val) * (rect.height() - 1)
+            # Marker + value label.
+            if y_val is not None and np.isfinite(y_val) and y_marker is not None:
                 painter.save()
                 painter.setBrush(dot_color)
                 painter.setPen(QtGui.QPen(dot_color))
                 painter.drawEllipse(QtCore.QPointF(x_line, y_marker), 2.5, 2.5)
                 painter.restore()
 
-            if y_val is not None and np.isfinite(y_val):
                 text = prettify_notation(y_val)
                 metrics = painter.fontMetrics()
                 text_w = metrics.horizontalAdvance(text)
@@ -575,6 +607,7 @@ class TableView(QtWidgets.QTableView):
         self.model_updated.emit()
 
     def _set_sparkline_hover(self, index, t):
+        self.setCursor(Qt.BlankCursor)
         old_index = self._sparkline_hover_index
         old_t = self._sparkline_hover_t
         if old_index == index and old_t == t:
@@ -587,6 +620,7 @@ class TableView(QtWidgets.QTableView):
             self.viewport().update(self.visualRect(index))
 
     def _clear_sparkline_hover(self):
+        self.setCursor(Qt.ArrowCursor)
         if not self._sparkline_hover_index.isValid():
             self._sparkline_hover_t = None
             return
@@ -1070,17 +1104,6 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         item = self.itemPrototype().clone()
         item.setData(line_data, role=LINE_DATA_ROLE)
         item.setData("", role=Qt.ItemDataRole.DisplayRole)
-        try:
-            y = np.asarray(line_data)[1]
-            finite = np.isfinite(y)
-            if finite.any():
-                y_min = np.nanmin(y[finite])
-                y_max = np.nanmax(y[finite])
-                item.setToolTip(
-                    f"Trendline: min={prettify_notation(y_min)}, max={prettify_notation(y_max)}"
-                )
-        except Exception:
-            pass
         return item
 
     def comment_item(self, text):

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -4,6 +4,7 @@ import time
 from base64 import b64encode
 from itertools import groupby
 
+import numpy as np
 from fonticon_fa6 import FA6S
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import QProcess, Qt
@@ -12,10 +13,11 @@ from PyQt5.QtWidgets import QAction, QMenu, QMessageBox
 from superqt.fonticon import icon
 from superqt.utils import qthrottled
 
-from ..backend.db import BlobTypes, DamnitDB, ReducedData, blob2complex
+from ..backend.db import BlobTypes, DamnitDB, ReducedData, blob2complex, blob2numpy
 from ..backend.extraction_control import ExtractionJobTracker
 from ..backend.user_variables import value_types_by_name
 from ..util import timestamp2str
+from .roles import LINE_DATA_ROLE
 from .table_filter import FilterMenu, FilterProxy, FilterStatus
 from .util import delete_variable, StatusbarStylesheet
 
@@ -351,6 +353,75 @@ class FilterHeaderView(QtWidgets.QHeaderView):
             parent.viewport().update()
 
 
+class SparklineDelegate(QtWidgets.QStyledItemDelegate):
+    def paint(self, painter, option, index):
+        arr = index.data(LINE_DATA_ROLE)
+        if arr is None:
+            return super().paint(painter, option, index)
+
+        opt = QtWidgets.QStyleOptionViewItem(option)
+        self.initStyleOption(opt, index)
+        opt.text = ""
+
+        style = opt.widget.style() if opt.widget else QtWidgets.QApplication.style()
+        style.drawControl(QtWidgets.QStyle.CE_ItemViewItem, opt, painter, opt.widget)
+
+        rect = opt.rect.adjusted(2, 2, -2, -2)
+        if rect.width() < 4 or rect.height() < 4:
+            return
+
+        if arr.ndim != 2 or arr.shape[0] != 2 or arr.shape[1] < 2:
+            return
+
+        x = np.asarray(arr[0], dtype=np.float64)
+        y = np.asarray(arr[1], dtype=np.float64)
+
+        finite = np.isfinite(x) & np.isfinite(y)
+        if not finite.any():
+            return
+        x = x[finite]
+        y = y[finite]
+        if x.size < 2:
+            return
+
+        x_min = float(np.nanmin(x))
+        x_max = float(np.nanmax(x))
+        y_min = float(np.nanmin(y))
+        y_max = float(np.nanmax(y))
+
+        span_x = x_max - x_min
+        span_y = y_max - y_min
+
+        if span_x == 0:
+            x_norm = np.linspace(0, 1, x.size)
+        else:
+            x_norm = (x - x_min) / span_x
+
+        if span_y == 0:
+            y_norm = np.full_like(y, 0.5)
+        else:
+            y_norm = (y - y_min) / span_y
+
+        x_pix = rect.left() + x_norm * (rect.width() - 1)
+        y_pix = rect.top() + (1 - y_norm) * (rect.height() - 1)
+
+        poly = QtGui.QPolygonF()
+        for xi, yi in zip(x_pix, y_pix):
+            poly.append(QtCore.QPointF(float(xi), float(yi)))
+
+        painter.save()
+        painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
+        if opt.state & QtWidgets.QStyle.State_Selected:
+            color = opt.palette.color(QtGui.QPalette.HighlightedText)
+        else:
+            color = opt.palette.color(QtGui.QPalette.Text)
+        pen = QtGui.QPen(color)
+        pen.setWidth(1)
+        painter.setPen(pen)
+        painter.drawPolyline(poly)
+        painter.restore()
+
+
 class TableView(QtWidgets.QTableView):
     settings_changed = QtCore.pyqtSignal()
     log_view_requested = QtCore.pyqtSignal(int, int)  # proposal, run
@@ -368,6 +439,7 @@ class TableView(QtWidgets.QTableView):
         )
 
         self.verticalHeader().setMinimumSectionSize(ROW_HEIGHT)
+        self.setItemDelegate(SparklineDelegate(self))
 
         # Add the widgets to be used in the column settings dialog
         self._columns_widget = QtWidgets.QListWidget()
@@ -893,6 +965,23 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         )
         return item
 
+    def line_item(self, line_data: np.ndarray):
+        item = self.itemPrototype().clone()
+        item.setData(line_data, role=LINE_DATA_ROLE)
+        item.setData("", role=Qt.ItemDataRole.DisplayRole)
+        try:
+            y = np.asarray(line_data)[1]
+            finite = np.isfinite(y)
+            if finite.any():
+                y_min = np.nanmin(y[finite])
+                y_max = np.nanmax(y[finite])
+                item.setToolTip(
+                    f"Trendline: min={prettify_notation(y_min)}, max={prettify_notation(y_max)}"
+                )
+        except Exception:
+            pass
+        return item
+
     def comment_item(self, text):
         item = self.text_item(text)
         item.setToolTip(text)
@@ -915,7 +1004,12 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         item.setData(QtGui.QColor(colour), Qt.ItemDataRole.DecorationRole)
         return item
 
-    def new_item(self, value, column_id, max_diff, attrs):
+    def new_item(self, value, column_id, max_diff, attrs, summary_type=None):
+        if summary_type == "trendline":
+            return self.line_item(blob2numpy(value))
+        if summary_type == "numpy":
+            arr = blob2numpy(value)
+            return self.text_item(f"{arr.dtype}: {arr.shape}")
         if is_png_bytes(value):
             return self.image_item(value)
         elif column_id == 'comment':
@@ -963,7 +1057,7 @@ class DamnitTableModel(QtGui.QStandardItemModel):
                 if summary_type == "complex":
                     value = blob2complex(value)
                 attrs = json.loads(attr_json) if attr_json else {}
-                self.setItem(row_ix, col_ix, self.new_item(value, name, max_diff, attrs))
+                self.setItem(row_ix, col_ix, self.new_item(value, name, max_diff, attrs, summary_type))
 
         self.setVerticalHeaderLabels(row_headers)
         t1 = time.perf_counter()
@@ -1049,16 +1143,21 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         self.column_index = {c: i for (i, c) in enumerate(self.column_ids)}
         super().removeColumn(column, parent)
 
-    def insert_run_row(self, proposal, run, contents: dict, max_diffs: dict, attrs: dict):
+    def insert_run_row(self, proposal, run, contents: dict, max_diffs: dict, attrs: dict, summary_types: dict = None):
         status_item = self.itemPrototype().clone()
         status_item.setCheckable(True)
         status_item.setCheckState(Qt.Checked)
         row = [status_item, self.text_item(proposal), self.text_item(run)]
 
+        summary_types = summary_types or {}
         for column_id in self.column_ids[3:]:
             if (value := contents.get(column_id, None)) is not None:
                 item = self.new_item(
-                    value, column_id, max_diffs.get(column_id) or 0, attrs.get(column_id) or {}
+                    value,
+                    column_id,
+                    max_diffs.get(column_id) or 0,
+                    attrs.get(column_id) or {},
+                    summary_types.get(column_id),
                 )
             elif column_id in self.editable_columns:
                 item = QtGui.QStandardItem()  # Editable by default
@@ -1086,25 +1185,33 @@ class DamnitTableModel(QtGui.QStandardItemModel):
         except KeyError:
             row_ix = None
 
+        data = {}
         max_diffs = {}
         attrs = {}
-        for name, max_diff, attr_json in self.db.conn.execute("""
-            SELECT name, max_diff, attributes FROM run_variables WHERE proposal=? AND run=?
+        summary_types = {}
+        for name, value, max_diff, summary_type, attr_json in self.db.conn.execute("""
+            SELECT name, value, max_diff, summary_type, attributes FROM run_variables WHERE proposal=? AND run=?
         """, (proposal, run)):
+            data[name] = value
             max_diffs[name] = max_diff
+            summary_types[name] = summary_type
             attrs[name] = json.loads(attr_json) if attr_json else {}
 
         col_id_to_ix = {c: i for (i, c) in enumerate(self.column_ids)}
 
         if row_ix is not None:
             log.debug("Update existing row %s for run %s", row_ix, run)
-            for column_id, value in values.items():
+            for column_id in values:
                 col_ix = col_id_to_ix[column_id]
                 self.setItem(row_ix, col_ix, self.new_item(
-                    value, column_id, max_diffs.get(column_id) or 0, attrs.get(column_id) or {}
+                    data.get(column_id),
+                    column_id,
+                    max_diffs.get(column_id) or 0,
+                    attrs.get(column_id) or {},
+                    summary_types.get(column_id),
                 ))
         else:
-            self.insert_run_row(proposal, run, values, max_diffs, attrs)
+            self.insert_run_row(proposal, run, data, max_diffs, attrs, summary_types)
 
     def handle_variable_set(self, var_info: dict):
         col_id = var_info['name']
@@ -1316,6 +1423,8 @@ class DamnitTableModel(QtGui.QStandardItemModel):
                     val = item and item.data(Qt.UserRole)
                     if val is None and item and item.data(Qt.DecorationRole):
                         val = "<image>"
+                    if val is None and item and item.data(LINE_DATA_ROLE) is not None:
+                        val = "<trendline>"
 
                 values.append(val)
                 for i, pytype in enumerate(value_types):
@@ -1385,3 +1494,6 @@ def prettify_notation(value):
 
 def is_png_bytes(obj):
     return isinstance(obj, bytes) and BlobTypes.identify(obj) is BlobTypes.png
+
+def is_numpy_bytes(obj):
+    return isinstance(obj, bytes) and BlobTypes.identify(obj) is BlobTypes.numpy

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -1182,16 +1182,30 @@ class DamnitTableModel(QtGui.QStandardItemModel):
 
         try:
             row_ix = self.find_row(proposal, run)
+            if not values:
+                # No need to update anything else
+                return
+            placeholders = ", ".join(["?"] * len(values))
+            query = (
+                "SELECT name, value, max_diff, summary_type, attributes "
+                "FROM run_variables WHERE proposal=? AND run=? "
+                f"AND name IN ({placeholders})"
+            )
+            params = (proposal, run, *values.keys())
         except KeyError:
             row_ix = None
+            query = (
+                "SELECT name, value, max_diff, summary_type, attributes "
+                "FROM run_variables WHERE proposal=? AND run=?"
+            )
+            params = (proposal, run)
 
         data = {}
         max_diffs = {}
         attrs = {}
         summary_types = {}
-        for name, value, max_diff, summary_type, attr_json in self.db.conn.execute("""
-            SELECT name, value, max_diff, summary_type, attributes FROM run_variables WHERE proposal=? AND run=?
-        """, (proposal, run)):
+
+        for name, value, max_diff, summary_type, attr_json in self.db.conn.execute(query, params):
             data[name] = value
             max_diffs[name] = max_diff
             summary_types[name] = summary_type

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -411,14 +411,72 @@ class SparklineDelegate(QtWidgets.QStyledItemDelegate):
 
         painter.save()
         painter.setRenderHint(QtGui.QPainter.Antialiasing, True)
-        if opt.state & QtWidgets.QStyle.State_Selected:
-            color = opt.palette.color(QtGui.QPalette.HighlightedText)
-        else:
-            color = opt.palette.color(QtGui.QPalette.Text)
-        pen = QtGui.QPen(color)
+        line_color = QtGui.QColor(0, 120, 215)    # blue
+        hover_line_color = QtGui.QColor(0, 0, 0)  # black
+        text_color = QtGui.QColor(0, 0, 0)        # black
+        dot_color = QtGui.QColor(220, 0, 0)       # red
+        pen = QtGui.QPen(line_color)
         pen.setWidth(1)
         painter.setPen(pen)
         painter.drawPolyline(poly)
+
+        view = opt.widget
+        hover_index = view._sparkline_hover_index
+        hover_t = view._sparkline_hover_t
+        if hover_index is not None and hover_t is not None and hover_index == index:
+            x_line = rect.left() + hover_t * (rect.width() - 1)
+            painter.setPen(QtGui.QPen(hover_line_color))
+            painter.drawLine(QtCore.QPointF(x_line, rect.top()),
+                             QtCore.QPointF(x_line, rect.bottom()))
+
+            try:
+                if span_x == 0:
+                    y_val = float(np.nanmean(y))
+                else:
+                    x_target = x_min + hover_t * span_x
+                    order = np.argsort(x)
+                    x_sorted = x[order]
+                    y_sorted = y[order]
+                    y_val = float(np.interp(x_target, x_sorted, y_sorted))
+            except Exception:
+                y_val = None
+
+            if y_val is not None and np.isfinite(y_val):
+                if span_y == 0:
+                    y_norm_val = 0.5
+                else:
+                    y_norm_val = (y_val - y_min) / span_y
+                y_norm_val = max(0.0, min(1.0, float(y_norm_val)))
+                y_marker = rect.top() + (1 - y_norm_val) * (rect.height() - 1)
+                painter.save()
+                painter.setBrush(dot_color)
+                painter.setPen(QtGui.QPen(dot_color))
+                painter.drawEllipse(QtCore.QPointF(x_line, y_marker), 2.5, 2.5)
+                painter.restore()
+
+            if y_val is not None and np.isfinite(y_val):
+                text = prettify_notation(y_val)
+                metrics = painter.fontMetrics()
+                text_w = metrics.horizontalAdvance(text)
+                text_h = metrics.height()
+                box_w = text_w + 6
+                box_h = text_h + 4
+                text_left = x_line + 4
+                if text_left + box_w > rect.right():
+                    text_left = x_line - box_w - 4
+                text_left = max(rect.left(), min(text_left, rect.right() - box_w))
+                text_top = rect.top() + 2
+                if text_top + box_h > rect.bottom():
+                    text_top = rect.bottom() - box_h - 2
+                box_rect = QtCore.QRectF(text_left, text_top, box_w, box_h)
+                bg = QtGui.QColor(255, 255, 255, 210)
+                painter.fillRect(box_rect, bg)
+                painter.setPen(text_color)
+                painter.drawText(
+                    box_rect.adjusted(3, 2, -3, -2),
+                    Qt.AlignLeft | Qt.AlignVCenter,
+                    text,
+                )
         painter.restore()
 
 
@@ -433,6 +491,8 @@ class TableView(QtWidgets.QTableView):
         self.setAlternatingRowColors(False)
         self.hierarchical_header_enabled = True
         self._restoring_column_widths = False
+        self._sparkline_hover_index = QtCore.QModelIndex()
+        self._sparkline_hover_t = None
 
         self.setSelectionBehavior(
             QtWidgets.QAbstractItemView.SelectionBehavior.SelectRows
@@ -440,6 +500,7 @@ class TableView(QtWidgets.QTableView):
 
         self.verticalHeader().setMinimumSectionSize(ROW_HEIGHT)
         self.setItemDelegate(SparklineDelegate(self))
+        self.setMouseTracking(True)
 
         # Add the widgets to be used in the column settings dialog
         self._columns_widget = QtWidgets.QListWidget()
@@ -512,6 +573,46 @@ class TableView(QtWidgets.QTableView):
         self.selectionModel().selectionChanged.connect(self.selection_changed)
 
         self.model_updated.emit()
+
+    def _set_sparkline_hover(self, index, t):
+        old_index = self._sparkline_hover_index
+        old_t = self._sparkline_hover_t
+        if old_index == index and old_t == t:
+            return
+        self._sparkline_hover_index = index
+        self._sparkline_hover_t = t
+        if old_index.isValid():
+            self.viewport().update(self.visualRect(old_index))
+        if index.isValid():
+            self.viewport().update(self.visualRect(index))
+
+    def _clear_sparkline_hover(self):
+        if not self._sparkline_hover_index.isValid():
+            self._sparkline_hover_t = None
+            return
+        old_index = self._sparkline_hover_index
+        self._sparkline_hover_index = QtCore.QModelIndex()
+        self._sparkline_hover_t = None
+        if old_index.isValid():
+            self.viewport().update(self.visualRect(old_index))
+
+    def mouseMoveEvent(self, event):
+        index = self.indexAt(event.pos())
+        if index.isValid() and index.data(LINE_DATA_ROLE) is not None:
+            rect = self.visualRect(index)
+            if rect.width() > 1:
+                t = (event.pos().x() - rect.left()) / (rect.width() - 1)
+            else:
+                t = 0.0
+            t = max(0.0, min(1.0, float(t)))
+            self._set_sparkline_hover(index, t)
+        else:
+            self._clear_sparkline_hover()
+        super().mouseMoveEvent(event)
+
+    def leaveEvent(self, event):
+        self._clear_sparkline_hover()
+        super().leaveEvent(event)
 
     def _on_section_resized(self, logical_index, old_size, new_size):
         if self._restoring_column_widths:

--- a/damnit/gui/table_filter.py
+++ b/damnit/gui/table_filter.py
@@ -24,6 +24,7 @@ from superqt import QSearchableListWidget as SuperQListWidget
 from superqt.fonticon import icon
 from superqt.utils import qthrottled
 
+from .roles import LINE_DATA_ROLE
 from .widgets import ValueRangeWidget
 
 
@@ -212,7 +213,11 @@ class FilterProxy(QtCore.QSortFilterProxyModel):
 
             item = self.sourceModel().index(source_row, col, source_parent)
             if isinstance(filter, ThumbnailFilter):
-                data = type(item.data(Qt.DecorationRole))
+                has_thumb = item.data(LINE_DATA_ROLE) is not None
+                if not has_thumb:
+                    thumb = item.data(Qt.DecorationRole)
+                    has_thumb = thumb is not None and not isinstance(thumb, QColor)
+                data = QPixmap if has_thumb else type(None)
             else:
                 data = item.data(Qt.UserRole)
             if not filter.accepts(data):
@@ -249,9 +254,14 @@ class FilterMenu(QMenu):
         is_numeric = True
         values = []
         decos = set()
+        has_sparkline = False
 
         for row in range(model.sourceModel().rowCount()):
             item = model.sourceModel().index(row, column)
+
+            if item.data(LINE_DATA_ROLE) is not None:
+                has_sparkline = True
+                continue
 
             if thumb := item.data(Qt.DecorationRole):
                 # QColor decoration is used for errors (no value)
@@ -271,7 +281,7 @@ class FilterMenu(QMenu):
         unique_values = set(values)
 
         # Create appropriate filter widget
-        if len(unique_values) == 0 and (len(decos) == 1) and (decos.pop() is QPixmap):
+        if len(unique_values) == 0 and (has_sparkline or (len(decos) == 1 and decos.pop() is QPixmap)):
             filter_widget = ThumbnailFilterWidget(column)
         elif is_numeric:
             filter_widget = NumericFilterWidget(column, values)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ Added:
 - Core: Introduced a migrations framework to apply future schema changes
   predictably (!510).
 - GUI: save/restore column widths setting (!526).
+- Core: downsampled 1D data is now saved in the database instead of thumbnail
+  (!531).
+- GUI: Display interactive sparklines for 1D data in the main table (!531).
 
 Fixed:
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -46,6 +46,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/ca/9a/ea42b0fd3bd4acaaef489d3d303ce75c673a1658eb77c7a4aa61f9ba2154/extra_proposal-0.1.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/5d/29fda080b909d7d2ceeb2825d2e447633da266ae147c20323710df04e6d3/fonticon_fontawesome6-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/b4/b96bb66f6f8cc4669de44a158099b249c8159231d254ab6b092909388be5/fonttools-4.59.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/39/c4/f5eb4756212d7df85b091324c73b9e15736c957ea91513bc1a23ed7e7d93/fpcs-1.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/27/ca28b77f4cf613282e4ea9bac360cdfa8db8b4d2154e2f0bd82fd26baeb3/h5netcdf-1.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
@@ -148,6 +149,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/39/c4/f5eb4756212d7df85b091324c73b9e15736c957ea91513bc1a23ed7e7d93/fpcs-1.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e6/65/7b3fcef8c9fb6d1023484d9caf87e78450a5c9cd1e191ce9632990b65284/griffe-1.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/4e/27/ca28b77f4cf613282e4ea9bac360cdfa8db8b4d2154e2f0bd82fd26baeb3/h5netcdf-1.6.3-py3-none-any.whl
@@ -235,6 +237,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/5d/29fda080b909d7d2ceeb2825d2e447633da266ae147c20323710df04e6d3/fonticon_fontawesome6-6.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/75/b4/b96bb66f6f8cc4669de44a158099b249c8159231d254ab6b092909388be5/fonttools-4.59.0-cp313-cp313-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/39/c4/f5eb4756212d7df85b091324c73b9e15736c957ea91513bc1a23ed7e7d93/fpcs-1.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/4e/27/ca28b77f4cf613282e4ea9bac360cdfa8db8b4d2154e2f0bd82fd26baeb3/h5netcdf-1.6.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e7/ec/86f59025306dcc6deee5fda54d980d077075b8d9889aac80f158bd585f1b/h5py-3.14.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl
@@ -471,9 +474,10 @@ packages:
   requires_python: '>=3.8'
 - pypi: ./
   name: damnit
-  version: 0.2.0
-  sha256: 565c52c3be811cb26814e78ee2cefc8bda657878db3a8788331b103e901b60fc
+  version: 0.2.1
+  sha256: 08054937bf9323f422e4c7b513cfc20a5aee488d861ea5de7ca14623e4e796b4
   requires_dist:
+  - fpcs
   - h5netcdf>=1.4.1
   - h5py
   - numpy
@@ -662,6 +666,18 @@ packages:
   - skia-pathops>=0.5.0 ; extra == 'all'
   - uharfbuzz>=0.23.0 ; extra == 'all'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/39/c4/f5eb4756212d7df85b091324c73b9e15736c957ea91513bc1a23ed7e7d93/fpcs-1.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+  name: fpcs
+  version: 1.0.0
+  sha256: 18d3191082b31be54c3e8319a474509e0298fae2867ab8ad7cb992c3477786c9
+  requires_dist:
+  - numpy
+  - cython ; extra == 'dev'
+  - matplotlib ; extra == 'dev'
+  - lttbc ; extra == 'dev'
+  - pytest ; extra == 'dev'
+  - pytest-benchmark ; extra == 'dev'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl
   name: ghp-import
   version: 2.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = ["License :: OSI Approved :: BSD License"]
 dynamic = ["version"]
 readme = "README.md"
 dependencies = [
+    "fpcs",
     "h5netcdf>=1.4.1",
     "h5py",
     "numpy",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,11 @@ def mock_ctx():
     def plotly_preview(run):
         fig = px.bar(x=["a", "b", "c"], y=[1, 3, 2])
         return Cell(np.zeros(4), preview=fig)
+
+    @Variable(title="Trendline")
+    def trendline(run):
+        data = np.arange(10000)
+        return data
     """
 
     return mkcontext(code)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -112,6 +112,10 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     @Variable
     def bool_array(run):
         return Cell(np.zeros(10, dtype=np.bool_))
+
+    @Variable(title="Line")
+    def line(run):
+        return np.linspace(0, 1, 15000)
     """
     (db_dir / "context.py").write_text(dedent(dataset_code))
     extract_mock_run(1)
@@ -171,6 +175,14 @@ def test_variable_data(mock_db_with_data, monkeypatch):
     assert rv["summary_only"].summary() == 7
 
     np.testing.assert_array_equal(rv['bool_array'].preview_data(), np.zeros(10, dtype=np.bool_))
+
+    line_summary = rv["line"].summary()
+    assert isinstance(line_summary, np.ndarray)
+    assert line_summary.shape[0] == 2
+    summary_type = db.conn.execute(
+        "SELECT summary_type FROM run_variables WHERE name='line' AND run=1"
+    ).fetchone()[0]
+    assert summary_type == "trendline"
 
 
 def test_api_dependencies(venv):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -12,22 +12,18 @@ import subprocess
 import textwrap
 from time import sleep, time
 from uuid import uuid4
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import extra_data as ed
 import h5py
 import numpy as np
 import plotly.express as px
 import pytest
-import requests
 import xarray as xr
-import yaml
 from PIL import Image
 from testpath import MockCommand
 
 from damnit.backend import listener_is_running, initialize_proposal, start_listener
-from damnit.backend.db import DamnitDB
+from damnit.backend.db import BlobTypes, DamnitDB, blob2numpy
 from damnit.backend.extract_data import Extractor, RunExtractor, add_to_db, load_reduced_data, main as extract_data_main
 from damnit.backend.extraction_control import ExtractionJobTracker
 from damnit.backend.listener import (MAX_CONCURRENT_THREADS, EventProcessor,
@@ -60,6 +56,11 @@ def check_png(dset):
     assert dset.ndim == 1
     assert dset.dtype == np.dtype(np.uint8)
     assert dset[:8].tobytes() == b'\x89PNG\r\n\x1a\n'
+
+def check_trendline(dset):
+    assert dset.ndim == 2
+    assert dset.shape[0] == 2
+    assert np.issubdtype(dset.dtype, np.floating)
 
 def test_add_to_h5_file(tmp_path):
     path = tmp_path / "foo.h5"
@@ -127,7 +128,7 @@ def test_context_file(mock_ctx, tmp_path):
     assert mock_ctx.ordered_vars() == (
         # First everything without dependencies, in definition order
         "scalar1", "empty_string", "timestamp", "string", "plotly_mc_plotface",
-        "results", "image", "array_preview", "plotly_preview",
+        "results", "image", "array_preview", "plotly_preview", "trendline",
         # Then the dependencies
         "scalar2", "array", "meta_array"
     )
@@ -673,7 +674,8 @@ def test_results_preview(mock_run, tmp_path):
     results.save_hdf5(results_hdf5_path)
     with h5py.File(results_hdf5_path) as f:
         np.testing.assert_array_equal(f['.preview/var1'][()], np.ones(5))
-        check_png(f['.reduced/var1'])  # Summary thumbnail made from preview
+        check_trendline(f['.reduced/var1'])
+        assert f['.reduced/var1'].attrs['summary_type'] == "trendline"
         check_rgba(f['.preview/var2'])
         check_png(f['.reduced/var2'])
         assert f['.preview/var3'].dtype == bool
@@ -754,6 +756,37 @@ def test_add_to_db(mock_db):
         "SELECT * FROM run_variables WHERE proposal=1234 AND run=42 AND name='float'"
     ).fetchone()
     assert json.loads(row["attributes"]) == {"background": [255, 0, 0]}
+
+def test_trendline_summary_to_db(mock_run, mock_db, tmp_path):
+    db_dir, db = mock_db
+
+    ctx_code = """
+    import numpy as np
+    from damnit_ctx import Variable
+
+    @Variable()
+    def line(run):
+        return np.linspace(0, 1, 15000)
+    """
+    ctx = mkcontext(ctx_code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    results_hdf5_path = tmp_path / 'results.h5'
+    results.save_hdf5(results_hdf5_path)
+
+    with h5py.File(results_hdf5_path) as f:
+        dset = f['.reduced/line']
+        check_trendline(dset)
+        assert dset.attrs['summary_type'] == "trendline"
+
+    reduced_data = load_reduced_data(results_hdf5_path)
+    add_to_db(reduced_data, db, 1000, 123)
+    row = db.conn.execute(
+        "SELECT value, summary_type FROM run_variables WHERE name='line'"
+    ).fetchone()
+    assert row["summary_type"] == "trendline"
+    assert BlobTypes.identify(row["value"]) is BlobTypes.numpy
+    arr = blob2numpy(row["value"])
+    assert arr.shape[0] == 2
 
 def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
     # Change to the DB directory

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,8 +1,10 @@
 import os
 
+import numpy as np
 import pytest
 
-from damnit.backend.db import complex2blob, blob2complex, DamnitDB
+from damnit.backend.db import (BlobTypes, DamnitDB, ReducedData, blob2complex,
+                               blob2numpy, complex2blob, numpy2blob)
 from damnit.backend.db_migrations import latest_version
 import sqlite3
 from pathlib import Path
@@ -183,6 +185,35 @@ def test_complex_blob_conversion(value):
     blob = complex2blob(value)
     result = blob2complex(blob)
     assert result == value
+
+
+def test_numpy_blob_conversion():
+    arr = np.arange(6, dtype=np.float64).reshape(2, 3)
+    blob = numpy2blob(arr)
+    assert blob.startswith(b'\x93NUMPY')
+    result = blob2numpy(blob)
+    np.testing.assert_array_equal(result, arr)
+
+
+def test_numpy_summary_type_and_storage(tmp_path):
+    db = DamnitDB.from_dir(tmp_path)
+    db.ensure_run(1234, 1)
+    arr = np.arange(10, dtype=np.float64)
+
+    db.set_variable(1234, 1, "array", ReducedData(arr))
+    row = db.conn.execute(
+        "SELECT value, summary_type FROM run_variables WHERE name='array'"
+    ).fetchone()
+    assert row["summary_type"] == "numpy"
+    assert BlobTypes.identify(row["value"]) is BlobTypes.numpy
+    np.testing.assert_array_equal(blob2numpy(row["value"]), arr)
+
+    db.set_variable(1234, 1, "line", ReducedData(arr, summary_type="trendline"))
+    row = db.conn.execute(
+        "SELECT value, summary_type FROM run_variables WHERE name='line'"
+    ).fetchone()
+    assert row["summary_type"] == "trendline"
+    assert BlobTypes.identify(row["value"]) is BlobTypes.numpy
 
 
 def test_new_db_schema_is_latest(tmp_path):

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -13,8 +13,9 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QPoint
 from PyQt5.QtGui import QColor, QPalette, QPixmap
+from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtWidgets import (QApplication, QDialog, QFileDialog, QInputDialog,
                              QLineEdit, QMessageBox, QStyledItemDelegate)
 
@@ -27,8 +28,9 @@ from damnit.gui.main_window import AddUserVariableDialog, MainWindow
 from damnit.gui.open_dialog import OpenDBDialog
 from damnit.gui.plot import HistogramPlotWindow, ScatterPlotWindow
 from damnit.gui.standalone_comments import TimeComment
-from damnit.gui.table import STATIC_COLUMNS
-from damnit.gui.table_filter import (CategoricalFilter,
+from damnit.gui.roles import LINE_DATA_ROLE
+from damnit.gui.table import STATIC_COLUMNS, SparklineDelegate, TableView
+from damnit.gui.table_filter import (CategoricalFilter, FilterProxy,
                                      CategoricalFilterWidget, FilterMenu,
                                      NumericFilter, NumericFilterWidget,
                                      ThumbnailFilter, ThumbnailFilterWidget)
@@ -1630,3 +1632,97 @@ def test_header_group_toggle_emits_signals(qtbot):
 
     assert table_view.hierarchical_header_enabled is True
     assert header._hierarchy_enabled is True
+
+
+def test_thumbnail_filter_accepts_sparkline():
+    model = QtGui.QStandardItemModel(1, 1)
+    item = QtGui.QStandardItem()
+    line = np.vstack((np.arange(5), np.array([0, 1, 0, 1, 0], dtype=float)))
+    item.setData(line, LINE_DATA_ROLE)
+    model.setItem(0, 0, item)
+
+    proxy = FilterProxy()
+    proxy.setSourceModel(model)
+    proxy.set_filter(0, ThumbnailFilter(0, show_with_thumbnail=True, show_without_thumbnail=False))
+    assert proxy.rowCount() == 1
+    proxy.set_filter(0, ThumbnailFilter(0, show_with_thumbnail=False, show_without_thumbnail=True))
+    assert proxy.rowCount() == 0
+
+
+def test_sparkline_hover_state(qtbot):
+    view = TableView()
+    model = QtGui.QStandardItemModel(1, 1)
+    item = QtGui.QStandardItem()
+    line = np.vstack((np.arange(10), np.arange(10, dtype=float)))
+    item.setData(line, LINE_DATA_ROLE)
+    model.setItem(0, 0, item)
+    view.setModel(model)
+    view.resize(200, 60)
+    qtbot.addWidget(view)
+    view.show()
+    qtbot.waitExposed(view)
+
+    proxy_index = view.model().index(0, 0)
+    rect = view.visualRect(proxy_index)
+    qtbot.mouseMove(view.viewport(), rect.center())
+
+    qtbot.waitUntil(lambda: view._sparkline_hover_index.isValid(), timeout=1000)
+    assert view._sparkline_hover_index == proxy_index
+    assert 0.0 <= view._sparkline_hover_t <= 1.0
+    # Verify hover_t matches the mouse x-position mapping.
+    expected_t = (rect.center().x() - rect.left()) / (rect.width() - 1)
+    assert abs(view._sparkline_hover_t - expected_t) < 0.1
+
+    qtbot.mouseMove(
+        view.viewport(),
+        QPoint(view.viewport().width() + 10, view.viewport().height() + 10),
+    )
+    qtbot.waitUntil(lambda: not view._sparkline_hover_index.isValid(), timeout=1000)
+    # Leaving the cell clears the hover state.
+    assert view._sparkline_hover_t is None
+
+
+def test_sparkline_delegate_paint_smoke(qtbot):
+    view = TableView()
+    model = QtGui.QStandardItemModel(1, 1)
+    item = QtGui.QStandardItem()
+    line = np.vstack((np.arange(5), np.array([0, 1, 0, 1, 0], dtype=float)))
+    item.setData(line, LINE_DATA_ROLE)
+    model.setItem(0, 0, item)
+    view.setModel(model)
+    view.resize(200, 60)
+    qtbot.addWidget(view)
+    view.show()
+    qtbot.waitExposed(view)
+
+    proxy_index = view.model().index(0, 0)
+    option = QtWidgets.QStyleOptionViewItem()
+    option.rect = view.visualRect(proxy_index)
+    option.widget = view
+
+    def image_bytes(img):
+        ptr = img.constBits()
+        ptr.setsize(img.byteCount())
+        return bytes(ptr)
+
+    delegate = SparklineDelegate(view)
+
+    # Render without hover.
+    image = QtGui.QImage(200, 60, QtGui.QImage.Format_ARGB32)
+    image.fill(Qt.transparent)
+    painter = QtGui.QPainter(image)
+    delegate.paint(painter, option, proxy_index)
+    painter.end()
+    base_bytes = image_bytes(image)
+
+    # Render with hover; output should differ from the baseline.
+    hover_image = QtGui.QImage(200, 60, QtGui.QImage.Format_ARGB32)
+    hover_image.fill(Qt.transparent)
+    hover_painter = QtGui.QPainter(hover_image)
+    view._sparkline_hover_index = proxy_index
+    view._sparkline_hover_t = 0.5
+    delegate.paint(hover_painter, option, proxy_index)
+    hover_painter.end()
+    hover_bytes = image_bytes(hover_image)
+
+    assert base_bytes != hover_bytes

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -19,7 +19,7 @@ from PyQt5.QtWidgets import (QApplication, QDialog, QFileDialog, QInputDialog,
                              QLineEdit, QMessageBox, QStyledItemDelegate)
 
 import damnit
-from damnit.backend.db import DamnitDB, ReducedData
+from damnit.backend.db import DamnitDB, MsgKind, ReducedData
 from damnit.backend.extract_data import add_to_db
 from damnit.ctxsupport.ctxrunner import ContextFile
 from damnit.gui.editor import ContextTestResult
@@ -275,11 +275,20 @@ def test_settings(mock_db_with_data, mock_ctx, tmp_path, monkeypatch, qtbot):
 
     # Simulate adding a new column while the GUI is running
     msg = {
-        "Proposal": 1234,
-        "Run": 1,
-        "new_var": 42
+        "msg_kind": MsgKind.run_values_updated.value,
+        "data": {
+            "proposal": 1234,
+            "run": 1,
+            "values": {"new_var": None},
+        }
     }
-    db.set_variable(msg["Proposal"], msg["Run"], "new_var", ReducedData(msg["new_var"]))
+    msg_data = msg['data']
+    db.set_variable(
+        msg_data["proposal"],
+        msg_data["run"],
+        "new_var",
+        ReducedData(42)
+    )
     win.handle_update(msg)
 
     # The new column should be at the end
@@ -291,7 +300,7 @@ def test_settings(mock_db_with_data, mock_ctx, tmp_path, monkeypatch, qtbot):
     assert headers == visible_headers()
 
     # Simulate adding a new column while the GUI is *not* running
-    db.set_variable(msg["Proposal"], msg["Run"], "newer_var", ReducedData("foo"))
+    db.set_variable(msg_data["proposal"], msg_data["run"], "newer_var", ReducedData("foo"))
 
     # Reload the database
     headers = visible_headers()
@@ -329,13 +338,22 @@ def test_handle_update(mock_db, qtbot):
 
     # Sending an update should add a row to the table
     msg = {
-        "Proposal": 1234,
-        "Run": 1,
-        "scalar1": 42,
-        "string": "foo"
+        "msg_kind": MsgKind.run_values_updated.value,
+        "data": {
+            "proposal": 1234,
+            "run": 1,
+            "values": {
+                "scalar1": None,
+                "string": None,
+            },
+        }
     }
+    msg_data = msg['data']
 
     assert win.table.rowCount() == 0
+    # we need to update the database first as the values are read from there upon table update
+    db.set_variable(msg_data["proposal"], msg_data["run"], "string", ReducedData("foo"))
+    db.set_variable(msg_data["proposal"], msg_data["run"], "scalar1", ReducedData(42))
     win.handle_update(msg)
     assert win.table.rowCount() == 1
 
@@ -345,12 +363,14 @@ def test_handle_update(mock_db, qtbot):
     assert "string" in headers
 
     # Send an update for an existing row
-    msg["scalar1"] = 43
+    msg["data"]["values"] = {"scalar1": None}
+    db.set_variable(msg_data["proposal"], msg_data["run"], "scalar1", ReducedData(43))
     win.handle_update(msg)
-    assert model().data(model().index(0, headers.index("Scalar1"))) == str(msg["scalar1"])
+    assert model().data(model().index(0, headers.index("Scalar1"))) == str(43)
 
     # Add a new column to an existing row
-    msg["unexpected_var"] = 7
+    msg["data"]["values"] = {"unexpected_var": None}
+    db.set_variable(msg_data["proposal"], msg_data["run"], "unexpected_var", ReducedData(7))
     win.handle_update(msg)
     assert len(headers) + 1 == len(get_headers())
     assert "unexpected_var" in get_headers()
@@ -376,11 +396,19 @@ def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
 
     extract_mock_run(2)
     msg = {
-        "Proposal": 1234,
-        "Run": 2,
-        "scalar1": 42,
-        "string": "foo"
+        "msg_kind": MsgKind.run_values_updated.value,
+        "data": {
+            "proposal": 1234,
+            "run": 1,
+            "values": {
+                "scalar1": None,
+                "string": None,
+            },
+        }
     }
+    msg_data = msg['data']
+    db.set_variable(msg_data["proposal"], msg_data["run"], "string", ReducedData("foo"))
+    db.set_variable(msg_data["proposal"], msg_data["run"], "scalar1", ReducedData(42))
     win.handle_update(msg)
 
 def test_autoconfigure(tmp_path, bound_port, request, qtbot):


### PR DESCRIPTION
This PR:
- replaces 1D PNG thumbnails with downsampled numeric summaries stored in SQLite
- adds GUI support to render those summaries as interactive sparklines.

It's probably easier to review commits separately as it touches a large area of the codebase since backend and gui is changed.

Behavior Changes:
  - 1D summary values are no longer PNG thumbnails.
  - DB now stores 1D summaries as numpy blobs with summary_type="trendline".
  - GUI displays 1D summaries as sparklines rather than static images.

As side effects:
- the Kafka messages for `run_values_updated` do not contain the actual data anymore, as I did not want to handle json serialization of numpy data. Though we said we wanted it removed anyway. It's directly read from the database now.
- Remove support for legacy kafka message format (some test were still relying on the old format).

[Screencast from 02-05-2026 01:26:13 PM.webm](https://github.com/user-attachments/assets/27c994bc-9fb7-4840-9b26-041e90f00c79)
