### PR TITLE
feat: variable group (v2)

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -290,7 +290,7 @@ class DamnitDB:
     def update_views(self):
         variables = self.variable_names()
 
-        col_select_sql = "max(CASE WHEN name='{var}' THEN {col} END) AS {var}"
+        col_select_sql = "max(CASE WHEN name='{var}' THEN {col} END) AS '{var}'"
         runs_cols = ", ".join([col_select_sql.format(var=var, col="value")
                                for var in variables])
         max_diff_cols = ", ".join([col_select_sql.format(var=var, col="max_diff")

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -132,7 +132,8 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run):
     # We're going to be formatting column names as strings into SQL code,
     # so check that they are simple identifiers before we get there.
     for name in reduced_data:
-        assert re.match(r'[a-zA-Z][a-zA-Z0-9_]*$', name), f"Bad field name {name}"
+        if not all(part.isidentifier() for part in name.split(".")):
+            raise ValueError(f"Invalid Variable name {name}")
 
     # Make a deepcopy before making modifications to the dictionary, such as
     # removing `start_time` and pickling non-{array, scalar} values.

--- a/damnit/context.py
+++ b/damnit/context.py
@@ -6,7 +6,7 @@ if ctxsupport_dir not in sys.path:
     sys.path.insert(0, ctxsupport_dir)
 
 # Exposing these here for compatibility
-from damnit_ctx import RunData, Variable
+from damnit_ctx import RunData, Variable, Group, GroupError, Cell, Skip
 from ctxrunner import (
     ContextFileErrors, ContextFile, DataType, PNGData, Results,
     add_to_h5_file, get_proposal_path,

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -12,14 +12,17 @@ import io
 import logging
 import os
 import pickle
+import re
 import sys
 import time
 import traceback
 from contextlib import contextmanager
+from copy import copy
 from datetime import timezone
 from enum import Enum
 from graphlib import CycleError, TopologicalSorter
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock
 
 import extra_data
@@ -27,7 +30,8 @@ import extra_proposal
 import h5py
 import numpy as np
 import xarray as xr
-from damnit_ctx import (Cell, RunData, Skip, Variable, expand_groups,
+from damnit_ctx import (Cell, GroupBoundVariable, GroupError, RunData, Skip,
+                        Variable, _normalize_tags, is_group_instance,
                         isinstance_no_import)
 
 log = logging.getLogger("ctxrunner")
@@ -51,6 +55,214 @@ class ContextFileErrors(RuntimeError):
 
     def __str__(self):
         return "\n".join(self.problems)
+
+
+def _group_name(group):
+    name = group.name
+    if isinstance(name, str) and name:
+        return name
+    if name is None:
+        raise GroupError(
+            f"Group instance of {type(group).__name__!r} has no name. "
+            "Provide name=... or assign it to a variable in the context file."
+        )
+    raise GroupError(
+        f"Group instance of {type(group).__name__!r} has invalid name {name!r}. "
+        "Provide a non-empty string name."
+    )
+
+
+def _assign_group_names(context):
+    # Group names can be assigned by context variable names after execution.
+    # e.g.: mygroup = MyGroup() -> since MyGroup(name=...) wasn't set, 'mygroup'
+    # becomes the name when the context is processed.
+    group_refs = {}
+    for var_name, value in context.items():
+        if var_name.startswith("__"):
+            continue
+        if is_group_instance(value):
+            entry = group_refs.setdefault(id(value), {"obj": value, "names": []})
+            entry["names"].append(var_name)
+
+    for entry in group_refs.values():
+        group = entry["obj"]
+        if group.name is None:
+            names = sorted(entry["names"])
+            if len(names) == 1:
+                group.name = names[0]
+            else:
+                raise GroupError(
+                    f"Group instance of {type(group).__name__!r} is assigned "
+                    f"to multiple names {names} without an explicit name."
+                )
+        if group.title is None:
+            group.title = group.name
+
+
+def _collect_group_instances(objects):
+    pending = [obj for obj in objects if is_group_instance(obj)]
+    groups = []
+    seen_ids = set()
+
+    while pending:
+        group = pending.pop()
+        group_id = id(group)
+        if group_id in seen_ids:
+            continue
+        seen_ids.add(group_id)
+
+        # check if group name is valid
+        _group_name(group)
+        groups.append(group)
+
+        for value in vars(group).values():
+            if is_group_instance(value):
+                pending.append(value)
+
+    return groups
+
+
+def _collect_group_variables(group):
+    vars_by_name = {}
+    for cls in reversed(type(group).mro()):
+        for name, value in cls.__dict__.items():
+            if isinstance(value, Variable):
+                vars_by_name[name] = value
+    return vars_by_name
+
+
+def _make_missing_dependency_placeholder(group, name: str) -> Variable:
+    """Create a fake Variable to replace missing group instances dependencies.
+
+    The Variable name is namespaced to the group and a special __missing__
+    section to make it clear in error messages that this is a placeholder for a
+    missing dependency.
+    """
+    def _missing(run):
+        return None
+
+    var = Variable(transient=True)
+    var(_missing)
+    # ensure the name does not contain any glob characters
+    safe_name = re.sub(r"[!?*\[\]]", "_", name)
+    var.name = f'{group.name}.__missing__.{safe_name}'
+    var.title = var.name
+    return var
+
+
+def _resolve_self_annotation(annotation: str, group):
+    path = annotation.removeprefix("self#")
+    target, _, remain = path.partition(".")
+
+    if remain:
+        target = getattr(group, target)
+        if target is None:
+            placeholder = _make_missing_dependency_placeholder(group, path)
+            return f'var#{placeholder.name}', placeholder
+        return _resolve_self_annotation(remain, target)
+
+    try:
+        var_ref = getattr(group, target)
+    except AttributeError:
+        if any(ch in target for ch in "*?["):
+            # glob pattern, will be resolved by ContextRunner.
+            return f'var#{group.name}.{target}', None
+        raise GroupError(
+            f"Attribute {target!r} on group {group.name!r} does not exist, "
+            "but is referenced as a dependency in annotation."
+        )
+
+    if var_ref is None:
+        placeholder = _make_missing_dependency_placeholder(group, target)
+        return f'var#{placeholder.name}', placeholder
+
+    if not isinstance(var_ref, (Variable, GroupBoundVariable)):
+        raise GroupError(
+            f"Attribute {target!r} on group {group.name!r} is of type "
+            f"{type(var_ref).__name__!r}, but a Variable is required for a self# dependency."
+        )
+
+    return f'var#{var_ref.name}', None
+
+
+def _expand_group(group):
+    """Build Variables for a group instance, resolving "self#" dependencies.
+
+    This binds each @Variable to the group instance, namespaces names and
+    titles, and rewrites annotations to "var#..." dependencies.
+    """
+    if group.title is None:
+        group.title = group.name
+
+    var_defs: dict[str, Variable] = _collect_group_variables(group)
+    expanded = {}
+
+    for var_def in var_defs.values():
+        # Create a per-instance Variable copy so name/title/annotations can be
+        # rewritten without mutating the class definition.
+        bound_func = var_def.func.__get__(group, type(group))
+        new_var = copy(var_def)
+        new_var(bound_func)
+        new_var.name = f"{group.name}.{var_def.name}"
+        new_var.title = f"{group.title}{group.sep}{var_def.title}"
+
+        annotations = {}
+        sig = inspect.signature(bound_func)
+        original_annotations = getattr(var_def.func, "__annotations__", {})
+        for arg_name, param in sig.parameters.items():
+            annotation = original_annotations.get(arg_name, param.annotation)
+            if not isinstance(annotation, str):
+                continue
+            if annotation.startswith("self#"):
+                # Resolve group-relative dependencies, possibly across nested groups.
+                resolved, placeholder = _resolve_self_annotation(annotation, group)
+                annotations[arg_name] = resolved
+                if placeholder is not None:
+                    # missing dependency -> add placeholder Variable
+                    expanded[placeholder.name] = placeholder
+
+            else:
+                annotations[arg_name] = annotation
+
+        new_var.tags = set(group.tags) | set(_normalize_tags(new_var.tags))
+        new_var._annotation_overrides = annotations
+        expanded[new_var.name] = new_var
+
+    return expanded
+
+
+def expand_groups(
+        context: dict[str, Any],
+        existing_vars: dict[str, Variable] | None = None,
+    ) -> dict[str, Variable]:
+    """Return Variables generated from Group instances in a context file."""
+    _assign_group_names(context)
+    groups = _collect_group_instances(context.values())
+    if not groups:
+        return {}
+
+    existing_names = set(existing_vars or {})
+    seen_group_names = {}
+    for group in groups:
+        group_id = id(group)
+        if group.name in seen_group_names and seen_group_names[group.name] != group_id:
+            raise GroupError(
+                f"Group name {group.name!r} is used by multiple group instances"
+            )
+        seen_group_names[group.name] = group_id
+
+    expanded = {}
+    for group in groups:
+        group_vars = _expand_group(group)
+        for var_name in group_vars:
+            if var_name in existing_names or var_name in expanded:
+                raise GroupError(
+                    f"Duplicate variable name {var_name!r} from group "
+                    f"{group.name!r}"
+                )
+        expanded.update(group_vars)
+
+    return expanded
 
 
 class ContextFile:

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -234,6 +234,8 @@ class ContextFile:
 
                 annotations = var.annotations()
                 for arg_name, param in inspect.signature(var.func).parameters.items():
+                    # Not using param.annotation, because the annotation in the
+                    # function def can be overridden for variables within a group.
                     annotation = annotations.get(arg_name, inspect.Parameter.empty)
                     if not isinstance(annotation, str):
                         continue

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -16,6 +16,7 @@ import re
 import sys
 import time
 import traceback
+from collections import deque
 from contextlib import contextmanager
 from copy import copy
 from datetime import timezone
@@ -76,16 +77,53 @@ def _assign_group_names(context):
     # Group names can be assigned by context variable names after execution.
     # e.g.: mygroup = MyGroup() -> since MyGroup(name=...) wasn't set, 'mygroup'
     # becomes the name when the context is processed.
-    group_refs = {}
+    # Nested groups inherit names from the attribute path. Shorter paths take
+    # precedence over deeper nesting.
+    pending = deque()
+    candidates = {}
+    expanded_depth = {}
+
+    def _record_candidate(group, path, depth):
+        group_id = id(group)
+        entry = candidates.get(group_id)
+        if entry is None or depth < entry["depth"]:
+            candidates[group_id] = {
+                "group": group,
+                "depth": depth,
+                "names": {path},
+            }
+        elif depth == entry["depth"]:
+            entry["names"].add(path)
+
     for var_name, value in context.items():
         if var_name.startswith("__"):
             continue
         if is_group_instance(value):
-            entry = group_refs.setdefault(id(value), {"obj": value, "names": []})
-            entry["names"].append(var_name)
+            group = value
+            root_name = group.name or var_name
+            _record_candidate(group, root_name, 0)
+            pending.append((group, root_name, 0))
 
-    for entry in group_refs.values():
-        group = entry["obj"]
+    while pending:
+        group, path, depth = pending.popleft()
+        group_id = id(group)
+
+        entry = candidates.get(group_id)
+        if entry is None or depth != entry["depth"]:
+            continue
+
+        if expanded_depth.get(group_id) == depth:
+            continue
+        expanded_depth[group_id] = depth
+
+        for attr, value in vars(group).items():
+            if is_group_instance(value):
+                child_path = f"{group.name or path}.{attr}"
+                _record_candidate(value, child_path, depth + 1)
+                pending.append((value, child_path, depth + 1))
+
+    for entry in candidates.values():
+        group = entry["group"]
         if group.name is None:
             names = sorted(entry["names"])
             if len(names) == 1:
@@ -96,7 +134,7 @@ def _assign_group_names(context):
                     f"to multiple names {names} without an explicit name."
                 )
         if group.title is None:
-            group.title = group.name
+            group.title = group.name.replace('.', group.sep)
 
 
 def _collect_group_instances(objects):

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -15,22 +15,22 @@ import pickle
 import sys
 import time
 import traceback
+from contextlib import contextmanager
 from datetime import timezone
 from enum import Enum
 from graphlib import CycleError, TopologicalSorter
 from pathlib import Path
 from unittest.mock import MagicMock
-from contextlib import contextmanager
 
 import extra_data
 import extra_proposal
 import h5py
 import numpy as np
 import xarray as xr
+from damnit_ctx import (Cell, RunData, Skip, Variable, expand_groups,
+                        isinstance_no_import)
 
-from damnit_ctx import RunData, Variable, Cell, Skip, isinstance_no_import
-
-log = logging.getLogger(__name__)
+log = logging.getLogger("ctxrunner")
 
 THUMBNAIL_SIZE = 300 # px
 COMPRESSION_OPTS = {'compression': 'gzip', 'compression_opts': 1, 'shuffle': True}
@@ -165,6 +165,7 @@ class ContextFile:
         codeobj = compile(code, path, 'exec')
         exec(codeobj, d)
         vars = {v.name: v for v in d.values() if isinstance(v, Variable)}
+        vars.update(expand_groups(d, vars))
         log.debug("Loaded %d variables", len(vars))
         return cls(vars, code)
 
@@ -231,8 +232,9 @@ class ContextFile:
                 missing_deps = []
                 missing_input = []
 
+                annotations = var.annotations()
                 for arg_name, param in inspect.signature(var.func).parameters.items():
-                    annotation = param.annotation
+                    annotation = annotations.get(arg_name, inspect.Parameter.empty)
                     if not isinstance(annotation, str):
                         continue
 

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -1,20 +1,32 @@
-"""This module is made available by manipulating sys.path
+"""Core DAMNIT context types and helpers.
+
+This module is made available by manipulating sys.path
 
 We aim to maintain compatibility with older Python 3 versions (currently 3.9+)
 than the DAMNIT code in general, to allow running context files in other Python
 environments.
 """
+import inspect
 import logging
 import re
 import sys
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from copy import copy
+from dataclasses import dataclass, field
 from enum import Enum
 
 import h5py
 import numpy as np
 import xarray as xr
 
-__all__ = ["RunData", "Variable", "Cell"]
+__all__ = [
+    "Cell",
+    "Group",
+    "GroupError",
+    "RunData",
+    "Skip",
+    "Variable"
+]
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +62,7 @@ class Variable:
         self.cluster = cluster
         self.transient = transient
         self._data = data
+        self._annotation_overrides = None
 
         if callable(title):
             # @Variable called without parenthesis
@@ -67,18 +80,26 @@ class Variable:
             self.title = self.name
         return self
 
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        if is_group_instance(instance):
+            # Return a proxy that resolves the group name lazily after context exec.
+            return GroupBoundVariable(instance, self)
+        return self
+
     def check(self):
         problems = []
-        if not self.name.isidentifier():
+        if not all(part.isidentifier() for part in self.name.split(".")):
             problems.append(
-                f"The variable name {self.name!r} is not a valid Python identifier"
+                f"The variable name {self.name!r} is not a valid Python identifier or dotted name"
             )
         if self._data not in (None, "raw", "proc"):
             problems.append(
                 f"data={self._data!r} for variable {self.name} (can be 'raw'/'proc')"
             )
         if self.tags is not None:
-            if not isinstance(self.tags, Sequence) or not all(
+            if not isinstance(self.tags, Iterable) or not all(
                 isinstance(tag, str) and tag != "" for tag in self.tags
             ):
                 problems.append(
@@ -111,6 +132,8 @@ class Variable:
 
         Returns a dict of argument names to their annotations.
         """
+        if self._annotation_overrides is not None:
+            return self._annotation_overrides
         return getattr(self.func, '__annotations__', {})
 
     def evaluate(self, run_data, kwargs):
@@ -268,3 +291,428 @@ class Cell:
 
 class Skip(Exception):
     pass
+
+
+# TODO: split module?
+
+
+class GroupError(Exception):
+    pass
+
+
+def _normalize_group_tags(tags):
+    if tags is None:
+        return None
+    if isinstance(tags, str):
+        return (tags,)
+    return tuple(tags)
+
+
+def _merge_tags(group_tags, var_tags):
+    if not group_tags and not var_tags:
+        return None
+    if not group_tags:
+        return set(var_tags)
+    if not var_tags:
+        return set(group_tags)
+
+    return set(group_tags) | set(var_tags)
+
+
+def _inherit_group_config(cls):
+    for base in cls.mro()[1:]:
+        config = base.__dict__.get("__damnit_group_config__")
+        if config is not None:
+            return config
+    return {}
+
+
+def Group(
+        _cls=None,
+        *,
+        tags: Iterable[str] | str | None = None,
+):
+    """Decorate a class to define a reusable group of Variables.
+
+    Group instances are dataclasses, therefore a Group subclass must also be
+    decorated with @Group. Instantiate them in the context file and access group
+    variables as "<group>.<var>" names. Use "self#..." in Variable annotations
+    to link to other group values or nested groups.
+
+    A group has 4 default parameters, they must be set at instantiation (except
+    for `tags`):
+        name: str | None = None
+            The group `name`. If None, the Group instance name assigned in the
+            context file will be used.
+        title: str | None = None
+            The group `title`. If None, the group `name` will be used as title.
+        tags: Iterable[str] | str | None = None
+            Tags to merge into each variable's tags.
+        sep: str = "/"
+            The separator between group title and variable title when generating
+            variable titles.
+
+    A Group decorator can define the default value of the Group instance `tags`.
+    `Tags` will be inherited from parent Group classes unless explicitly
+    overridden.
+    """
+    RESERVED_GROUP_FIELDS = {
+        "name": None,
+        "title": None,
+        "tags": None,
+        "sep": "/",
+    }
+
+    def wrap(cls):
+        # Prevent Group classes from shadowing internal config fields.
+        reserved_fields = set(RESERVED_GROUP_FIELDS)
+        defined_fields = set(getattr(cls, "__annotations__", {}))
+        conflicts = sorted(reserved_fields & defined_fields)
+        if conflicts:
+            raise GroupError(
+                "Group classes cannot define reserved fields: "
+                f"{', '.join(conflicts)}"
+            )
+        explicit_attrs = reserved_fields & set(cls.__dict__)
+        if explicit_attrs:
+            conflicts = ", ".join(sorted(explicit_attrs))
+            raise GroupError(
+                "Group classes cannot override reserved attributes: "
+                f"{conflicts}"
+            )
+
+        # inherit parents' Group tags if not redefined
+        parent_config = _inherit_group_config(cls)
+        nonlocal tags
+        if tags is None:
+            tags = parent_config.get("tags")
+        tags = _normalize_group_tags(tags)
+
+        cls.__damnit_group__ = True
+        cls.__damnit_group_config__ = RESERVED_GROUP_FIELDS.copy()
+        cls.__damnit_group_config__["tags"] = tags
+
+        annotations = dict(getattr(cls, "__annotations__", {}))
+        for field_name in reserved_fields:
+            annotations.pop(field_name, None)
+        annotations.update({
+            "name": str | None,
+            "title": str | None,
+            "tags": Iterable[str] | str | None,
+            "sep": str,
+        })
+        cls.__annotations__ = annotations
+
+        cls.name = field(default=RESERVED_GROUP_FIELDS["name"], kw_only=True)
+        cls.title = field(default=RESERVED_GROUP_FIELDS["title"], kw_only=True)
+        cls.sep = field(default=RESERVED_GROUP_FIELDS["sep"], kw_only=True)
+        cls.tags = field(default=tags, kw_only=True)
+
+        original_post_init = getattr(cls, "__post_init__", None)
+
+        def __post_init__(self):
+            self.tags = _normalize_group_tags(self.tags)
+            if self.title is None:
+                self.title = self.name
+
+            if original_post_init is not None:
+                original_post_init(self)
+
+        cls.__post_init__ = __post_init__
+
+        return dataclass(cls)
+
+    if _cls is None:
+        return wrap
+    return wrap(_cls)
+
+
+def is_group_instance(obj):
+    """Return True if obj is an instance of a Group class."""
+    return hasattr(type(obj), "__damnit_group__")
+
+
+def _group_name(group):
+    name = group.name
+    if isinstance(name, str) and name:
+        return name
+    if name is None:
+        raise GroupError(
+            f"Group instance of {type(group).__name__!r} has no name. "
+            "Provide name=... or assign it to a variable in the context file."
+        )
+    raise GroupError(
+        f"Group instance of {type(group).__name__!r} has invalid name {name!r}. "
+        "Provide a non-empty string name."
+    )
+
+
+def _assign_group_names(context):
+    # Group names can be assigned by context variable names after execution.
+    # e.g.: mygroup = MyGroup() -> since MyGroup(name=...) wasn't set, 'mygroup'
+    # becomes the name when the context is processed.
+    group_refs = {}
+    for var_name, value in context.items():
+        if var_name.startswith("__"):
+            continue
+        if is_group_instance(value):
+            entry = group_refs.setdefault(id(value), {"obj": value, "names": []})
+            entry["names"].append(var_name)
+
+    for entry in group_refs.values():
+        group = entry["obj"]
+        if group.name is None:
+            names = sorted(entry["names"])
+            if len(names) == 1:
+                group.name = names[0]
+            else:
+                raise GroupError(
+                    f"Group instance of {type(group).__name__!r} is assigned "
+                    f"to multiple names {names} without an explicit name."
+                )
+        if group.title is None:
+            group.title = group.name
+
+
+def _collect_group_instances(objects):
+    pending = [obj for obj in objects if is_group_instance(obj)]
+    groups = []
+    seen_ids = set()
+
+    while pending:
+        group = pending.pop()
+        group_id = id(group)
+        if group_id in seen_ids:
+            continue
+        seen_ids.add(group_id)
+        groups.append(group)
+
+        for value in vars(group).values():
+            if is_group_instance(value):
+                pending.append(value)
+
+    return groups
+
+
+def _collect_group_variables(group):
+    vars_by_name = {}
+    for cls in reversed(type(group).mro()):
+        for name, value in cls.__dict__.items():
+            if isinstance(value, Variable):
+                vars_by_name[name] = value
+    return vars_by_name
+
+
+def _resolve_self_dependency(group, path):
+    if not path:
+        raise GroupError("Empty self# dependency")
+
+    target = group
+    parts = path.split(".")
+    for attr in parts[:-1]:
+        if not hasattr(target, attr):
+            raise GroupError(
+                f"Group {type(group).__name__!r} has no attribute {attr!r}"
+            )
+        target = getattr(target, attr)
+        if target is None:
+            return None, None, True
+        if not is_group_instance(target):
+            raise GroupError(
+                f"Attribute {attr!r} on group {type(group).__name__!r} "
+                "does not reference a Group instance"
+            )
+
+    return target, parts[-1], False
+
+
+class _MissingDependency(Enum):
+    REQUIRED = "required"
+    OPTIONAL = "optional"
+
+
+def _resolve_group_attr_variable_name(group, dep_name, param):
+    """Resolve a group attribute to a Variable name or missing sentinel."""
+    attr = getattr(group, dep_name, None)
+    if attr is None:
+        if param.default is inspect.Parameter.empty:
+            return _MissingDependency.REQUIRED
+        return _MissingDependency.OPTIONAL
+    if isinstance(attr, (Variable, GroupBoundVariable)):
+        return attr.name
+    raise GroupError(
+        f"Group {type(group).__name__!r} attribute {dep_name!r} is not a Variable"
+    )
+
+
+def _resolve_self_annotation(group, var_defs, arg_name, annotation, param):
+    """Resolve a self# annotation into a var# annotation + dependency metadata.
+
+    Returns (resolved_annotation, internal_dep, drop_var, skip_annotation):
+    - resolved_annotation: string or None
+    - internal_dep: (arg_name, dep_name, required) tuple or None
+    - drop_var: True if the variable should be removed entirely
+    - skip_annotation: True if the argument should keep its default
+    """
+    target_group, dep_name, missing = _resolve_self_dependency(
+        group, annotation.removeprefix("self#")
+    )
+    if missing:
+        if param.default is inspect.Parameter.empty:
+            return None, None, True, False
+        return None, None, False, True
+
+    if target_group is group and dep_name in var_defs:
+        # Reference to another method-defined variable in this group.
+        resolved = f"{_group_name(target_group)}.{dep_name}"
+        required = param.default is inspect.Parameter.empty
+        return f"var#{resolved}", (arg_name, dep_name, required), False, False
+
+    if target_group is group:
+        # Reference to a Variable field (or bound variable) on this group.
+        resolved = _resolve_group_attr_variable_name(group, dep_name, param)
+    else:
+        # Reference to a Variable field on a nested group instance.
+        resolved = _resolve_group_attr_variable_name(target_group, dep_name, param)
+
+    if resolved is _MissingDependency.REQUIRED:
+        return None, None, True, False
+    if resolved is _MissingDependency.OPTIONAL:
+        return None, None, False, True
+    return f"var#{resolved}", None, False, False
+
+
+def _expand_group(group):
+    """Build Variables for a group instance, resolving "self#" dependencies.
+
+    This binds each @Variable to the group instance, namespaces names and
+    titles, and rewrites annotations to "var#..." dependencies. Group-internal
+    dependencies are tracked so variables with missing required inputs are
+    dropped, and optional dependencies are removed from annotations.
+    """
+    group_name = _group_name(group)
+    if group.title is None:
+        group.title = group_name
+
+    var_defs = _collect_group_variables(group)
+    var_infos = {}
+
+    for method_name, var_def in var_defs.items():
+        # Create a per-instance Variable copy so name/title/annotations can be
+        # rewritten without mutating the class definition.
+        bound_func = var_def.func.__get__(group, type(group))
+        new_var = copy(var_def)
+        new_var(bound_func)
+        new_var.name = f"{group_name}.{var_def.name}"
+        new_var.title = f"{group.title}{group.sep}{var_def.title}"
+
+        annotations = {}
+        internal_deps = []
+        drop_var = False
+        sig = inspect.signature(bound_func)
+        original_annotations = getattr(var_def.func, "__annotations__", {})
+        for arg_name, param in sig.parameters.items():
+            annotation = original_annotations.get(arg_name, param.annotation)
+            if not isinstance(annotation, str):
+                continue
+            if annotation.startswith("self#"):
+                # Resolve group-relative dependencies, possibly across nested groups.
+                resolved, internal_dep, drop, skip = _resolve_self_annotation(
+                    group, var_defs, arg_name, annotation, param
+                )
+                if drop:
+                    drop_var = True
+                    break
+                if skip:
+                    continue
+                annotations[arg_name] = resolved
+                if internal_dep is not None:
+                    internal_deps.append(internal_dep)
+            else:
+                annotations[arg_name] = annotation
+
+        if drop_var:
+            continue
+
+        new_var.tags = _merge_tags(group.tags, new_var.tags)
+        var_infos[method_name] = {
+            "var": new_var,
+            "annotations": annotations,
+            "internal_deps": internal_deps,
+        }
+
+    active = set(var_infos)
+    changed = True
+    while changed:
+        changed = False
+        for method_name in list(active):
+            info = var_infos[method_name]
+            remaining_deps = []
+            for arg_name, dep_name, required in info["internal_deps"]:
+                if dep_name not in active:
+                    # Drop variables that depend on missing required internal vars;
+                    # otherwise remove the dependency and let defaults apply.
+                    if required:
+                        active.remove(method_name)
+                        changed = True
+                        remaining_deps = []
+                        break
+                    info["annotations"].pop(arg_name, None)
+                else:
+                    remaining_deps.append((arg_name, dep_name, required))
+            info["internal_deps"] = remaining_deps
+
+    expanded = {}
+    for method_name in active:
+        info = var_infos[method_name]
+        info["var"]._annotation_overrides = info["annotations"]
+        expanded[info["var"].name] = info["var"]
+
+    return expanded
+
+
+def expand_groups(context, existing_vars=None):
+    """Return Variables generated from Group instances in a context file."""
+    _assign_group_names(context)
+    groups = _collect_group_instances(context.values())
+    if not groups:
+        return {}
+
+    existing_names = set(existing_vars or {})
+    seen_group_names = {}
+    for group in groups:
+        name = _group_name(group)
+        group_id = id(group)
+        if name in seen_group_names and seen_group_names[name] != group_id:
+            raise GroupError(
+                f"Group name {name!r} is used by multiple group instances"
+            )
+        seen_group_names[name] = group_id
+
+    expanded = {}
+    for group in groups:
+        group_vars = _expand_group(group)
+        for var_name in group_vars:
+            if var_name in existing_names or var_name in expanded:
+                raise GroupError(
+                    f"Duplicate variable name {var_name!r} from group "
+                    f"{_group_name(group)!r}"
+                )
+        expanded.update(group_vars)
+
+    return expanded
+
+
+class GroupBoundVariable:
+    __damnit_group_bound__ = True
+
+    def __init__(self, group, var_def):
+        self._group = group
+        self._var_def = var_def
+
+    @property
+    def name(self):
+        return f"{_group_name(self._group)}.{self._var_def.name}"
+
+    def __getattr__(self, attr):
+        return getattr(self._var_def, attr)

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -508,14 +508,13 @@ def _resolve_self_dependency(group, path):
     if not path:
         raise GroupError("Empty self# dependency")
 
-    target = group
     parts = path.split(".")
     for attr in parts[:-1]:
-        if not hasattr(target, attr):
+        if not hasattr(group, attr):
             raise GroupError(
                 f"Group {type(group).__name__!r} has no attribute {attr!r}"
             )
-        target = getattr(target, attr)
+        target = getattr(group, attr)
         if target is None:
             return None, None, True
         if not is_group_instance(target):
@@ -523,8 +522,9 @@ def _resolve_self_dependency(group, path):
                 f"Attribute {attr!r} on group {type(group).__name__!r} "
                 "does not reference a Group instance"
             )
+        group = target
 
-    return target, parts[-1], False
+    return group, parts[-1], False
 
 
 class _MissingDependency(Enum):

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -14,7 +14,7 @@ from collections.abc import Iterable, Sequence
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
-from graphlib import CycleError, TopologicalSorter
+from typing import Any
 
 import h5py
 import numpy as np
@@ -504,100 +504,74 @@ def _collect_group_variables(group):
     return vars_by_name
 
 
-def _resolve_self_dependency(group, path):
-    if not path:
-        raise GroupError("Empty self# dependency")
+def _make_missing_dependency_placeholder(group, name: str) -> Variable:
+    """Create a fake Variable to replace missing group istances dependencies.
 
-    parts = path.split(".")
-    for attr in parts[:-1]:
-        if not hasattr(group, attr):
-            raise GroupError(
-                f"Group {type(group).__name__!r} has no attribute {attr!r}"
-            )
-        target = getattr(group, attr)
-        if target is None:
-            return None, None, True
-        if not is_group_instance(target):
-            raise GroupError(
-                f"Attribute {attr!r} on group {type(group).__name__!r} "
-                "does not reference a Group instance"
-            )
-        group = target
-
-    return group, parts[-1], False
-
-
-class _MissingDependency(Enum):
-    REQUIRED = "required"
-    OPTIONAL = "optional"
-
-
-def _resolve_group_attr_variable_name(group, dep_name, param):
-    """Resolve a group attribute to a Variable name or missing sentinel."""
-    attr = getattr(group, dep_name, None)
-    if attr is None:
-        if param.default is inspect.Parameter.empty:
-            return _MissingDependency.REQUIRED
-        return _MissingDependency.OPTIONAL
-    if isinstance(attr, (Variable, GroupBoundVariable)):
-        return attr.name
-    raise GroupError(
-        f"Group {type(group).__name__!r} attribute {dep_name!r} is not a Variable"
-    )
-
-
-def _resolve_self_annotation(group, var_defs, arg_name, annotation, param):
-    """Resolve a self# annotation into a var# annotation + dependency metadata.
-
-    Returns (resolved_annotation, internal_dep, drop_var):
-    - resolved_annotation: string or None
-    - internal_dep: (arg_name, dep_name, required) tuple or None
-    - drop_var: True if the variable should be removed entirely
+    The Variable name is namespaced to the group and a special __missing__
+    section to make it clear in error messages that this is a placeholder for a
+    missing dependency.
     """
-    target_group, dep_name, missing = _resolve_self_dependency(
-        group, annotation.removeprefix("self#")
-    )
-    if missing:
-        if param.default is inspect.Parameter.empty:
-            return None, None, True
-        return None, None, False
+    def _missing(run):
+        return None
 
-    if target_group is group and dep_name in var_defs:
-        # Reference to another method-defined variable in this group.
-        resolved = f"{_group_name(target_group)}.{dep_name}"
-        required = param.default is inspect.Parameter.empty
-        return f"var#{resolved}", (arg_name, dep_name, required), False
+    var = Variable(transient=True)
+    var(_missing)
+    # ensure the name does not contain any glob characters
+    safe_name = re.sub(r"[\!\?\*\[\]]", "_", name)
+    var.name = f'{_group_name(group)}.__missing__.{safe_name}'
+    var.title = var.name
+    return var
 
-    if target_group is group:
-        # Reference to a Variable field (or bound variable) on this group.
-        resolved = _resolve_group_attr_variable_name(group, dep_name, param)
-    else:
-        # Reference to a Variable field on a nested group instance.
-        resolved = _resolve_group_attr_variable_name(target_group, dep_name, param)
 
-    if resolved is _MissingDependency.REQUIRED:
-        return None, None, True
-    if resolved is _MissingDependency.OPTIONAL:
-        return None, None, False
-    return f"var#{resolved}", None, False
+def _resolve_self_annotation(annotation: str, group):
+    path = annotation.removeprefix("self#")
+    target, _, remain = path.partition(".")
+
+    if remain:
+        target = getattr(group, target)
+        if target is None:
+            placeholder = _make_missing_dependency_placeholder(group, path)
+            return f'var#{placeholder.name}', placeholder
+        return _resolve_self_annotation(remain, target)
+
+    try:
+        var_ref = getattr(group, target)
+    except AttributeError:
+        if any(ch in target for ch in "*?["):
+            # glob pattern, will be resolved by ContextRunner.
+            return f'var#{_group_name(group)}.{target}', None
+        raise GroupError(
+            f"Attribute {target!r} on group {_group_name(group)!r} does not exist, "
+            "but is referenced as a dependency in annotation."
+        )
+
+    if var_ref is None:
+        placeholder = _make_missing_dependency_placeholder(group, target)
+        return f'var#{placeholder.name}', placeholder
+
+    if not isinstance(var_ref, (Variable, GroupBoundVariable)):
+        raise GroupError(
+            f"Attribute {target!r} on group {_group_name(group)!r} is of type "
+            f"{type(var_ref).__name__!r}, but a Variable is required for a self# dependency."
+        )
+
+    return f'var#{var_ref.name}', None
 
 
 def _expand_group(group):
     """Build Variables for a group instance, resolving "self#" dependencies.
 
     This binds each @Variable to the group instance, namespaces names and
-    titles, and rewrites annotations to "var#..." dependencies. Group-internal
-    dependencies are tracked so variables with missing required inputs are
-    dropped, and optional dependencies are removed from annotations.
+    titles, and rewrites annotations to "var#..." dependencies.
     """
     group_name = _group_name(group)
     if group.title is None:
         group.title = group_name
 
-    var_defs = _collect_group_variables(group)
-    var_infos = {}
+    var_defs: dict[str, Variable] = _collect_group_variables(group)
+    expanded = {}
 
-    for method_name, var_def in var_defs.items():
+    for var_def in var_defs.values():
         # Create a per-instance Variable copy so name/title/annotations can be
         # rewritten without mutating the class definition.
         bound_func = var_def.func.__get__(group, type(group))
@@ -607,8 +581,6 @@ def _expand_group(group):
         new_var.title = f"{group.title}{group.sep}{var_def.title}"
 
         annotations = {}
-        internal_deps = []
-        drop_var = False
         sig = inspect.signature(bound_func)
         original_annotations = getattr(var_def.func, "__annotations__", {})
         for arg_name, param in sig.parameters.items():
@@ -617,80 +589,26 @@ def _expand_group(group):
                 continue
             if annotation.startswith("self#"):
                 # Resolve group-relative dependencies, possibly across nested groups.
-                resolved, internal_dep, drop = _resolve_self_annotation(
-                    group, var_defs, arg_name, annotation, param
-                )
-                if drop:
-                    drop_var = True
-                    break
-                
-                if resolved is not None:
-                    annotations[arg_name] = resolved
-                    if internal_dep is not None:
-                        internal_deps.append(internal_dep)
+                resolved, placeholder = _resolve_self_annotation(annotation, group)
+                annotations[arg_name] = resolved
+                if placeholder is not None:
+                    # missing dependency -> add placeholder Variable
+                    expanded[placeholder.name] = placeholder
+
             else:
                 annotations[arg_name] = annotation
 
-        if drop_var:
-            continue
-
         new_var.tags = _merge_tags(group.tags, new_var.tags)
-        var_infos[method_name] = {
-            "var": new_var,
-            "annotations": annotations,
-            "internal_deps": internal_deps,
-        }
-
-    # Variables can be dropped during the initial pass above if a required
-    # group-field dependency is missing. We then need to cascade that removal to
-    # any Variables that require the dropped variables.
-    active = set(var_infos)
-    graph = {
-        method_name: {
-            dep_name
-            for (_, dep_name, _) in info["internal_deps"]
-            if dep_name in var_infos
-        }
-        for method_name, info in var_infos.items()
-    }
-
-    try:
-        order = tuple(TopologicalSorter(graph).static_order())
-    except CycleError as e:
-        raise CycleError(
-            f"Group {group_name!r} has cyclical dependencies between "
-            f"variables: {e.args[1]}"
-        ) from e
-
-    for method_name in order:
-        if method_name not in active:
-            continue
-
-        info = var_infos[method_name]
-        remaining_deps = []
-        for arg_name, dep_name, required in info["internal_deps"]:
-            if dep_name not in active:
-                # Drop variables that depend on missing required internal vars;
-                # otherwise remove the dependency and let defaults apply.
-                if required:
-                    active.remove(method_name)
-                    remaining_deps = []
-                    break
-                info["annotations"].pop(arg_name, None)
-            else:
-                remaining_deps.append((arg_name, dep_name, required))
-        info["internal_deps"] = remaining_deps
-
-    expanded = {}
-    for method_name in active:
-        info = var_infos[method_name]
-        info["var"]._annotation_overrides = info["annotations"]
-        expanded[info["var"].name] = info["var"]
+        new_var._annotation_overrides = annotations
+        expanded[new_var.name] = new_var
 
     return expanded
 
 
-def expand_groups(context, existing_vars=None):
+def expand_groups(
+        context: dict[str, Any],
+        existing_vars: dict[str, Variable] | None = None,
+    ) -> dict[str, Variable]:
     """Return Variables generated from Group instances in a context file."""
     _assign_group_names(context)
     groups = _collect_group_instances(context.values())

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -6,15 +6,12 @@ We aim to maintain compatibility with older Python 3 versions (currently 3.9+)
 than the DAMNIT code in general, to allow running context files in other Python
 environments.
 """
-import inspect
 import logging
 import re
 import sys
 from collections.abc import Iterable, Sequence
-from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any
 
 import h5py
 import numpy as np
@@ -292,9 +289,6 @@ class Skip(Exception):
     pass
 
 
-# TODO: split module?
-
-
 class GroupError(Exception):
     pass
 
@@ -316,9 +310,9 @@ def _inherit_group_config(cls):
 
 
 def Group(
-        _cls=None,
-        *,
-        tags: Iterable[str] | str | None = None,
+    _cls=None,
+    *,
+    tags: Iterable[str] | str | None = None,
 ):
     """Decorate a class to define a reusable group of Variables.
 
@@ -416,214 +410,6 @@ def Group(
 def is_group_instance(obj):
     """Return True if obj is an instance of a Group class."""
     return hasattr(type(obj), "__damnit_group__")
-
-
-def _group_name(group):
-    name = group.name
-    if isinstance(name, str) and name:
-        return name
-    if name is None:
-        raise GroupError(
-            f"Group instance of {type(group).__name__!r} has no name. "
-            "Provide name=... or assign it to a variable in the context file."
-        )
-    raise GroupError(
-        f"Group instance of {type(group).__name__!r} has invalid name {name!r}. "
-        "Provide a non-empty string name."
-    )
-
-
-def _assign_group_names(context):
-    # Group names can be assigned by context variable names after execution.
-    # e.g.: mygroup = MyGroup() -> since MyGroup(name=...) wasn't set, 'mygroup'
-    # becomes the name when the context is processed.
-    group_refs = {}
-    for var_name, value in context.items():
-        if var_name.startswith("__"):
-            continue
-        if is_group_instance(value):
-            entry = group_refs.setdefault(id(value), {"obj": value, "names": []})
-            entry["names"].append(var_name)
-
-    for entry in group_refs.values():
-        group = entry["obj"]
-        if group.name is None:
-            names = sorted(entry["names"])
-            if len(names) == 1:
-                group.name = names[0]
-            else:
-                raise GroupError(
-                    f"Group instance of {type(group).__name__!r} is assigned "
-                    f"to multiple names {names} without an explicit name."
-                )
-        if group.title is None:
-            group.title = group.name
-
-
-def _collect_group_instances(objects):
-    pending = [obj for obj in objects if is_group_instance(obj)]
-    groups = []
-    seen_ids = set()
-
-    while pending:
-        group = pending.pop()
-        group_id = id(group)
-        if group_id in seen_ids:
-            continue
-        seen_ids.add(group_id)
-
-        # check if group name is valid
-        _group_name(group)
-        groups.append(group)
-
-        for value in vars(group).values():
-            if is_group_instance(value):
-                pending.append(value)
-
-    return groups
-
-
-def _collect_group_variables(group):
-    vars_by_name = {}
-    for cls in reversed(type(group).mro()):
-        for name, value in cls.__dict__.items():
-            if isinstance(value, Variable):
-                vars_by_name[name] = value
-    return vars_by_name
-
-
-def _make_missing_dependency_placeholder(group, name: str) -> Variable:
-    """Create a fake Variable to replace missing group instances dependencies.
-
-    The Variable name is namespaced to the group and a special __missing__
-    section to make it clear in error messages that this is a placeholder for a
-    missing dependency.
-    """
-    def _missing(run):
-        return None
-
-    var = Variable(transient=True)
-    var(_missing)
-    # ensure the name does not contain any glob characters
-    safe_name = re.sub(r"[!?*\[\]]", "_", name)
-    var.name = f'{group.name}.__missing__.{safe_name}'
-    var.title = var.name
-    return var
-
-
-def _resolve_self_annotation(annotation: str, group):
-    path = annotation.removeprefix("self#")
-    target, _, remain = path.partition(".")
-
-    if remain:
-        target = getattr(group, target)
-        if target is None:
-            placeholder = _make_missing_dependency_placeholder(group, path)
-            return f'var#{placeholder.name}', placeholder
-        return _resolve_self_annotation(remain, target)
-
-    try:
-        var_ref = getattr(group, target)
-    except AttributeError:
-        if any(ch in target for ch in "*?["):
-            # glob pattern, will be resolved by ContextRunner.
-            return f'var#{group.name}.{target}', None
-        raise GroupError(
-            f"Attribute {target!r} on group {group.name!r} does not exist, "
-            "but is referenced as a dependency in annotation."
-        )
-
-    if var_ref is None:
-        placeholder = _make_missing_dependency_placeholder(group, target)
-        return f'var#{placeholder.name}', placeholder
-
-    if not isinstance(var_ref, (Variable, GroupBoundVariable)):
-        raise GroupError(
-            f"Attribute {target!r} on group {group.name!r} is of type "
-            f"{type(var_ref).__name__!r}, but a Variable is required for a self# dependency."
-        )
-
-    return f'var#{var_ref.name}', None
-
-
-def _expand_group(group):
-    """Build Variables for a group instance, resolving "self#" dependencies.
-
-    This binds each @Variable to the group instance, namespaces names and
-    titles, and rewrites annotations to "var#..." dependencies.
-    """
-    if group.title is None:
-        group.title = group.name
-
-    var_defs: dict[str, Variable] = _collect_group_variables(group)
-    expanded = {}
-
-    for var_def in var_defs.values():
-        # Create a per-instance Variable copy so name/title/annotations can be
-        # rewritten without mutating the class definition.
-        bound_func = var_def.func.__get__(group, type(group))
-        new_var = copy(var_def)
-        new_var(bound_func)
-        new_var.name = f"{group.name}.{var_def.name}"
-        new_var.title = f"{group.title}{group.sep}{var_def.title}"
-
-        annotations = {}
-        sig = inspect.signature(bound_func)
-        original_annotations = getattr(var_def.func, "__annotations__", {})
-        for arg_name, param in sig.parameters.items():
-            annotation = original_annotations.get(arg_name, param.annotation)
-            if not isinstance(annotation, str):
-                continue
-            if annotation.startswith("self#"):
-                # Resolve group-relative dependencies, possibly across nested groups.
-                resolved, placeholder = _resolve_self_annotation(annotation, group)
-                annotations[arg_name] = resolved
-                if placeholder is not None:
-                    # missing dependency -> add placeholder Variable
-                    expanded[placeholder.name] = placeholder
-
-            else:
-                annotations[arg_name] = annotation
-
-        new_var.tags = set(group.tags) | set(_normalize_tags(new_var.tags))
-        new_var._annotation_overrides = annotations
-        expanded[new_var.name] = new_var
-
-    return expanded
-
-
-def expand_groups(
-        context: dict[str, Any],
-        existing_vars: dict[str, Variable] | None = None,
-    ) -> dict[str, Variable]:
-    """Return Variables generated from Group instances in a context file."""
-    _assign_group_names(context)
-    groups = _collect_group_instances(context.values())
-    if not groups:
-        return {}
-
-    existing_names = set(existing_vars or {})
-    seen_group_names = {}
-    for group in groups:
-        group_id = id(group)
-        if group.name in seen_group_names and seen_group_names[group.name] != group_id:
-            raise GroupError(
-                f"Group name {group.name!r} is used by multiple group instances"
-            )
-        seen_group_names[group.name] = group_id
-
-    expanded = {}
-    for group in groups:
-        group_vars = _expand_group(group)
-        for var_name in group_vars:
-            if var_name in existing_names or var_name in expanded:
-                raise GroupError(
-                    f"Duplicate variable name {var_name!r} from group "
-                    f"{group.name!r}"
-                )
-        expanded.update(group_vars)
-
-    return expanded
 
 
 class GroupBoundVariable:

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -301,17 +301,17 @@ class GroupError(Exception):
     pass
 
 
-def _normalize_group_tags(tags):
+def _normalize_group_tags(tags) -> tuple[str]:
     if tags is None:
-        return None
+        return ()
     if isinstance(tags, str):
         return (tags,)
     return tuple(tags)
 
 
-def _merge_tags(group_tags, var_tags):
+def _merge_tags(group_tags, var_tags) -> set[str]:
     if not group_tags and not var_tags:
-        return None
+        return set()
     if not group_tags:
         return set(var_tags)
     if not var_tags:

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -549,25 +549,24 @@ def _resolve_group_attr_variable_name(group, dep_name, param):
 def _resolve_self_annotation(group, var_defs, arg_name, annotation, param):
     """Resolve a self# annotation into a var# annotation + dependency metadata.
 
-    Returns (resolved_annotation, internal_dep, drop_var, skip_annotation):
+    Returns (resolved_annotation, internal_dep, drop_var):
     - resolved_annotation: string or None
     - internal_dep: (arg_name, dep_name, required) tuple or None
     - drop_var: True if the variable should be removed entirely
-    - skip_annotation: True if the argument should keep its default
     """
     target_group, dep_name, missing = _resolve_self_dependency(
         group, annotation.removeprefix("self#")
     )
     if missing:
         if param.default is inspect.Parameter.empty:
-            return None, None, True, False
-        return None, None, False, True
+            return None, None, True
+        return None, None, False
 
     if target_group is group and dep_name in var_defs:
         # Reference to another method-defined variable in this group.
         resolved = f"{_group_name(target_group)}.{dep_name}"
         required = param.default is inspect.Parameter.empty
-        return f"var#{resolved}", (arg_name, dep_name, required), False, False
+        return f"var#{resolved}", (arg_name, dep_name, required), False
 
     if target_group is group:
         # Reference to a Variable field (or bound variable) on this group.
@@ -577,10 +576,10 @@ def _resolve_self_annotation(group, var_defs, arg_name, annotation, param):
         resolved = _resolve_group_attr_variable_name(target_group, dep_name, param)
 
     if resolved is _MissingDependency.REQUIRED:
-        return None, None, True, False
+        return None, None, True
     if resolved is _MissingDependency.OPTIONAL:
-        return None, None, False, True
-    return f"var#{resolved}", None, False, False
+        return None, None, False
+    return f"var#{resolved}", None, False
 
 
 def _expand_group(group):
@@ -618,17 +617,17 @@ def _expand_group(group):
                 continue
             if annotation.startswith("self#"):
                 # Resolve group-relative dependencies, possibly across nested groups.
-                resolved, internal_dep, drop, skip = _resolve_self_annotation(
+                resolved, internal_dep, drop = _resolve_self_annotation(
                     group, var_defs, arg_name, annotation, param
                 )
                 if drop:
                     drop_var = True
                     break
-                if skip:
-                    continue
-                annotations[arg_name] = resolved
-                if internal_dep is not None:
-                    internal_deps.append(internal_dep)
+                
+                if resolved is not None:
+                    annotations[arg_name] = resolved
+                    if internal_dep is not None:
+                        internal_deps.append(internal_dep)
             else:
                 annotations[arg_name] = annotation
 

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -724,6 +724,20 @@ def expand_groups(context, existing_vars=None):
 
 
 class GroupBoundVariable:
+    """Proxy for accessing a Group `Variable` on an instance.
+
+    1. It allows you to wire dependencies before the group’s final name is
+       known, (because that name can be inferred from the global assignment
+       after the context code runs) so we don't have to mutate or reuse the
+       shared class-level Variable definition across instances by deferring the
+       per-instance binding work until expand_groups().
+    3. Prevents accidentally collecting this reference in case it leaks into the
+       context top level namespace, which would cause duplicate variable
+       definitions.
+
+    The proxy forwards all other attribute access to the original `Variable`, so
+    it behaves like a `Variable` for e.g. dependency wiring.
+    """
     __damnit_group_bound__ = True
 
     def __init__(self, group, var_def):

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -82,8 +82,6 @@ class Variable:
         return self
 
     def __get__(self, instance, owner):
-        if instance is None:
-            return self
         if is_group_instance(instance):
             # Return a proxy that resolves the group name lazily after context exec.
             return GroupBoundVariable(instance, self)
@@ -301,23 +299,12 @@ class GroupError(Exception):
     pass
 
 
-def _normalize_group_tags(tags) -> tuple[str]:
+def _normalize_tags(tags) -> tuple[str]:
     if tags is None:
         return ()
     if isinstance(tags, str):
         return (tags,)
     return tuple(tags)
-
-
-def _merge_tags(group_tags, var_tags) -> set[str]:
-    if not group_tags and not var_tags:
-        return set()
-    if not group_tags:
-        return set(var_tags)
-    if not var_tags:
-        return set(group_tags)
-
-    return set(group_tags) | set(var_tags)
 
 
 def _inherit_group_config(cls):
@@ -387,15 +374,13 @@ def Group(
         nonlocal tags
         if tags is None:
             tags = parent_config.get("tags")
-        tags = _normalize_group_tags(tags)
+        tags = _normalize_tags(tags)
 
         cls.__damnit_group__ = True
         cls.__damnit_group_config__ = RESERVED_GROUP_FIELDS.copy()
         cls.__damnit_group_config__["tags"] = tags
 
         annotations = dict(getattr(cls, "__annotations__", {}))
-        for field_name in reserved_fields:
-            annotations.pop(field_name, None)
         annotations.update({
             "name": str | None,
             "title": str | None,
@@ -412,7 +397,7 @@ def Group(
         original_post_init = getattr(cls, "__post_init__", None)
 
         def __post_init__(self):
-            self.tags = _normalize_group_tags(self.tags)
+            self.tags = _normalize_tags(self.tags)
             if self.title is None:
                 self.title = self.name
 
@@ -486,6 +471,9 @@ def _collect_group_instances(objects):
         if group_id in seen_ids:
             continue
         seen_ids.add(group_id)
+
+        # check if group name is valid
+        _group_name(group)
         groups.append(group)
 
         for value in vars(group).values():
@@ -505,7 +493,7 @@ def _collect_group_variables(group):
 
 
 def _make_missing_dependency_placeholder(group, name: str) -> Variable:
-    """Create a fake Variable to replace missing group istances dependencies.
+    """Create a fake Variable to replace missing group instances dependencies.
 
     The Variable name is namespaced to the group and a special __missing__
     section to make it clear in error messages that this is a placeholder for a
@@ -517,8 +505,8 @@ def _make_missing_dependency_placeholder(group, name: str) -> Variable:
     var = Variable(transient=True)
     var(_missing)
     # ensure the name does not contain any glob characters
-    safe_name = re.sub(r"[\!\?\*\[\]]", "_", name)
-    var.name = f'{_group_name(group)}.__missing__.{safe_name}'
+    safe_name = re.sub(r"[!?*\[\]]", "_", name)
+    var.name = f'{group.name}.__missing__.{safe_name}'
     var.title = var.name
     return var
 
@@ -539,9 +527,9 @@ def _resolve_self_annotation(annotation: str, group):
     except AttributeError:
         if any(ch in target for ch in "*?["):
             # glob pattern, will be resolved by ContextRunner.
-            return f'var#{_group_name(group)}.{target}', None
+            return f'var#{group.name}.{target}', None
         raise GroupError(
-            f"Attribute {target!r} on group {_group_name(group)!r} does not exist, "
+            f"Attribute {target!r} on group {group.name!r} does not exist, "
             "but is referenced as a dependency in annotation."
         )
 
@@ -551,7 +539,7 @@ def _resolve_self_annotation(annotation: str, group):
 
     if not isinstance(var_ref, (Variable, GroupBoundVariable)):
         raise GroupError(
-            f"Attribute {target!r} on group {_group_name(group)!r} is of type "
+            f"Attribute {target!r} on group {group.name!r} is of type "
             f"{type(var_ref).__name__!r}, but a Variable is required for a self# dependency."
         )
 
@@ -564,9 +552,8 @@ def _expand_group(group):
     This binds each @Variable to the group instance, namespaces names and
     titles, and rewrites annotations to "var#..." dependencies.
     """
-    group_name = _group_name(group)
     if group.title is None:
-        group.title = group_name
+        group.title = group.name
 
     var_defs: dict[str, Variable] = _collect_group_variables(group)
     expanded = {}
@@ -577,7 +564,7 @@ def _expand_group(group):
         bound_func = var_def.func.__get__(group, type(group))
         new_var = copy(var_def)
         new_var(bound_func)
-        new_var.name = f"{group_name}.{var_def.name}"
+        new_var.name = f"{group.name}.{var_def.name}"
         new_var.title = f"{group.title}{group.sep}{var_def.title}"
 
         annotations = {}
@@ -598,7 +585,7 @@ def _expand_group(group):
             else:
                 annotations[arg_name] = annotation
 
-        new_var.tags = _merge_tags(group.tags, new_var.tags)
+        new_var.tags = set(group.tags) | set(_normalize_tags(new_var.tags))
         new_var._annotation_overrides = annotations
         expanded[new_var.name] = new_var
 
@@ -618,13 +605,12 @@ def expand_groups(
     existing_names = set(existing_vars or {})
     seen_group_names = {}
     for group in groups:
-        name = _group_name(group)
         group_id = id(group)
-        if name in seen_group_names and seen_group_names[name] != group_id:
+        if group.name in seen_group_names and seen_group_names[group.name] != group_id:
             raise GroupError(
-                f"Group name {name!r} is used by multiple group instances"
+                f"Group name {group.name!r} is used by multiple group instances"
             )
-        seen_group_names[name] = group_id
+        seen_group_names[group.name] = group_id
 
     expanded = {}
     for group in groups:
@@ -633,7 +619,7 @@ def expand_groups(
             if var_name in existing_names or var_name in expanded:
                 raise GroupError(
                     f"Duplicate variable name {var_name!r} from group "
-                    f"{_group_name(group)!r}"
+                    f"{group.name!r}"
                 )
         expanded.update(group_vars)
 
@@ -648,7 +634,7 @@ class GroupBoundVariable:
        after the context code runs) so we don't have to mutate or reuse the
        shared class-level Variable definition across instances by deferring the
        per-instance binding work until expand_groups().
-    3. Prevents accidentally collecting this reference in case it leaks into the
+    2. Prevents accidentally collecting this reference in case it leaks into the
        context top level namespace, which would cause duplicate variable
        definitions.
 
@@ -663,7 +649,7 @@ class GroupBoundVariable:
 
     @property
     def name(self):
-        return f"{_group_name(self._group)}.{self._var_def.name}"
+        return f"{self._group.name}.{self._var_def.name}"
 
     def __getattr__(self, attr):
         return getattr(self._var_def, attr)

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -14,6 +14,7 @@ from collections.abc import Iterable, Sequence
 from copy import copy
 from dataclasses import dataclass, field
 from enum import Enum
+from graphlib import CycleError, TopologicalSorter
 
 import h5py
 import numpy as np
@@ -641,26 +642,45 @@ def _expand_group(group):
             "internal_deps": internal_deps,
         }
 
+    # Variables can be dropped during the initial pass above if a required
+    # group-field dependency is missing. We then need to cascade that removal to
+    # any Variables that require the dropped variables.
     active = set(var_infos)
-    changed = True
-    while changed:
-        changed = False
-        for method_name in list(active):
-            info = var_infos[method_name]
-            remaining_deps = []
-            for arg_name, dep_name, required in info["internal_deps"]:
-                if dep_name not in active:
-                    # Drop variables that depend on missing required internal vars;
-                    # otherwise remove the dependency and let defaults apply.
-                    if required:
-                        active.remove(method_name)
-                        changed = True
-                        remaining_deps = []
-                        break
-                    info["annotations"].pop(arg_name, None)
-                else:
-                    remaining_deps.append((arg_name, dep_name, required))
-            info["internal_deps"] = remaining_deps
+    graph = {
+        method_name: {
+            dep_name
+            for (_, dep_name, _) in info["internal_deps"]
+            if dep_name in var_infos
+        }
+        for method_name, info in var_infos.items()
+    }
+
+    try:
+        order = tuple(TopologicalSorter(graph).static_order())
+    except CycleError as e:
+        raise CycleError(
+            f"Group {group_name!r} has cyclical dependencies between "
+            f"variables: {e.args[1]}"
+        ) from e
+
+    for method_name in order:
+        if method_name not in active:
+            continue
+
+        info = var_infos[method_name]
+        remaining_deps = []
+        for arg_name, dep_name, required in info["internal_deps"]:
+            if dep_name not in active:
+                # Drop variables that depend on missing required internal vars;
+                # otherwise remove the dependency and let defaults apply.
+                if required:
+                    active.remove(method_name)
+                    remaining_deps = []
+                    break
+                info["annotations"].pop(arg_name, None)
+            else:
+                remaining_deps.append((arg_name, dep_name, required))
+        info["internal_deps"] = remaining_deps
 
     expanded = {}
     for method_name in active:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,10 @@ Added:
 - Core: Introduced a migrations framework to apply future schema changes
   predictably (!510).
 - GUI: save/restore column widths setting (!526).
+- Core: downsampled 1D data is now saved in the database instead of thumbnail
+  (!531).
+- GUI: Display interactive sparklines for 1D data in the main table (!531).
+- Core: New ``Group`` class decorator to create reusable components (!532).
 
 Fixed:
 

--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -173,6 +173,81 @@ $ damnit db-config noncluster_cpus 8
 $ damnit db-config noncluster_mem 50G
 ```
 
+### Cell
+
+The `Cell` object is a versatile container that allows customizing how data is
+stored and displayed in the table. When writing [Variables](#variables), you can
+return a `Cell` object to control both the full data storage and its summary
+representation. A `Cell` takes these arguments:
+
+- `data`: The main data to store
+- `summary`: Function name (as string) from the `numpy` module to compute
+  summary from data (e.g., 'mean', 'std')
+- `summary_value`: Direct value to use as summary (number or string)
+- `bold`: A boolean indicating whether the text should be rendered in a bold
+  font in the table's cell
+- `background`: Cell background color as hex string (e.g. `'#ffcc00'`)
+  or RGB sequence (0-255 values)
+- `preview`: What to show in a pop-up when the cell is double clicked.
+  This can be a 1D or 2D array, or a Matplotlib or Plotly figure.
+  If `data` is one of these types, it doesn't need to be specified again.
+
+Example Usage:
+
+```python
+@Variable(title="Peaks")
+def peaks(run):
+    success, counts, data = computation(run)
+    return Cell(
+        data=data,
+        summary_value=f"{counts} peaks detected" if success else "No peak",
+        bold=True,
+        background="#7cfc00" if success else "#ff0000"
+    )
+```
+
+### Using Slurm
+As mentioned in the previous section, variables can be marked for execution in a
+Slurm job with the `cluster=True` argument to the decorator:
+```python
+@Variable(title="Foo", cluster=True)
+def foo(run):
+    # some heavy computation ...
+    return 42
+```
+
+This should work out-of-the-box with no other configuration needed. The default
+timeout for Slurm jobs is 2 hours, which can be customized through the
+`slurm_time` setting:
+```bash
+# Set a time limit of 5 hours
+$ damnit db-config slurm_time 05:00:00
+```
+
+By default DAMNIT will figure out an appropriate partition that user has access
+to, but that can be overridden by explicitly setting a partition or reservation:
+```bash
+# Set a reservation
+$ damnit db-config slurm_reservation upex_001234
+
+# Set a partition
+$ damnit db-config slurm_partition allgpu
+```
+
+If both `slurm_reservation` and `slurm_partition` are set, the reservation will
+be chosen. The jobs will be named something like `r42-p1234-damnit` and both
+stdout and stderr will be written to the run's log file in the `process_logs/`
+directory.
+
+!!! warning
+
+    Make sure to delete the reservation setting after the reservation has
+    expired, otherwise Slurm jobs will fail to launch.
+
+    ```bash
+    $ damnit db-config slurm_reservation --delete
+    ```
+
 ## `@Group`
 For more complex or reusable sets of analyses, you can group related variables
 together using a class decorated with `@Group`. This allows you to create
@@ -436,83 +511,6 @@ class DetectorAnalysisAlt(BaseAnalysis):
 # This instance will have two variables: detector.n_trains and detector.photon_count
 detector = DetectorAnalysis(title="Detector")
 ```
-
-### Cell
-
-The `Cell` object is a versatile container that allows customizing how data is
-stored and displayed in the table. When writing [Variables](#variables), you can
-return a `Cell` object to control both the full data storage and its summary
-representation. A `Cell` takes these arguments:
-
-- `data`: The main data to store
-- `summary`: Function name (as string) from the `numpy` module to compute
-  summary from data (e.g., 'mean', 'std')
-- `summary_value`: Direct value to use as summary (number or string)
-- `bold`: A boolean indicating whether the text should be rendered in a bold
-  font in the table's cell
-- `background`: Cell background color as hex string (e.g. `'#ffcc00'`)
-  or RGB sequence (0-255 values)
-- `preview`: What to show in a pop-up when the cell is double clicked.
-  This can be a 1D or 2D array, or a Matplotlib or Plotly figure.
-  If `data` is one of these types, it doesn't need to be specified again.
-
-Example Usage:
-
-```python
-from damnit_ctx import Variable, Cell
-
-@Variable(title="Peaks")
-def peaks(run):
-    success, counts, data = computation(run)
-    return Cell(
-        data=data,
-        summary_value=f"{counts} peaks detected" if success else "No peak",
-        bold=True,
-        background="#7cfc00" if success else "#ff0000"
-    )
-```
-
-### Using Slurm
-As mentioned in the previous section, variables can be marked for execution in a
-Slurm job with the `cluster=True` argument to the decorator:
-```python
-@Variable(title="Foo", cluster=True)
-def foo(run):
-    # some heavy computation ...
-    return 42
-```
-
-This should work out-of-the-box with no other configuration needed. The default
-timeout for Slurm jobs is 2 hours, which can be customized through the
-`slurm_time` setting:
-```bash
-# Set a time limit of 5 hours
-$ damnit db-config slurm_time 05:00:00
-```
-
-By default DAMNIT will figure out an appropriate partition that user has access
-to, but that can be overridden by explicitly setting a partition or reservation:
-```bash
-# Set a reservation
-$ damnit db-config slurm_reservation upex_001234
-
-# Set a partition
-$ damnit db-config slurm_partition allgpu
-```
-
-If both `slurm_reservation` and `slurm_partition` are set, the reservation will
-be chosen. The jobs will be named something like `r42-p1234-damnit` and both
-stdout and stderr will be written to the run's log file in the `process_logs/`
-directory.
-
-!!! warning
-
-    Make sure to delete the reservation setting after the reservation has
-    expired, otherwise Slurm jobs will fail to launch.
-
-    ```bash
-    $ damnit db-config slurm_reservation --delete
-    ```
 
 ## Using custom environments
 DAMNIT supports running the context file in a user-defined Python environment,

--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -253,7 +253,7 @@ without an explicit `name=`.
 Decorator tag defaults can be overridden per instance:
 
 ```python
-another_xgm = XGMDiagnostics(name="another_xgm", title="Another XGM", tags=["XGM!"])
+xgm = XGMDiagnostics(name="another_xgm", title="Another XGM", tags=["XGM!"])
 ```
 
 > Note: Group classes cannot define or override the reserved fields `name`,
@@ -311,8 +311,8 @@ class A:
     def asdf(self, run, data: "self#v"):
         return data + 1
 
-a1 = A(name="a1", v=base)
-a2 = A(name="a2", v=a1.asdf)
+a1 = A(v=base)
+a2 = A(v=a1.asdf)
 # a1.asdf depends on base; a2.asdf depends on a1.asdf
 ```
 
@@ -354,17 +354,17 @@ class MIDDiagnostics:
 
 # 1. Define the shared, top-level instances. Their `name` values
 #    ("xgm_sa2", "xgm_hed") are their public identifiers.
-xgm_sa2 = XGMDiagnostics(name="xgm_sa2", device_name="SA2_XTD6_XGM/XGM/DOOCS")
-xgm_hed = XGMDiagnostics(name="xgm_hed", device_name="HED_XTD9_XGM/XGM/DOOCS")
+xgm_sa2 = XGMDiagnostics(device_name="SA2_XTD6_XGM/XGM/DOOCS")
+xgm_mid = XGMDiagnostics(device_name="MID_XTD9_XGM/XGM/DOOCS")
 
-agipd = Detector(name="agipd", title="AGIPD")
+agipd = Detector(title="AGIPD")
 
 # 2. Instantiate the linking group and provide the dependency objects.
-diag1 = MIDDiagnostics(name="mid_diag_sa2", title="MID Diagnostics", xgm=xgm_sa2, detector=agipd)
-diag2 = MIDDiagnostics(name="mid_diag_hed", title="MID Diagnostics", xgm=xgm_hed, detector=agipd)
+diag1 = MIDDiagnostics(title="MID Diagnostics SA2", xgm=xgm_sa2, detector=agipd)
+diag2 = MIDDiagnostics(title="MID Diagnostics MID", xgm=xgm_mid, detector=agipd)
 
 # Result: `diag1` depends on `xgm_sa2.corrected_energy`, and
-# `diag2` depends on `xgm_hed.corrected_energy`. No work is duplicated.
+# `diag2` depends on `xgm_mid.corrected_energy`. No work is duplicated.
 ```
 
 ### Optional components and defaults
@@ -398,8 +398,8 @@ class B:
         return value + 1
 
 a = A(name="a")
-b_full = B(name="b_full", upstream=a)
-b_partial = B(name="b_partial")  # upstream defaults to None
+b_full = B(upstream=a)
+b_partial = B()  # upstream defaults to None
 # b_full exposes both variables. b_partial drops needs_upstream but keeps
 # optional_upstream, which receives the default value (42) at runtime.
 ```
@@ -434,7 +434,7 @@ class DetectorAnalysisAlt(BaseAnalysis):
     ...
 
 # This instance will have two variables: detector.n_trains and detector.photon_count
-detector = DetectorAnalysis(name="detector", title="Detector")
+detector = DetectorAnalysis(title="Detector")
 ```
 
 ### Cell

--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -173,6 +173,271 @@ $ damnit db-config noncluster_cpus 8
 $ damnit db-config noncluster_mem 50G
 ```
 
+## `@Group`
+For more complex or reusable sets of analyses, you can group related variables
+together using a class decorated with `@Group`. This allows you to create
+self-contained, configurable components that can be instantiated multiple times.
+
+A `Group` is a standard Python class containing methods decorated with
+`@Variable`. The class itself is decorated with `@Group`, which transforms it
+into a configurable, `dataclass` object.
+
+```python title="context.py"
+from extra.components import XGM
+from damnit_ctx import Variable, Group
+
+@Group(tags=["XGM"])
+class XGMDiagnostics:
+    # parameters are defined as dataclass fields
+    device_name: str
+    offset: float = 0.0
+
+    @Variable(title="Pulse Energy", summary="mean")
+    def pulse_energy(self, run):
+        # Use instance attributes for configuration
+        return XGM(run, self.device_name).pulse_energy()
+
+    @Variable(title="Corrected Energy", summary="mean")
+    def corrected_energy(self, run, energy: "self#pulse_energy"):
+        # This has an intra-group dependency on the 'pulse_energy' variable
+        return energy + self.offset
+
+# Instantiate the group in your context file, providing parameter values
+xgm_sa2 = XGMDiagnostics(
+    name="xgm_sa2",
+    title="XGM SA2",
+    device_name="SA2_XTD6_XGM/XGM/DOOCS",
+    offset=1.1,
+)
+xgm_hed = XGMDiagnostics(
+    name="xgm_hed",
+    title="XGM HED",
+    device_name="HED_XTD9_XGM/XGM/DOOCS",
+    offset=0.9,
+)
+```
+
+### Naming and Titles
+Each `Group` instance has a `name` attribute that becomes the prefix for every
+`Variable` inside it. Pass a unique, non-empty `name=` when you instantiate the
+group, or assign the instance to a name in the context file (e.g.
+`xgm = XGMDiagnostics()`); in that case, the variable name becomes the group
+name. If `name` is still unset after the context is processed, DAMNIT raises an
+error. An error is also raised if two groups end up with the same name, or if a
+single group instance is assigned to multiple names without an explicit
+`name=`.
+
+- The **`Variable` name** is formed by joining the `Group`'s `name` and the
+  method's name with a dot: `xgm_sa2.pulse_energy`.
+- The **variable title** (for display in the GUI) is formed by joining the
+  `Group`'s title and the `Variable`'s title with a separator (default is `/`):
+  `XGM SA2/Pulse Energy`. If a group instance has no title, it defaults to the
+  group name.
+
+### `Group` attributes:
+`@Group` injects a few dataclass fields that automatically apply to the group's
+`Variable`s:
+
+- `name`: Machine-readable identifier and prefix. Must be unique; defaults to
+  `None`. If left unset, it is inferred from the variable name in the context
+  file when the instance is assigned.
+- `title`: Prefixes every `Variable` title within the `Group`.
+- `sep` (default `/`): Separator between the group title and the variable title.
+- `tags`: Added to every `Variable` in the group and merged with per-variable
+  tags.
+- `cluster`, `data` and `transient`: These properties remain per-`Variable` and
+  cannot be configured on the group itself.
+
+`@Group` only accepts `tags=...` as a decorator argument; `name`, `title`, and
+`sep` are per-instance fields.
+
+Decorator tag defaults can be overridden per instance:
+
+```python
+another_xgm = XGMDiagnostics(name="another_xgm", title="Another XGM", tags=["XGM!"])
+```
+
+> Note: Group classes cannot define or override the reserved fields `name`,
+> `title`, `sep`, or `tags`. These are injected by `@Group`.
+
+### Dependencies
+- **Intra-group dependencies:** To depend on another variable within the same
+  `Group` instance, you must replace the `var#` prefix with `self#` in the
+  attribute annotation. This explicitly tells DAMNIT to look for the `Variable`
+  within the current `Group`'s scope.
+  ```python
+  @Variable()
+  def corrected_energy(self, run, energy: "self#pulse_energy"):
+      ...
+  ```
+- **Global and Cross-Group Dependencies:** To depend on any variable outside the
+  current group's scope, you use the standard `var#` prefix with the variable's
+  final, fully-qualified name.
+  ```python
+  @Variable(title="Global Offset")
+  def global_offset(run):
+      return 42
+
+  @Group
+  class MyGroup:
+
+      @Variable()
+      def local_var(self, run, offset: "var#global_offset"):
+          # Correctly depends on the top-level global_offset
+          return 10 + offset
+
+      @Variable()
+      def another_var(self, run, xgm_energy: "var#xgm_hed.corrected_energy"):
+          # Correctly depends on a variable from another group instance
+          return xgm_energy * 2
+
+  instance = MyGroup(name="analysis", title="Group")
+  ```
+
+### Linking Variable fields
+Group fields can point to `Variable` instances (including variables within other
+group instances). A `self#` dependency can reference those fields directly, and
+DAMNIT resolves the final variable name.
+
+```python
+@Variable
+def base(run):
+    return 1
+
+@Group
+class A:
+    v: Variable
+
+    @Variable
+    def asdf(self, run, data: "self#v"):
+        return data + 1
+
+a1 = A(name="a1", v=base)
+a2 = A(name="a2", v=a1.asdf)
+# a1.asdf depends on base; a2.asdf depends on a1.asdf
+```
+
+### Linking Groups
+You can create more complex analysis pipelines by linking independent `Group`s.
+This is useful for:
+
+- **Avoiding Duplication**: Link to a shared component (like an XGM diagnostic)
+  from multiple other groups. The XGM analysis will run only once, and all
+  dependent groups will use its result.
+- **Logical Separation**: Keep different analysis domains separate. For example,
+  detector diagnostics and beamline diagnostics can be defined in independent
+  groups and then linked together by a higher-level analysis, without mixing
+  their internal logic.
+- **No Hardcoding**: Avoid hardcoding variable names like
+  `var#xgm_sa2.intensity`. By linking, you make your group configurable,
+  allowing it to be connected to `xgm_sa2` in one context and `xgm_hed` in
+  another by passing different group instances.
+
+Declare dataclass fields typed as other `Group`s and assign concrete instances
+when you instantiate the outer group. A `self#` dependency such as
+`self#xgm.corrected_energy` follows the attribute path, resolves the nested
+instance, and uses that instance's `name` (e.g. `xgm_sa2`) to build the final
+dependency (`xgm_sa2.corrected_energy`).
+
+```python
+@Group(tags=["MID", "Diag"])
+class MIDDiagnostics:
+    xgm: XGMDiagnostics
+    detector: Detector
+
+    @Variable(title="Photons per µJ")
+    def photons_per_microjoule(self, run,
+                               photons: "self#detector.n_photons",
+                               energy: "self#xgm.corrected_energy"):
+        # The system resolves `xgm` to the linked instance named "xgm_sa2"
+        # and looks up the final variable `xgm_sa2.corrected_energy`.
+        return photons / energy
+
+# 1. Define the shared, top-level instances. Their `name` values
+#    ("xgm_sa2", "xgm_hed") are their public identifiers.
+xgm_sa2 = XGMDiagnostics(name="xgm_sa2", device_name="SA2_XTD6_XGM/XGM/DOOCS")
+xgm_hed = XGMDiagnostics(name="xgm_hed", device_name="HED_XTD9_XGM/XGM/DOOCS")
+
+agipd = Detector(name="agipd", title="AGIPD")
+
+# 2. Instantiate the linking group and provide the dependency objects.
+diag1 = MIDDiagnostics(name="mid_diag_sa2", title="MID Diagnostics", xgm=xgm_sa2, detector=agipd)
+diag2 = MIDDiagnostics(name="mid_diag_hed", title="MID Diagnostics", xgm=xgm_hed, detector=agipd)
+
+# Result: `diag1` depends on `xgm_sa2.corrected_energy`, and
+# `diag2` depends on `xgm_hed.corrected_energy`. No work is duplicated.
+```
+
+### Optional components and defaults
+Sometimes a group depends on sub-components that are not always present. Declare
+those fields with a default of `None` and annotate dependencies with `self#`. If
+the referenced attribute is `None` and the variable argument has no default,
+DAMNIT removes that variable during instantiation so it never runs with missing
+inputs. If the argument has a default, the dependency is omitted and the default
+value is used at runtime.
+
+Provide a default argument to keep the variable around and fall back to that
+value when the dependency is absent:
+
+```python
+@Group
+class A:
+    @Variable
+    def var(self, run):
+        return 41
+
+@Group
+class B:
+    upstream: A | None = None
+
+    @Variable
+    def needs_upstream(self, run, value: "self#upstream.var"):
+        return value + 1
+
+    @Variable
+    def optional_upstream(self, run, value: "self#upstream.var" = 42):
+        return value + 1
+
+a = A(name="a")
+b_full = B(name="b_full", upstream=a)
+b_partial = B(name="b_partial")  # upstream defaults to None
+# b_full exposes both variables. b_partial drops needs_upstream but keeps
+# optional_upstream, which receives the default value (42) at runtime.
+```
+
+### Inheritance
+`Group` supports standard Python class inheritance, similar to dataclasses.
+Subclasses should also be decorated with `@Group` so their dataclass fields are
+processed. A decorated subclass automatically includes all `@Variable` methods
+from its parent(s). `tags` defined in a `@group` decorator are inherited unless
+redefined in the subclass.
+
+```python
+@Group(tags=['Analysis'])
+class BaseAnalysis:
+    @Variable(title="Train Count")
+    def n_trains(self, run):
+        return len(run.train_ids)
+
+@Group
+class DetectorAnalysis(BaseAnalysis):
+    # Inherits n_trains Variable
+    # Inherits tags=['Analysis']
+
+    @Variable(title="Photon Count", data="proc")
+    def photon_count(self, run, n_trains: "self#n_trains"):
+        # Depends on an inherited variable
+        return 1e6 / n_trains
+
+@Group(tags=["Alt"])
+class DetectorAnalysisAlt(BaseAnalysis):
+    # Group tags are overwritten in this subclass.
+    ...
+
+# This instance will have two variables: detector.n_trains and detector.photon_count
+detector = DetectorAnalysis(name="detector", title="Detector")
+```
+
 ### Cell
 
 The `Cell` object is a versatile container that allows customizing how data is

--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -204,13 +204,11 @@ class XGMDiagnostics:
 
 # Instantiate the group in your context file, providing parameter values
 xgm_sa2 = XGMDiagnostics(
-    name="xgm_sa2",
     title="XGM SA2",
     device_name="SA2_XTD6_XGM/XGM/DOOCS",
     offset=1.1,
 )
 xgm_hed = XGMDiagnostics(
-    name="xgm_hed",
     title="XGM HED",
     device_name="HED_XTD9_XGM/XGM/DOOCS",
     offset=0.9,
@@ -219,13 +217,14 @@ xgm_hed = XGMDiagnostics(
 
 ### Naming and Titles
 Each `Group` instance has a `name` attribute that becomes the prefix for every
-`Variable` inside it. Pass a unique, non-empty `name=` when you instantiate the
-group, or assign the instance to a name in the context file (e.g.
-`xgm = XGMDiagnostics()`); in that case, the variable name becomes the group
-name. If `name` is still unset after the context is processed, DAMNIT raises an
-error. An error is also raised if two groups end up with the same name, or if a
-single group instance is assigned to multiple names without an explicit
-`name=`.
+`Variable` inside it. By default, you can leave `name` unset and assign the
+instance to a top-level variable in the context file (e.g.
+`xgm = XGMDiagnostics()`); that variable name becomes the group name. If you
+need a different name (or the instance is not referenced in the globals of the
+context file), pass a unique, non-empty `name=` when you instantiate the group.
+DAMNIT raises an error if the name cannot be determined, if two groups end up
+with the same name, or if a single group instance is assigned to multiple names
+without an explicit `name=`.
 
 - The **`Variable` name** is formed by joining the `Group`'s `name` and the
   method's name with a dot: `xgm_sa2.pulse_energy`.

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -250,6 +250,32 @@ def test_context_file(mock_ctx, tmp_path):
     assert ctx.vars["foo"].title == "foo"
     assert ctx.vars["foo"].name == "foo"
 
+    # test variable name
+    invalid_var_name = """
+    from damnit_ctx import Variable
+
+    @Variable
+    def var(run):
+        return 42
+
+    var.name = 'var.1.name'
+    """
+    ctx = mkcontext(invalid_var_name)
+    with pytest.raises(ContextFileErrors, match='not a valid Python identifier'):
+        ctx.check()
+
+    # test invalid data source
+    invalid_var_data = """
+    from damnit_ctx import Variable
+
+    @Variable(data="scratch/test")
+    def var(run):
+        return 42
+    """
+    ctx = mkcontext(invalid_var_data)
+    with pytest.raises(ValueError):
+        ctx.check()
+
 
 def run_ctx_helper(context, run, run_number, proposal, caplog, input_vars=None):
     # Track all error messages during creation. This is necessary because a

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -45,12 +45,167 @@ def test_group_linking_resolves_dependencies():
         def scaled(self, run, energy: "self#inner.energy"):
             return energy * 2
 
-    outer = Outer(name="outer", inner=Inner(name="inner"))
+    outer = Outer(name="outer", inner=Inner(name="blah"))
     """
     ctx = mkcontext(code)
-    assert "inner.energy" in ctx.vars
-    assert "outer.scaled" in ctx.vars
-    assert ctx.vars["outer.scaled"].arg_dependencies() == {"energy": "inner.energy"}
+    assert set(ctx.vars) == {"blah.energy", "outer.scaled"}
+    assert ctx.vars["outer.scaled"].arg_dependencies() == {"energy": "blah.energy"}
+
+
+def test_group_glob(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Other:
+        @Variable
+        def var_a(self, run):
+            return 1
+
+        @Variable
+        def var_b(self, run):
+            return 2
+
+    @Group
+    class G:
+        other: Other
+
+        @Variable
+        def total(self, run, data: "self#other.var_*"):
+            return sum(data.values())
+
+    g = G(other=Other(name="blah"))
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    
+    assert ctx.vars["g.total"].arg_dependencies() == {"data": "blah.var_*"}
+    assert set(ctx.vars) == {"blah.var_a", "blah.var_b", "g.total"}
+    assert results.cells["g.total"].data == 3
+
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Upstream:
+        @Variable
+        def x(self, run):
+            return 1
+
+    @Group
+    class G:
+        upstream: Upstream | None = None
+
+        @Variable
+        def var_a(self, run, x: "self#upstream.x"):
+            return x + 1
+
+        @Variable
+        def var_b(self, run, x: "self#upstream.x"):
+            return x + 2
+
+        @Variable
+        def total(self, run, data: "self#var_*"):
+            return sum(data.values())
+
+    g = G()
+    g2 = G(upstream=Upstream(name="u"))
+    """
+    ctx = mkcontext(code)
+    assert "g.var_a" in ctx.vars
+    assert "g.var_b" in ctx.vars
+    assert "g.total" in ctx.vars
+
+    assert ctx.vars["g2.total"].arg_dependencies() == {"data": "g2.var_*"}
+    assert "g2.var_a" in ctx.vars
+    assert "g2.var_b" in ctx.vars
+    assert "g2.total" in ctx.vars
+
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "g.total" not in results.cells
+    assert results.cells["g2.total"].data == 5
+
+
+def test_group_glob_only_allowed_on_leaf():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Other:
+        @Variable
+        def var(self, run):
+            return 1
+
+    @Group
+    class G:
+        other: Other
+
+        @Variable
+        def out(self, run, v: "self#other*.var"):
+            return v
+
+    g = G(other=Other(name="other"))
+    """
+    with pytest.raises(AttributeError):
+        mkcontext(code)
+
+
+def test_group_missing_group_with_glob_pattern():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Other:
+        @Variable
+        def var_a(self, run):
+            return 1
+
+    @Group
+    class G:
+        other: Other | None = None
+
+        @Variable
+        def total(self, run, data: "self#other.var_*"):
+            return sum(data.values())
+
+    g = G(name="g")
+    """
+    ctx = mkcontext(code)
+    ctx.check()
+    missing = [name for name in ctx.vars if ".__missing__." in name]
+    assert missing[0] == "g.__missing__.other.var__"
+
+
+def test_group_invalid_self_annotation(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def out(self, run, v: "self#no_such_group.x"):
+            return v
+
+    g = G()
+    """
+    with pytest.raises(AttributeError, match="no_such_group"):
+        mkcontext(code)
+
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        blah: int = 5
+
+        @Variable
+        def out(self, run, v: "self#blah"):
+            return v ** 2
+
+    g = G()
+    """
+    with pytest.raises(GroupError, match="type 'int'"):
+        mkcontext(code)
 
 
 def test_group_variable_field_linking(mock_run):
@@ -176,7 +331,7 @@ def test_group_name_instance(mock_run):
     assert results.cells["instance.val"].data == 5
 
 
-def test_group_optional_component_drops_missing_dependency(mock_run):
+def test_group_optional_component_skips_missing_dependency(mock_run):
     code = """
     from damnit_ctx import Variable, Group
 
@@ -202,9 +357,12 @@ def test_group_optional_component_drops_missing_dependency(mock_run):
     """
     ctx = mkcontext(code)
     results = ctx.execute(mock_run, 1000, 123, {})
-    assert "b.needs_upstream" not in ctx.vars
+    assert "b.needs_upstream" in ctx.vars
+    assert "b.needs_upstream" not in results.cells
     assert "b.optional_upstream" in ctx.vars
-    assert ctx.vars["b.optional_upstream"].arg_dependencies() == {}
+    assert ctx.vars["b.optional_upstream"].arg_dependencies() == {
+        "value": "b.__missing__.upstream.var"
+    }
     assert results.cells["b.optional_upstream"].data == 43
 
 
@@ -301,8 +459,11 @@ def test_group_optional_component_cascades_drop(mock_run):
     outer = Outer(name="outer")
     """
     ctx = mkcontext(code)
-    assert "outer.needs_upstream" not in ctx.vars
-    assert "outer.depends_on_needs" not in ctx.vars
+    assert "outer.needs_upstream" in ctx.vars
+    assert "outer.depends_on_needs" in ctx.vars
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "outer.needs_upstream" not in results.cells
+    assert "outer.depends_on_needs" not in results.cells
 
 
     code = """
@@ -355,26 +516,27 @@ def test_group_optional_component_cascades_drop(mock_run):
     ctx = mkcontext(code)
     results = ctx.execute(mock_run, 1000, 123, {})
 
-    # Missing upstream drops 'a', which drops 'b', which cascades to other vars
-    # requiring those internal variables.
-    assert "grp.a" not in ctx.vars
-    assert "grp.b" not in ctx.vars
-    assert "grp.required_from_b" not in ctx.vars
+    # Missing upstream keeps variables but they skip at runtime.
+    assert "grp.a" in ctx.vars
+    assert "grp.b" in ctx.vars
+    assert "grp.required_from_b" in ctx.vars
+    assert "grp.a" not in results.cells
+    assert "grp.b" not in results.cells
+    assert "grp.required_from_b" not in results.cells
 
-    # Optional internal deps are stripped so defaults apply.
     assert "grp.c" in ctx.vars
-    assert ctx.vars["grp.c"].arg_dependencies() == {}
+    assert ctx.vars["grp.c"].arg_dependencies() == {"v": "grp.a"}
     assert results.cells["grp.c"].data == 6
 
     assert "grp.optional_from_b" in ctx.vars
-    assert ctx.vars["grp.optional_from_b"].arg_dependencies() == {}
+    assert ctx.vars["grp.optional_from_b"].arg_dependencies() == {"v": "grp.b"}
     assert results.cells["grp.optional_from_b"].data == 30
 
     # Variables depending on the surviving ones still execute normally.
     assert results.cells["grp.base"].data == 2
     assert results.cells["grp.d"].data == 12
 
-    assert ctx.vars["grp.e"].arg_dependencies() == {"base": "grp.base"}
+    assert ctx.vars["grp.e"].arg_dependencies() == {"base": "grp.base", "v": "grp.a"}
     assert results.cells["grp.e"].data == 12
 
 

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -3,7 +3,43 @@ from graphlib import CycleError
 import pytest
 
 from damnit.context import GroupError
+from damnit.ctxsupport.damnit_ctx import Variable, Group, GroupBoundVariable, is_group_instance, expand_groups
 from .helpers import mkcontext
+
+
+def test_group_variable_reference():
+    @Variable
+    def var(run):
+        return 42
+
+    @Group
+    class Grp:
+        ref: Variable = None
+        grp_ref: Group = None
+
+        @Variable(tags='G!')
+        def grp_var(self, run):
+            return 1 / 42
+
+    group1 = Grp()
+    group2 = Grp(ref=var, grp_ref=group1)
+
+    assert isinstance(var, Variable)
+    assert is_group_instance(group1)
+    assert group1.ref is group1.grp_ref is None
+    assert isinstance(group1.grp_var, GroupBoundVariable)
+    assert isinstance(group2.grp_ref, Grp)
+    assert isinstance(group2.grp_var, GroupBoundVariable)
+    assert isinstance(group2.grp_ref.grp_var, GroupBoundVariable)
+
+    with pytest.raises(match="has no name"):
+        # group names aren't assigned yet
+        group2.grp_ref.grp_var.name
+    
+    expand_groups({"group1": group1, "group2": group2,}, {"var": var})
+
+    # now group names are assigned from context
+    assert group2.grp_ref.grp_var.name == "group1.grp_var"
 
 
 def test_group_expands_variables_and_prefixes():
@@ -42,8 +78,8 @@ def test_group_linking_resolves_dependencies():
         inner: Inner
 
         @Variable
-        def scaled(self, run, energy: "self#inner.energy"):
-            return energy * 2
+        def scaled(self, run, energy: "self#inner.energy", factor: int = 2):
+            return energy * factor
 
     outer = Outer(name="outer", inner=Inner(name="blah"))
     """
@@ -335,6 +371,10 @@ def test_group_optional_component_skips_missing_dependency(mock_run):
     code = """
     from damnit_ctx import Variable, Group
 
+    @Variable
+    def var(run):
+        return 1
+
     @Group
     class A:
         @Variable
@@ -344,14 +384,15 @@ def test_group_optional_component_skips_missing_dependency(mock_run):
     @Group
     class B:
         upstream: A | None = None
+        other_var: Variable | None = None
 
         @Variable
         def needs_upstream(self, run, value: "self#upstream.var"):
             return value + 1
 
         @Variable
-        def optional_upstream(self, run, value: "self#upstream.var" = 42):
-            return value + 1
+        def optional_upstream(self, run, value: "self#upstream.var" = 42, other_value: "self#other_var" = -1):
+            return other_value * (value + 1)
 
     b = B(name="b")
     """
@@ -361,9 +402,10 @@ def test_group_optional_component_skips_missing_dependency(mock_run):
     assert "b.needs_upstream" not in results.cells
     assert "b.optional_upstream" in ctx.vars
     assert ctx.vars["b.optional_upstream"].arg_dependencies() == {
-        "value": "b.__missing__.upstream.var"
+        "value": "b.__missing__.upstream.var",
+        "other_value": "b.__missing__.other_var"
     }
-    assert results.cells["b.optional_upstream"].data == 43
+    assert results.cells["b.optional_upstream"].data == -43
 
 
 def test_group_execute_intra_dependencies_and_overrides(mock_run):
@@ -382,7 +424,7 @@ def test_group_execute_intra_dependencies_and_overrides(mock_run):
         def adjusted(self, run, base: "self#base"):
             return base + self.offset
 
-    g = G(name="g", title="MyDiag", offset=5, tags=["Override"])
+    g = G(name="g", title="MyDiag", offset=5, tags="Override")
     """
     ctx = mkcontext(code)
     results = ctx.execute(mock_run, 1000, 123, {})
@@ -420,7 +462,7 @@ def test_group_linking_exec_and_dependency_paths(mock_run):
         def scaled(self, run, energy: "self#xgm.corrected"):
             return energy * self.factor
 
-    xgm_sa2 = XGM(name="xgm_sa2", title="XGM", offset=1.5)
+    xgm_sa2 = XGM(name="xgm_sa2", title="XGM", offset=1.5, tags="XGM")
     mid = MID(name="mid", title="MID", sep=" | ", xgm=xgm_sa2, factor=3)
     """
     ctx = mkcontext(code)
@@ -750,4 +792,25 @@ def test_group_ambiguous_assignment_raises():
     alias = g
     """
     with pytest.raises(GroupError):
+        mkcontext(code)
+
+
+def test_duplicate_group_var_name():
+    code = """
+    from damnit_ctx import Variable, Group
+    
+    @Variable
+    def dummy(run):
+        return 42
+    dummy.name = "g.var"
+    
+    @Group
+    class G:
+        @Variable
+        def var(self, run):
+            return -42
+    
+    g = G()
+    """
+    with pytest.raises(GroupError, match="Duplicate variable name"):
         mkcontext(code)

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -3,7 +3,10 @@ from graphlib import CycleError
 import pytest
 
 from damnit.context import GroupError
-from damnit.ctxsupport.damnit_ctx import Variable, Group, GroupBoundVariable, is_group_instance, expand_groups
+from damnit.ctxsupport.ctxrunner import expand_groups
+from damnit.ctxsupport.damnit_ctx import (Group, GroupBoundVariable, Variable,
+                                          is_group_instance)
+
 from .helpers import mkcontext
 
 

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -1,3 +1,5 @@
+from graphlib import CycleError
+
 import pytest
 
 from damnit.context import GroupError
@@ -273,7 +275,7 @@ def test_group_linking_exec_and_dependency_paths(mock_run):
     assert ctx.vars["mid.scaled"].title == "MID | Scaled"
 
 
-def test_group_optional_component_cascades_drop():
+def test_group_optional_component_cascades_drop(mock_run):
     code = """
     from typing import Optional
     from damnit_ctx import Variable, Group
@@ -301,6 +303,99 @@ def test_group_optional_component_cascades_drop():
     ctx = mkcontext(code)
     assert "outer.needs_upstream" not in ctx.vars
     assert "outer.depends_on_needs" not in ctx.vars
+
+
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Upstream:
+        @Variable
+        def var(self, run):
+            return 100
+
+    @Group
+    class G:
+        upstream: Upstream | None = None
+
+        @Variable
+        def base(self, run):
+            return 2
+
+        @Variable
+        def a(self, run, v: "self#upstream.var"):
+            return v + 1
+
+        @Variable
+        def b(self, run, v: "self#a"):
+            return v + 1
+
+        @Variable
+        def c(self, run, v: "self#a" = 5):
+            return v + 1
+
+        @Variable
+        def d(self, run, v: "self#c"):
+            return v * 2
+
+        @Variable
+        def e(self, run, base: "self#base", v: "self#a" = 10):
+            return base + v
+
+        @Variable
+        def required_from_b(self, run, v: "self#b"):
+            return v * 10
+
+        @Variable
+        def optional_from_b(self, run, v: "self#b" = 3):
+            return v * 10
+
+    g = G(name="grp")
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+
+    # Missing upstream drops 'a', which drops 'b', which cascades to other vars
+    # requiring those internal variables.
+    assert "grp.a" not in ctx.vars
+    assert "grp.b" not in ctx.vars
+    assert "grp.required_from_b" not in ctx.vars
+
+    # Optional internal deps are stripped so defaults apply.
+    assert "grp.c" in ctx.vars
+    assert ctx.vars["grp.c"].arg_dependencies() == {}
+    assert results.cells["grp.c"].data == 6
+
+    assert "grp.optional_from_b" in ctx.vars
+    assert ctx.vars["grp.optional_from_b"].arg_dependencies() == {}
+    assert results.cells["grp.optional_from_b"].data == 30
+
+    # Variables depending on the surviving ones still execute normally.
+    assert results.cells["grp.base"].data == 2
+    assert results.cells["grp.d"].data == 12
+
+    assert ctx.vars["grp.e"].arg_dependencies() == {"base": "grp.base"}
+    assert results.cells["grp.e"].data == 12
+
+
+def test_group_internal_cycle_raises_clear_error():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def a(self, run, v: "self#b"):
+            return v + 1
+
+        @Variable
+        def b(self, run, v: "self#a"):
+            return v + 1
+
+    g = G(name="g")
+    """
+    with pytest.raises(CycleError, match=r"cyclical dependencies"):
+        mkcontext(code)
 
 
 def test_group_reserved_field_annotation_rejected():

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -369,6 +369,204 @@ def test_group_name_instance(mock_run):
     assert results.cells["instance.val"].data == 5
 
 
+def test_nested_group_name_assignment(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    outer = Outer(inner=Inner())
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "outer.inner.val" in ctx.vars
+    assert "outer.out" in ctx.vars
+    assert ctx.vars["outer.out"].arg_dependencies() == {"val": "outer.inner.val"}
+    assert ctx.vars["outer.inner.val"].title == "outer/inner/val"
+    assert results.cells["outer.inner.val"].data == 1
+    assert results.cells["outer.out"].data == 2
+
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def val(self, run):
+            return 5
+
+    g = G(name="explicit.dot")
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "explicit.dot.val" in ctx.vars
+    assert ctx.vars["explicit.dot.val"].title == "explicit.dot/val"
+    assert results.cells["explicit.dot.val"].data == 5
+
+
+def test_group_name_shortest_path():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    inner = Inner()
+    outer = Outer(inner=inner)
+    """
+    ctx = mkcontext(code)
+    assert "inner.val" in ctx.vars
+    assert "outer.out" in ctx.vars
+    assert "outer.inner.val" not in ctx.vars
+    assert ctx.vars["outer.out"].arg_dependencies() == {"val": "inner.val"}
+
+
+def test_group_nested_name_uses_explicit_parent_prefix():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    outer = Outer(name="explicit", inner=Inner())
+    """
+    ctx = mkcontext(code)
+    assert "explicit.inner.val" in ctx.vars
+    assert "explicit.out" in ctx.vars
+    assert "outer.inner.val" not in ctx.vars
+    assert ctx.vars["explicit.out"].arg_dependencies() == {"val": "explicit.inner.val"}
+
+
+def test_group_explicit_child_name_overrides_nested_assignment(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    inner = Inner(name="custom")
+    outer = Outer(inner=inner)
+    """
+    ctx = mkcontext(code)
+    assert "custom.val" in ctx.vars
+    assert "outer.out" in ctx.vars
+    assert "outer.inner.val" not in ctx.vars
+    assert ctx.vars["outer.out"].arg_dependencies() == {"val": "custom.val"}
+
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert results.cells["custom.val"].data == 1
+    assert results.cells["outer.out"].data == 2
+
+
+def test_group_nested_ambiguous_names_at_same_depth_raises():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    __shared = Inner()
+    outer1 = Outer(inner=__shared)
+    outer2 = Outer(inner=__shared)
+    """
+    with pytest.raises(GroupError, match="multiple names"):
+        mkcontext(code)
+
+
+def test_group_nested_shortest_path_prefers_shallower():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Mid:
+        inner: Inner
+
+    @Group
+    class Outer:
+        mid: Mid
+
+    @Group
+    class Alt:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    shared = Inner()
+    outer = Outer(mid=Mid(inner=shared))
+    alt = Alt(inner=shared)
+    """
+    ctx = mkcontext(code)
+    assert "shared.val" in ctx.vars
+    assert "alt.out" in ctx.vars
+    assert "alt.inner.val" not in ctx.vars
+    assert "outer.mid.inner.val" not in ctx.vars
+    assert ctx.vars["alt.out"].arg_dependencies() == {"val": "shared.val"}
+
+
 def test_group_optional_component_skips_missing_dependency(mock_run):
     code = """
     from damnit_ctx import Variable, Group
@@ -640,7 +838,7 @@ def test_group_reserved_attribute_rejected():
         mkcontext(code)
 
 
-def test_group_missing_name_for_nested_component_raises():
+def test_group_explicit_name_avoids_ambiguity():
     code = """
     from damnit_ctx import Variable, Group
 
@@ -658,10 +856,18 @@ def test_group_missing_name_for_nested_component_raises():
         def out(self, run, val: "self#inner.val"):
             return val + 1
 
-    outer = Outer(name="outer", inner=Inner())
+    shared = Inner(name="shared")
+    outer1 = Outer(inner=shared)
+    outer2 = Outer(inner=Inner(name="inner2"))
+    outer3 = Outer(inner=Inner())
     """
-    with pytest.raises(GroupError):
-        mkcontext(code)
+    ctx = mkcontext(code)
+    assert "shared.val" in ctx.vars
+    assert "inner2.val" in ctx.vars
+    assert "outer3.inner.val" in ctx.vars
+    assert ctx.vars["outer1.out"].arg_dependencies() == {"val": "shared.val"}
+    assert ctx.vars["outer2.out"].arg_dependencies() == {"val": "inner2.val"}
+    assert ctx.vars["outer3.out"].arg_dependencies() == {"val": "outer3.inner.val"}
 
 
 def test_group_inheritance_and_reset(mock_run):

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -32,9 +32,8 @@ def test_group_variable_reference():
     assert isinstance(group2.grp_var, GroupBoundVariable)
     assert isinstance(group2.grp_ref.grp_var, GroupBoundVariable)
 
-    with pytest.raises(match="has no name"):
-        # group names aren't assigned yet
-        group2.grp_ref.grp_var.name
+    # group names aren't assigned yet
+    assert group2.grp_ref.name is None
     
     expand_groups({"group1": group1, "group2": group2,}, {"var": var})
 

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -319,24 +319,12 @@ def test_group_optional_component_cascades_drop(mock_run):
         upstream: Upstream | None = None
 
         @Variable
-        def base(self, run):
-            return 2
-
-        @Variable
-        def a(self, run, v: "self#upstream.var"):
-            return v + 1
-
-        @Variable
-        def b(self, run, v: "self#a"):
-            return v + 1
+        def d(self, run, v: "self#c"):
+            return v * 2
 
         @Variable
         def c(self, run, v: "self#a" = 5):
             return v + 1
-
-        @Variable
-        def d(self, run, v: "self#c"):
-            return v * 2
 
         @Variable
         def e(self, run, base: "self#base", v: "self#a" = 10):
@@ -349,6 +337,18 @@ def test_group_optional_component_cascades_drop(mock_run):
         @Variable
         def optional_from_b(self, run, v: "self#b" = 3):
             return v * 10
+
+        @Variable
+        def b(self, run, v: "self#a"):
+            return v + 1
+
+        @Variable
+        def a(self, run, v: "self#upstream.var"):
+            return v + 1
+
+        @Variable
+        def base(self, run):
+            return 2
 
     g = G(name="grp")
     """

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -1,0 +1,496 @@
+import pytest
+
+from damnit.context import GroupError
+from .helpers import mkcontext
+
+
+def test_group_expands_variables_and_prefixes():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group(tags=["XGM"])
+    class XGM:
+        device_name: str
+
+        @Variable(title="Pulse Energy", tags=["Energy"])
+        def pulse_energy(self, run):
+            return 1
+
+    xgm = XGM(name="xgm_sa2", title="XGM Diag", device_name="SA2_XTD6_XGM/XGM/DOOCS")
+    """
+    ctx = mkcontext(code)
+    assert "xgm_sa2.pulse_energy" in ctx.vars
+    var = ctx.vars["xgm_sa2.pulse_energy"]
+    assert var.title == "XGM Diag/Pulse Energy"
+    assert var.tags == {"XGM", "Energy"}
+
+
+def test_group_linking_resolves_dependencies():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def energy(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def scaled(self, run, energy: "self#inner.energy"):
+            return energy * 2
+
+    outer = Outer(name="outer", inner=Inner(name="inner"))
+    """
+    ctx = mkcontext(code)
+    assert "inner.energy" in ctx.vars
+    assert "outer.scaled" in ctx.vars
+    assert ctx.vars["outer.scaled"].arg_dependencies() == {"energy": "inner.energy"}
+
+
+def test_group_variable_field_linking(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Variable
+    def base(run):
+        return 1
+
+    @Group
+    class A:
+        v: Variable
+
+        @Variable
+        def asdf(self, run, data: "self#v"):
+            return data + 1
+
+    a1 = A(name="a1", v=base)
+    a2 = A(name="a2", v=a1.asdf)
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert results.cells["base"].data == 1
+    assert results.cells["a1.asdf"].data == 2
+    assert results.cells["a2.asdf"].data == 3
+    assert ctx.vars["a1.asdf"].arg_dependencies() == {"data": "base"}
+    assert ctx.vars["a2.asdf"].arg_dependencies() == {"data": "a1.asdf"}
+
+
+def test_group_nested_variable_field_chain(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Variable
+    def base(run):
+        return 5
+
+    @Group
+    class Leaf:
+        linked_base: Variable
+        scale: int = 2
+
+        @Variable
+        def scaled(self, run, value: "self#linked_base"):
+            return value * self.scale
+
+    @Group
+    class Mid:
+        leaf: Leaf
+        offset: int = 4
+
+        @Variable
+        def total(self, run, value: "self#leaf.scaled"):
+            return value + self.offset
+
+    @Group
+    class Outer:
+        mid: Mid
+        factor: int = 2
+
+        @Variable
+        def final(self, run, value: "self#mid.total"):
+            return value * self.factor
+
+        @Variable
+        def extra(self, run, value: "self#mid.leaf.linked_base"):
+            return 2 * value
+
+    leaf = Leaf(name="leaf", linked_base=base, scale=2)
+    mid = Mid(name="mid", leaf=leaf, offset=4)
+    outer = Outer(name="outer", mid=mid, factor=2)
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert results.cells["base"].data == 5
+    assert results.cells["leaf.scaled"].data == 10
+    assert results.cells["mid.total"].data == 14
+    assert results.cells["outer.final"].data == 28
+    assert results.cells["outer.extra"].data == 10
+    assert ctx.vars["leaf.scaled"].arg_dependencies() == {"value": "base"}
+    assert ctx.vars["mid.total"].arg_dependencies() == {"value": "leaf.scaled"}
+    assert ctx.vars["outer.final"].arg_dependencies() == {"value": "mid.total"}
+    assert ctx.vars["outer.extra"].arg_dependencies() == {"value": "base"}
+
+
+def test_group_name_from_context_assignment(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def val(self, run):
+            return 3
+
+    group_name = G()
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "group_name.val" in ctx.vars
+    assert ctx.vars["group_name.val"].title == "group_name/val"
+    assert results.cells["group_name.val"].data == 3
+
+
+def test_group_name_instance(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def val(self, run):
+            return 5
+
+    g = G(name="instance")
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "instance.val" in ctx.vars
+    assert ctx.vars["instance.val"].title == "instance/val"
+    assert "decorated.val" not in ctx.vars
+    assert results.cells["instance.val"].data == 5
+
+
+def test_group_optional_component_drops_missing_dependency(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class A:
+        @Variable
+        def var(self, run):
+            return 41
+
+    @Group
+    class B:
+        upstream: A | None = None
+
+        @Variable
+        def needs_upstream(self, run, value: "self#upstream.var"):
+            return value + 1
+
+        @Variable
+        def optional_upstream(self, run, value: "self#upstream.var" = 42):
+            return value + 1
+
+    b = B(name="b")
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert "b.needs_upstream" not in ctx.vars
+    assert "b.optional_upstream" in ctx.vars
+    assert ctx.vars["b.optional_upstream"].arg_dependencies() == {}
+    assert results.cells["b.optional_upstream"].data == 43
+
+
+def test_group_execute_intra_dependencies_and_overrides(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group(tags=["Default"])
+    class G:
+        offset: float = 0.0
+
+        @Variable(title="Base", tags=["Base"])
+        def base(self, run):
+            return 10
+
+        @Variable(title="Adjusted")
+        def adjusted(self, run, base: "self#base"):
+            return base + self.offset
+
+    g = G(name="g", title="MyDiag", offset=5, tags=["Override"])
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+
+    assert results.cells["g.base"].data == 10
+    assert results.cells["g.adjusted"].data == 15
+    assert ctx.vars["g.adjusted"].arg_dependencies() == {"base": "g.base"}
+    assert ctx.vars["g.adjusted"].title == "MyDiag/Adjusted"
+    assert ctx.vars["g.base"].tags == {"Override", "Base"}
+    assert ctx.vars["g.adjusted"].tags == {"Override"}
+
+
+def test_group_linking_exec_and_dependency_paths(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class XGM:
+        offset: float = 0.0
+
+        @Variable(title="Energy")
+        def energy(self, run):
+            return 10
+
+        @Variable(title="Corrected")
+        def corrected(self, run, energy: "self#energy"):
+            return energy + self.offset
+
+    @Group
+    class MID:
+        xgm: XGM
+        factor: float = 2.0
+
+        @Variable(title="Scaled")
+        def scaled(self, run, energy: "self#xgm.corrected"):
+            return energy * self.factor
+
+    xgm_sa2 = XGM(name="xgm_sa2", title="XGM", offset=1.5)
+    mid = MID(name="mid", title="MID", sep=" | ", xgm=xgm_sa2, factor=3)
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+
+    assert results.cells["xgm_sa2.energy"].data == 10
+    assert results.cells["xgm_sa2.corrected"].data == pytest.approx(11.5)
+    assert results.cells["mid.scaled"].data == pytest.approx(34.5)
+    assert ctx.vars["mid.scaled"].arg_dependencies() == {"energy": "xgm_sa2.corrected"}
+    assert ctx.vars["mid.scaled"].title == "MID | Scaled"
+
+
+def test_group_optional_component_cascades_drop():
+    code = """
+    from typing import Optional
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Upstream:
+        @Variable
+        def value(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        upstream: Optional[Upstream] = None
+
+        @Variable
+        def needs_upstream(self, run, value: "self#upstream.value"):
+            return value + 1
+
+        @Variable
+        def depends_on_needs(self, run, value: "self#needs_upstream"):
+            return value + 1
+
+    outer = Outer(name="outer")
+    """
+    ctx = mkcontext(code)
+    assert "outer.needs_upstream" not in ctx.vars
+    assert "outer.depends_on_needs" not in ctx.vars
+
+
+def test_group_reserved_field_annotation_rejected():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Bad:
+        name: str
+
+        @Variable
+        def val(self, run):
+            return 1
+
+    bad = Bad(name="bad")
+    """
+    with pytest.raises(GroupError):
+        mkcontext(code)
+
+
+def test_group_reserved_attribute_rejected():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Bad:
+        tags = ["nope"]
+
+        @Variable
+        def val(self, run):
+            return 1
+
+    bad = Bad(name="bad")
+    """
+    with pytest.raises(GroupError):
+        mkcontext(code)
+
+
+def test_group_missing_name_for_nested_component_raises():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class Inner:
+        @Variable
+        def val(self, run):
+            return 1
+
+    @Group
+    class Outer:
+        inner: Inner
+
+        @Variable
+        def out(self, run, val: "self#inner.val"):
+            return val + 1
+
+    outer = Outer(name="outer", inner=Inner())
+    """
+    with pytest.raises(GroupError):
+        mkcontext(code)
+
+
+def test_group_inheritance_and_reset(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group(tags=["BaseTag"])
+    class Base:
+        @Variable(title="BaseVar")
+        def base(self, run):
+            return 5
+
+    @Group
+    class Derived(Base):
+        @Variable(title="ChildVar")
+        def child(self, run, base: "self#base"):
+            return base + 1
+
+    @Group(tags=["AltTag"])
+    class DerivedAlt(Base):
+        @Variable(title="AltVar")
+        def alt(self, run):
+            return 7
+
+    derived = Derived(name="derived")
+    alt = DerivedAlt(name="alt", title="Alt")
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+
+    assert results.cells["derived.base"].data == 5
+    assert results.cells["derived.child"].data == 6
+    assert results.cells["alt.base"].data == 5
+    assert results.cells["alt.alt"].data == 7
+
+    assert ctx.vars["derived.base"].title == "derived/BaseVar"
+    assert ctx.vars["derived.child"].title == "derived/ChildVar"
+    assert ctx.vars["derived.base"].tags == {"BaseTag"}
+
+    assert ctx.vars["alt.base"].title == "Alt/BaseVar"
+    assert ctx.vars["alt.alt"].title == "Alt/AltVar"
+    assert ctx.vars["alt.base"].tags == {"AltTag"}
+
+
+def test_group_inherited_dataclass_fields(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class A:
+        label: str
+
+        @Variable
+        def label_len(self, run):
+            return len(self.label)
+
+    @Group
+    class B(A):
+        age: int
+
+        @Variable
+        def age_plus(self, run):
+            return self.age + 1
+
+    b = B(label="asdf", age=12)
+    """
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert results.cells["b.label_len"].data == 4
+    assert results.cells["b.age_plus"].data == 13
+
+
+def test_group_decorated_subclass_non_default_field(mock_run):
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class A:
+        base: int = 1
+
+        @Variable
+        def base_val(self, run):
+            return self.base
+
+    @Group
+    class B(A):
+        value: int
+
+        @Variable
+        def combined(self, run):
+            return self.base + self.value
+
+    b = B(value=3)
+    """
+    with pytest.raises(TypeError):
+        mkcontext(code)
+    # results = ctx.execute(mock_run, 1000, 123, {})
+    # assert results.cells["b.base_val"].data == 1
+    # assert results.cells["b.combined"].data == 4
+
+
+def test_group_duplicate_names_raise():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def val(self, run):
+            return 1
+
+    g1 = G(name="dup")
+    g2 = G(name="dup")
+    """
+    with pytest.raises(GroupError):
+        mkcontext(code)
+
+
+def test_group_ambiguous_assignment_raises():
+    code = """
+    from damnit_ctx import Variable, Group
+
+    @Group
+    class G:
+        @Variable
+        def val(self, run):
+            return 1
+
+    g = G()
+    alias = g
+    """
+    with pytest.raises(GroupError):
+        mkcontext(code)


### PR DESCRIPTION
Alternative implementation to #478 

I wasn't happy with the previous implementation (and got stuck with one requirement 🙈 ). I believe this implementation is more straightforward as it does not try to mutate the Group classes, but instead "collect" variables at exec.

There are slight differences:
- only `tags` can be a `Group` argument. In hindsight, default name/title does not make much sense.
- if a `Group` instance doesn't have a name, it will be "assigned" the instance name from the context file.
- support "nested" Groups.
- probably something else I can't recall now.