### PR TITLE
Fixed typo in SA1 and SA3: exra -> extra

### DIFF
--- a/damnit/ctx-templates/SA1_base.py
+++ b/damnit/ctx-templates/SA1_base.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import numpy as np
 
-from exra.components import XGM, XrayPulses
+from extra.components import XGM, XrayPulses
 from damnit_ctx import Variable
 
 

--- a/damnit/ctx-templates/SA3_base.py
+++ b/damnit/ctx-templates/SA3_base.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import numpy as np
 
-from exra.components import XGM, XrayPulses
+from extra.components import XGM, XrayPulses
 from damnit_ctx import Variable
 
 


### PR DESCRIPTION
There is a typo in the import statements. Fixed for both `SA1_base.py` and `SA3_base.py`. `SA2_base.py` was already correct.