### PR TITLE
Show the `Cell` import in the docs

### DIFF
--- a/docs/configuration_and_management.md
+++ b/docs/configuration_and_management.md
@@ -195,6 +195,8 @@ representation. A `Cell` takes these arguments:
 Example Usage:
 
 ```python
+from damnit_ctx import Variable, Cell
+
 @Variable(title="Peaks")
 def peaks(run):
     success, counts, data = computation(run)


### PR DESCRIPTION
This confused a few people who didn't realize it had to be imported explicitly.