### PR TITLE
Tests: send updates to a simplified Kafka broker instead of mocking

### DIFF
--- a/damnit/backend/combine.py
+++ b/damnit/backend/combine.py
@@ -14,7 +14,7 @@ from kafka import KafkaConsumer, KafkaProducer
 from xarray.backends import H5NetCDFStore
 
 from ..context import DataType
-from ..definitions import FILE_SUBMIT_TOPIC, UPDATE_BROKERS
+from ..definitions import FILE_SUBMIT_TOPIC, update_brokers
 from .db import DamnitDB, MsgKind, msg_dict
 from .extract_data import load_reduced_data, add_to_db
 from .service import notify_ready
@@ -75,12 +75,12 @@ class FileSubmissionProcessor:
     def __init__(self):
         self.consumer = KafkaConsumer(
             FILE_SUBMIT_TOPIC,
-            bootstrap_servers=UPDATE_BROKERS,
+            bootstrap_servers=update_brokers(),
             group_id='xfel-da-damnit-combiner',
             consumer_timeout_ms=600_000,
         )
         self.producer = KafkaProducer(
-            bootstrap_servers=UPDATE_BROKERS,
+            bootstrap_servers=update_brokers(),
             value_serializer=lambda d: json.dumps(d).encode('utf-8')
         )
 

--- a/damnit/backend/combine.py
+++ b/damnit/backend/combine.py
@@ -72,12 +72,13 @@ def combine(src: Path, dst: Path):
 
 
 class FileSubmissionProcessor:
-    def __init__(self):
+    def __init__(self, consumer_config=None):
         self.consumer = KafkaConsumer(
             FILE_SUBMIT_TOPIC,
             bootstrap_servers=update_brokers(),
             group_id='xfel-da-damnit-combiner',
             consumer_timeout_ms=600_000,
+            **(consumer_config or {})
         )
         self.producer = KafkaProducer(
             bootstrap_servers=update_brokers(),
@@ -97,19 +98,25 @@ class FileSubmissionProcessor:
 
     def run(self):
         while True:
-            for record in self.consumer:
-                try:
-                    ts = datetime.fromtimestamp(record.timestamp / 1000, tz=timezone.utc)
-                    msg = json.loads(record.value.decode())
-                    if msg['msg_kind'] == MsgKind.file_submission.value:
-                        self.process_file_submission_msg(msg['data'], ts)
-                    else:
-                        log.info("Unexpected message kind %r", msg['msg_kind'])
-                except Exception:
-                    log.error(
-                        "Unexpected error processing file submission message",
-                        exc_info=True,
-                    )
+            try:
+                self.handle_one_message()
+            except StopIteration:
+                pass  # consumer timeout was reached
+
+    def handle_one_message(self):
+        record  = next(self.consumer)
+        try:
+            ts = datetime.fromtimestamp(record.timestamp / 1000, tz=timezone.utc)
+            msg = json.loads(record.value.decode())
+            if msg['msg_kind'] == MsgKind.file_submission.value:
+                self.process_file_submission_msg(msg['data'], ts)
+            else:
+                log.info("Unexpected message kind %r", msg['msg_kind'])
+        except Exception:
+            log.error(
+                "Unexpected error processing file submission message",
+                exc_info=True,
+            )
 
     def process_file_submission_msg(self, d: dict, msg_timestamp: datetime):
         """Handle a notification from Kafka"""

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -163,7 +163,7 @@ def notify_new_file(damnit_dir, proposal: int, run: int, file_path: str):
         value_serializer=lambda d: json.dumps(d).encode('utf-8')
     )
     prod.send(FILE_SUBMIT_TOPIC, msg)
-    prod.flush(timeout=10)
+    prod.close(timeout=10)
 
 
 def file_submit_msg(damnit_dir: Path, proposal: int, run: int, file_path: str):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -27,7 +27,7 @@ import numpy as np
 from kafka import KafkaProducer
 
 from ..context import ContextFile, Pipeline, RunData
-from ..definitions import UPDATE_BROKERS, FILE_SUBMIT_TOPIC
+from ..definitions import update_brokers, FILE_SUBMIT_TOPIC
 from .db import DamnitDB, ReducedData, BlobTypes, MsgKind, msg_dict
 from .extraction_control import ExtractionRequest, ExtractionSubmitter
 
@@ -159,7 +159,7 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run, provenance):
 def notify_new_file(damnit_dir, proposal: int, run: int, file_path: str):
     msg = file_submit_msg(damnit_dir, proposal, run, file_path)
     prod = KafkaProducer(
-        bootstrap_servers=UPDATE_BROKERS,
+        bootstrap_servers=update_brokers(),
         value_serializer=lambda d: json.dumps(d).encode('utf-8')
     )
     prod.send(FILE_SUBMIT_TOPIC, msg)
@@ -187,7 +187,7 @@ class Extractor:
         self.db = DamnitDB()
         if connect_to_kafka:
             self.kafka_prd = KafkaProducer(
-                bootstrap_servers=UPDATE_BROKERS,
+                bootstrap_servers=update_brokers(),
                 value_serializer=lambda d: json.dumps(d).encode('utf-8'),
             )
         else:

--- a/damnit/definitions.py
+++ b/damnit/definitions.py
@@ -1,10 +1,11 @@
 import os
 
 # Kafka for sending updates around
-if "AMORE_BROKER" in os.environ:
-    UPDATE_BROKERS = [os.environ["AMORE_BROKER"]]
-else:
-    UPDATE_BROKERS = ['exflwgs06.desy.de:9091']
+def update_brokers():
+    if "AMORE_BROKER" in os.environ:
+        return [os.environ["AMORE_BROKER"]]
+    else:
+        return ['exflwgs06.desy.de:9091']
 
 UPDATE_TOPIC = "test.damnit.db-{}"  # Fill in ID stored in database
 FILE_SUBMIT_TOPIC = "test.damnit.file_submissions"

--- a/damnit/gui/kafka.py
+++ b/damnit/gui/kafka.py
@@ -5,7 +5,7 @@ from kafka import KafkaConsumer, KafkaProducer
 from PyQt5 import QtCore
 
 from ..backend.db import MsgKind, msg_dict
-from ..definitions import UPDATE_BROKERS, UPDATE_TOPIC
+from ..definitions import update_brokers, UPDATE_TOPIC
 
 log = logging.getLogger(__name__)
 
@@ -18,10 +18,10 @@ class UpdateAgent(QtCore.QObject):
         self.update_topic = UPDATE_TOPIC.format(db_id)
 
         self.kafka_cns = KafkaConsumer(
-            self.update_topic, bootstrap_servers=UPDATE_BROKERS
+            self.update_topic, bootstrap_servers=update_brokers()
         )
         self.kafka_prd = KafkaProducer(
-            bootstrap_servers=UPDATE_BROKERS,
+            bootstrap_servers=update_brokers(),
             value_serializer=lambda d: json.dumps(d).encode('utf-8')
         )
         self.running = False

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -25,7 +25,7 @@ from ..backend import initialize_proposal
 from ..backend.db import DamnitDB, MsgKind, ReducedData, db_path
 from ..backend.extraction_control import ExtractionSubmitter, process_log_path
 from ..backend.user_variables import UserEditableVariable
-from ..definitions import UPDATE_BROKERS
+from ..definitions import update_brokers
 from ..util import isinstance_no_import
 from .editor import ContextTestResult, Editor, SaveConflictDialog
 from .kafka import UpdateAgent
@@ -613,7 +613,7 @@ da-dev@xfel.eu"""
             self.update_agent = UpdateAgent(self.db_id)
         except NoBrokersAvailable:
             QtWidgets.QMessageBox.warning(self, "Broker connection failed",
-                                          f"Could not connect to any Kafka brokers at: {' '.join(UPDATE_BROKERS)}\n\n" +
+                                          f"Could not connect to any Kafka brokers at: {' '.join(update_brokers())}\n\n" +
                                           "DAMNIT can operate offline, but it will not receive any updates from new or reprocessed runs.")
             return
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -234,7 +234,7 @@ da-dev@xfel.eu"""
             }
             db[str(self._context_path)] = settings
 
-    def autoconfigure(self, path: Path):
+    def autoconfigure(self, path: Path, check_context=True):
         sqlite_path = db_path(path)
         # If the user selected an empty folder in the GUI, the database has been
         # created before we reach this point, so this is just a sanity check.
@@ -297,8 +297,9 @@ da-dev@xfel.eu"""
         self._tab_widget.setEnabled(True)
         self.show_default_status_message()
         self.context_dir_changed.emit(str(path))
-        self.launch_update_computed_vars()
-        self.start_watching_context_file()
+        if check_context:
+            self.launch_update_computed_vars()
+            self.start_watching_context_file()
 
     def _save_context_finished(self, saved):
         if saved:

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -64,10 +64,13 @@ class MainWindow(QtWidgets.QMainWindow):
     db_id = None
     _columns_dialog = None
 
-    def __init__(self, context_dir: Path = None, connect_to_kafka: bool = True):
+    def __init__(self, context_dir: Path = None, connect_to_kafka: bool = True, background_activity=True):
         super().__init__()
 
         self._connect_to_kafka = connect_to_kafka
+        # Background activity includes watching the context file & parsing it
+        # in a child process; it can be disabled to make unit testing easier.
+        self._background_activity = background_activity
         self._updates_thread = None
         self._received_update = False
         self._context_path = None
@@ -234,7 +237,7 @@ da-dev@xfel.eu"""
             }
             db[str(self._context_path)] = settings
 
-    def autoconfigure(self, path: Path, check_context=True):
+    def autoconfigure(self, path: Path):
         sqlite_path = db_path(path)
         # If the user selected an empty folder in the GUI, the database has been
         # created before we reach this point, so this is just a sanity check.
@@ -297,12 +300,12 @@ da-dev@xfel.eu"""
         self._tab_widget.setEnabled(True)
         self.show_default_status_message()
         self.context_dir_changed.emit(str(path))
-        if check_context:
+        if self._background_activity:
             self.launch_update_computed_vars()
             self.start_watching_context_file()
 
     def _save_context_finished(self, saved):
-        if saved:
+        if saved and self._background_activity:
             self.launch_update_computed_vars()
 
     def launch_update_computed_vars(self, ctx_size_mtime=None):

--- a/pixi.lock
+++ b/pixi.lock
@@ -260,7 +260,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/45/53dbdd7013a1b84bec5ae0cea432ea212cd29d7a85a1baa42cf0ac079aac/mpl_pan_zoom-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/a4/070512af1bbf73de4d2648bbfc355619abf27dd468dba6dae35805a05b43/mplcursors-0.6-py3-none-any.whl
-      - pypi: git+https://git.xfel.eu/kluyvert/nafka#b30aa9ca81a034822be2e86f96711ddb9c255938
+      - pypi: https://files.pythonhosted.org/packages/42/0f/a53925bd0bcdb01649fe8462f21338ea411959cc71166cf41587c6129ab0/nafka-0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/26/43caf834e47c63883a5eddc02893b7fdbe6a0a4508ff6dc401907f3cc085/narwhals-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/0f/571b2c7a3833ae419fe69ff7b479a78d313581785203cc70a8db90121b9a/numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -482,7 +482,7 @@ packages:
 - pypi: ./
   name: damnit
   version: 0.3.0
-  sha256: c6c50e2826d59190d0443f7e46978131df4892d9d0529b5c6e59e67659ee010b
+  sha256: 327eab2b41e5d7fc515244a9c4f1e56156f62d20c8e83f4093232c8fa7dec087
   requires_dist:
   - fpcs
   - h5netcdf>=1.4.1
@@ -529,7 +529,7 @@ packages:
   - pytest-timeout ; extra == 'test'
   - pytest-venv ; extra == 'test'
   - testpath ; extra == 'test'
-  - nafka @ git+https://git.xfel.eu/kluyvert/nafka ; extra == 'test'
+  - nafka ; extra == 'test'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
   name: decorator
@@ -1240,9 +1240,10 @@ packages:
   - sphinx ; extra == 'docs'
   - sphinx-gallery ; extra == 'docs'
   requires_python: '>=3.7'
-- pypi: git+https://git.xfel.eu/kluyvert/nafka#b30aa9ca81a034822be2e86f96711ddb9c255938
+- pypi: https://files.pythonhosted.org/packages/42/0f/a53925bd0bcdb01649fe8462f21338ea411959cc71166cf41587c6129ab0/nafka-0.1-py2.py3-none-any.whl
   name: nafka
   version: '0.1'
+  sha256: 2158e953a213df6fa30fbda9ba34552ee962fe22fd978c39fedbbe52412e334c
   requires_dist:
   - kafka-python>=2,<3
 - pypi: https://files.pythonhosted.org/packages/7f/26/43caf834e47c63883a5eddc02893b7fdbe6a0a4508ff6dc401907f3cc085/narwhals-2.0.1-py3-none-any.whl

--- a/pixi.lock
+++ b/pixi.lock
@@ -260,6 +260,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/8f/8e/9ad090d3553c280a8060fbf6e24dc1c0c29704ee7d1c372f0c174aa59285/matplotlib_inline-0.1.7-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1e/45/53dbdd7013a1b84bec5ae0cea432ea212cd29d7a85a1baa42cf0ac079aac/mpl_pan_zoom-1.0.0-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/a4/070512af1bbf73de4d2648bbfc355619abf27dd468dba6dae35805a05b43/mplcursors-0.6-py3-none-any.whl
+      - pypi: git+https://git.xfel.eu/kluyvert/nafka#b30aa9ca81a034822be2e86f96711ddb9c255938
       - pypi: https://files.pythonhosted.org/packages/7f/26/43caf834e47c63883a5eddc02893b7fdbe6a0a4508ff6dc401907f3cc085/narwhals-2.0.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/82/7a9d0550484a62c6da82858ee9419f3dd1ccc9aa1c26a1e43da3ecd20b0d/natsort-8.4.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1d/0f/571b2c7a3833ae419fe69ff7b479a78d313581785203cc70a8db90121b9a/numpy-2.3.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl
@@ -481,7 +482,7 @@ packages:
 - pypi: ./
   name: damnit
   version: 0.3.0
-  sha256: 7f45445822d0e44c50b206950b077158ed8c3a496bd23aa23a027c0b03cd6964
+  sha256: c6c50e2826d59190d0443f7e46978131df4892d9d0529b5c6e59e67659ee010b
   requires_dist:
   - fpcs
   - h5netcdf>=1.4.1
@@ -528,6 +529,7 @@ packages:
   - pytest-timeout ; extra == 'test'
   - pytest-venv ; extra == 'test'
   - testpath ; extra == 'test'
+  - nafka @ git+https://git.xfel.eu/kluyvert/nafka ; extra == 'test'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
   name: decorator
@@ -1238,6 +1240,11 @@ packages:
   - sphinx ; extra == 'docs'
   - sphinx-gallery ; extra == 'docs'
   requires_python: '>=3.7'
+- pypi: git+https://git.xfel.eu/kluyvert/nafka#b30aa9ca81a034822be2e86f96711ddb9c255938
+  name: nafka
+  version: '0.1'
+  requires_dist:
+  - kafka-python>=2,<3
 - pypi: https://files.pythonhosted.org/packages/7f/26/43caf834e47c63883a5eddc02893b7fdbe6a0a4508ff6dc401907f3cc085/narwhals-2.0.1-py3-none-any.whl
   name: narwhals
   version: 2.0.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ test = [
     "pytest-timeout",
     "pytest-venv",
     "testpath",
+    "nafka @ git+https://git.xfel.eu/kluyvert/nafka",
 ]
 docs = [
     "mkdocs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ test = [
     "pytest-timeout",
     "pytest-venv",
     "testpath",
-    "nafka @ git+https://git.xfel.eu/kluyvert/nafka",
+    "nafka",
 ]
 docs = [
     "mkdocs",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 
 import pytest
 import numpy as np
+from nafka.runner import BrokerThreadRunner
 
 from damnit.backend.db import DamnitDB
 from damnit.backend.user_variables import value_types_by_name, UserEditableVariable
@@ -171,7 +172,7 @@ def mock_run():
 
 
 @pytest.fixture
-def mock_db(tmp_path, mock_ctx, monkeypatch):
+def mock_db(tmp_path, mock_ctx, mock_kafka_broker, monkeypatch):
     db = DamnitDB.from_dir(tmp_path, create=True)
     db.metameta['proposal'] = 1234
 
@@ -187,7 +188,12 @@ def mock_db(tmp_path, mock_ctx, monkeypatch):
 
 
 @pytest.fixture
-def mock_db_with_data(mock_ctx, mock_db, monkeypatch):
+def mock_kafka_broker(tmp_path, monkeypatch, nafka_broker):
+    monkeypatch.setenv("AMORE_BROKER", nafka_broker.address)
+    return nafka_broker
+
+@pytest.fixture
+def mock_db_with_data(mock_ctx, mock_db, mock_kafka_broker, monkeypatch):
     db_dir, db = mock_db
 
     with monkeypatch.context() as m:
@@ -199,7 +205,7 @@ def mock_db_with_data(mock_ctx, mock_db, monkeypatch):
 
 
 @pytest.fixture
-def mock_db_with_data_2(mock_ctx, mock_db, monkeypatch):
+def mock_db_with_data_2(mock_ctx, mock_db, mock_kafka_broker, monkeypatch):
     db_dir, db = mock_db
 
     with monkeypatch.context() as m:

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,6 +1,5 @@
 import textwrap
 from pathlib import Path
-from unittest.mock import patch
 
 from PyQt5 import QtGui, QtWidgets
 
@@ -29,17 +28,16 @@ def amore_proto(args):
     It is the callers responsibility to make sure the PWD is a database
     directory.
     """
-    with patch("damnit.backend.extract_data.KafkaProducer"):
-        main(args)
+    main(args)
 
 def extract_mock_run(run_num: int, match=()):
     """Run the context file in the CWD on the specified run"""
-    with patch("damnit.backend.extract_data.KafkaProducer"):
-        db = DamnitDB()
-        prop = db.metameta['proposal']
-        extr = RunExtractor(prop, run_num, match=match, mock=True)
-        extr.update_db_vars()
-        extr.extract_and_ingest()
+    db = DamnitDB()
+    prop = db.metameta['proposal']
+    extr = RunExtractor(prop, run_num, match=match, mock=True)
+    extr.update_db_vars()
+    extr.extract_and_ingest()
+    extr.kafka_prd.flush(timeout=30)
 
     gather_all_fragments(Path.cwd())
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -44,7 +44,7 @@ def test_damnit(mock_db_with_data):
     df = damnit.table(with_titles=True)
     assert "Scalar1" in df.columns
 
-def test_run_variables(mock_db_with_data, monkeypatch):
+def test_run_variables(mock_db_with_data, mock_kafka_broker, monkeypatch):
     db_dir, db = mock_db_with_data
     damnit = Damnit(db_dir)
     monkeypatch.chdir(db_dir)
@@ -87,7 +87,7 @@ def test_run_variables(mock_db_with_data, monkeypatch):
     with pytest.raises(KeyError):
         rv["foo"]
 
-def test_variable_data(mock_db_with_data, monkeypatch):
+def test_variable_data(mock_db_with_data, mock_kafka_broker, monkeypatch):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
     damnit = Damnit(db_dir)

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -836,18 +836,15 @@ def test_extractor(mock_ctx, mock_db, mock_run, mock_kafka_broker, monkeypatch):
 
     extractor = RunExtractor(1234, 42, cluster=False, run_data=RunData.ALL)
 
-    kafka_offset = mock_kafka_broker.next_offset(db.kafka_topic)
-
-    # Test regular variables and slurm variables are executed
-    reduced_data = reduced_data_from_dict({ "n": 53 })
-    with patch(f"{pkg}.RunExtractor.extract_in_subprocess", return_value=reduced_data) as extract_in_subprocess, \
-         MockCommand.fixed_output("sbatch", "9876; maxwell") as sbatch:
-        extractor.extract_and_ingest()
+    with mock_kafka_broker.assert_produces(db.kafka_topic):
+        # Test regular variables and slurm variables are executed
+        reduced_data = reduced_data_from_dict({ "n": 53 })
+        with patch(f"{pkg}.RunExtractor.extract_in_subprocess", return_value=reduced_data) as extract_in_subprocess, \
+             MockCommand.fixed_output("sbatch", "9876; maxwell") as sbatch:
+            extractor.extract_and_ingest()
 
     extract_in_subprocess.assert_called_once()
     sbatch.assert_called()
-    new_kafka_records = mock_kafka_broker.records(db.kafka_topic, kafka_offset)
-    assert new_kafka_records != []
 
     # This works because we loaded damnit.context above
     from ctxrunner import main

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -808,7 +808,7 @@ def test_trendline_summary_to_db(mock_run, mock_db, tmp_path):
     arr = blob2numpy(row["value"])
     assert arr.shape[0] == 2
 
-def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
+def test_extractor(mock_ctx, mock_db, mock_run, mock_kafka_broker, monkeypatch):
     # Change to the DB directory
     db_dir, db = mock_db
     db.metameta["proposal"] = 1234
@@ -834,18 +834,20 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
     ctx_path = db_dir / "context.py"
     ctx_path.write_text(mock_ctx.code)
 
-    # Create Extractor with a mocked KafkaProducer
-    with patch(f"{pkg}.KafkaProducer") as _:
-        extractor = RunExtractor(1234, 42, cluster=False, run_data=RunData.ALL)
+    extractor = RunExtractor(1234, 42, cluster=False, run_data=RunData.ALL)
+
+    kafka_offset = mock_kafka_broker.next_offset(db.kafka_topic)
 
     # Test regular variables and slurm variables are executed
     reduced_data = reduced_data_from_dict({ "n": 53 })
     with patch(f"{pkg}.RunExtractor.extract_in_subprocess", return_value=reduced_data) as extract_in_subprocess, \
          MockCommand.fixed_output("sbatch", "9876; maxwell") as sbatch:
         extractor.extract_and_ingest()
-        extract_in_subprocess.assert_called_once()
-        extractor.kafka_prd.send.assert_called()
-        sbatch.assert_called()
+
+    extract_in_subprocess.assert_called_once()
+    sbatch.assert_called()
+    new_kafka_records = mock_kafka_broker.records(db.kafka_topic, kafka_offset)
+    assert new_kafka_records != []
 
     # This works because we loaded damnit.context above
     from ctxrunner import main
@@ -911,7 +913,7 @@ def test_extractor(mock_ctx, mock_db, mock_run, monkeypatch):
         open_run.assert_called_with(1234, 42)
     gather_all_fragments(db_dir)
 
-def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
+def test_custom_environment(mock_db, mock_kafka_broker, venv, monkeypatch, qtbot):
     db_dir, db = mock_db
     monkeypatch.chdir(db_dir)
 
@@ -942,14 +944,13 @@ def test_custom_environment(mock_db, venv, monkeypatch, qtbot):
 
     pkg = "damnit.backend.extract_data"
 
-    with patch(f"{pkg}.KafkaProducer"), pytest.raises(RuntimeError, match="sfollow"):
+    with pytest.raises(RuntimeError, match="sfollow"):
         Extractor()
 
     # Set the context_python field in the database
     db.metameta["context_python"] = str(venv.python)
 
-    with patch(f"{pkg}.KafkaProducer"):
-        RunExtractor(1234, 42, mock=True).extract_and_ingest()
+    RunExtractor(1234, 42, mock=True).extract_and_ingest()
     gather_all_fragments(db_dir)
 
     with h5py.File(db_dir / "extracted_data" / "p1234_r42.h5") as f:
@@ -1296,7 +1297,7 @@ def test_job_tracker():
     assert set(tracker.jobs) == set()
 
 
-def test_extract_data_sandbox(mock_db, tmp_path, monkeypatch):
+def test_extract_data_sandbox(mock_db, mock_kafka_broker, tmp_path, monkeypatch):
     """extract_data should invoke the sandbox for whoami and for exec payload.
 
     We verify both invocations and that the wrapper forwards to the payload (so
@@ -1328,12 +1329,11 @@ exec "$@"
 
     # Run extract_data.main with sandbox args
     pkg = "damnit.backend.extract_data"
-    with patch(f"{pkg}.KafkaProducer"):
-        extract_data_main([
-            "1234", "1", "all",
-            "--mock",
-            "--sandbox-args", f"{script_path} {log_path}",
-        ])
+    extract_data_main([
+        "1234", "1", "all",
+        "--mock",
+        "--sandbox-args", f"{script_path} {log_path}",
+    ])
 
     # Check that sandbox was called for whoami, then ctx (context inspection), and exec
     lines = log_path.read_text().splitlines()

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,0 +1,45 @@
+import json
+
+import numpy as np
+from kafka import TopicPartition
+
+from damnit.api import Damnit, submit
+from damnit.backend.combine import FileSubmissionProcessor
+from damnit.backend.db import MsgKind
+from damnit.definitions import FILE_SUBMIT_TOPIC
+
+def test_combiner_service(mock_db, mock_kafka_broker):
+    db_dir, db = mock_db
+
+    combiner = FileSubmissionProcessor(consumer_config={
+        'auto_offset_reset': 'earliest',  # Read from the 1st submission message
+    })
+
+    with mock_kafka_broker.assert_produces(FILE_SUBMIT_TOPIC):
+        submit(1234, 56, {
+            # We need start_time in the DB for the API to see the run
+            "array": np.arange(10), "start_time": 1776335722
+        }, provenance="test", damnit_dir=db_dir)
+
+    with mock_kafka_broker.assert_produces(db.kafka_topic) as new_records:
+        combiner.handle_one_message()
+        combiner.producer.flush(timeout=5)
+
+    msgs = [json.loads(r.value) for r in new_records]
+    assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
+    assert set(msgs[0]['data']['values']) == {"array", "start_time"}
+
+    api_obj = Damnit(db_dir)
+    np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(10))
+
+    # Overwrite the variable with a second fragment
+    with mock_kafka_broker.assert_produces(FILE_SUBMIT_TOPIC):
+        submit(
+            1234, 56, {"array": np.arange(15)}, provenance="test", damnit_dir=db_dir
+        )
+
+    with mock_kafka_broker.assert_produces(db.kafka_topic):
+        combiner.handle_one_message()
+        combiner.producer.flush(timeout=5)
+
+    np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(15))

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -383,7 +383,7 @@ def test_handle_update(mock_db, qtbot):
     assert len(headers) + 1 == len(get_headers())
     assert "unexpected_var" in get_headers()
 
-def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
+def test_handle_update_plots(mock_db_with_data, mock_kafka_broker, monkeypatch, qtbot):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
 
@@ -733,7 +733,7 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
     # Check that the value in the db matches what was typed in the table
     assert get_value_from_db("user_boolean") is None
 
-def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, monkeypatch, qtbot):
+def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, mock_kafka_broker, monkeypatch, qtbot):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
 
@@ -992,7 +992,7 @@ def test_zulip(mock_db_with_data, monkeypatch, qtbot):
         messenger.send_table.assert_called_once()
 
 @pytest.mark.parametrize("extension", [".xlsx", ".csv"])
-def test_exporting(mock_db_with_data, qtbot, monkeypatch, extension):
+def test_exporting(mock_db_with_data, mock_kafka_broker, qtbot, monkeypatch, extension):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -57,6 +57,17 @@ def pid_dead(pid):
         return True
 
 
+@contextmanager
+def assert_sends_update(win, broker):
+    win.update_agent.kafka_prd.flush(timeout=3)  # Flush old messages before capture
+    with broker.assert_produces(win.db.kafka_topic) as new_records:
+        l = []
+        yield l
+        win.update_agent.kafka_prd.flush(timeout=3)  # Flush new messages
+
+    l.extend([json.loads(r.value) for r in new_records])
+
+
 def test_connect_to_kafka(mock_db, qtbot):
     db_dir, db = mock_db
     pkg = "damnit.gui.kafka"
@@ -482,7 +493,7 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qt
         add_to_db(reduced_data, db, proposal, run_number, provenance="test")
 
 
-    win = MainWindow()
+    win = MainWindow(background_activity=False)
     win.show()
     qtbot.addWidget(win)
 
@@ -503,7 +514,7 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qt
         db.add_user_variable(vv, exist_ok=True)
 
     # Loads the context file to do the other tests
-    win.autoconfigure(db_dir, check_context=False)
+    win.autoconfigure(db_dir)
 
     # After loading a context file the menu should be enabled
     assert create_user_menu.isEnabled()
@@ -636,12 +647,9 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qt
 
     @contextmanager
     def check_kafka_send(variable):
-        win.update_agent.kafka_prd.flush(timeout=3)  # Flush old messages before capture
-        with mock_kafka_broker.assert_produces(db.kafka_topic) as new_records:
+        with assert_sends_update(win, mock_kafka_broker) as msgs:
             yield
-            win.update_agent.kafka_prd.flush(timeout=3)  # Flush new messages
 
-        msgs = [json.loads(r.value) for r in new_records]
         assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
         assert set(msgs[0]['data']['values']) == {variable}
 
@@ -804,7 +812,7 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, mock_kafka_br
     extract_mock_run(1)
 
     # Create window
-    win = MainWindow(db_dir, False)
+    win = MainWindow(db_dir, background_activity=False)
     qtbot.addWidget(win)
 
     # Helper function to get a QModelIndex from a variable title
@@ -844,7 +852,11 @@ def test_table_and_plotting(mock_db_with_data, mock_ctx, mock_run, mock_kafka_br
 
     # Edit a comment
     comment_index = get_index("Comment")
-    win.table.setData(comment_index, "Foo", Qt.EditRole)
+    with assert_sends_update(win, mock_kafka_broker) as msgs:
+        win.table.setData(comment_index, "Foo", Qt.EditRole)
+
+    assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
+    assert set(msgs[0]['data']['values']) == {"comment"}
 
     # Check that 2D arrays are treated as images
     image_index = get_index("Image")

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import sys
@@ -457,7 +458,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
         win.autoconfigure.assert_called_once_with(db_dir)
         initialize_proposal.assert_not_called()
 
-def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
+def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qtbot):
 
     proposal = 1234
     run_number = 1000
@@ -481,7 +482,7 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
         add_to_db(reduced_data, db, proposal, run_number, provenance="test")
 
 
-    win = MainWindow(connect_to_kafka=False)
+    win = MainWindow()
     win.show()
     qtbot.addWidget(win)
 
@@ -502,7 +503,7 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
         db.add_user_variable(vv, exist_ok=True)
 
     # Loads the context file to do the other tests
-    win.autoconfigure(db_dir)
+    win.autoconfigure(db_dir, check_context=False)
 
     # After loading a context file the menu should be enabled
     assert create_user_menu.isEnabled()
@@ -633,13 +634,26 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
             raise ValueError(f"Error in field_name: the variable name '{field_name}' is not of the form '[a-zA-Z_]\\w+'")
         return db.conn.execute(f"SELECT {field_name} FROM runs WHERE run = ?", (run_number,)).fetchone()[0]
 
+    @contextmanager
+    def check_kafka_send(variable):
+        win.update_agent.kafka_prd.flush(timeout=3)  # Flush old messages before capture
+        with mock_kafka_broker.assert_produces(db.kafka_topic) as new_records:
+            yield
+            win.update_agent.kafka_prd.flush(timeout=3)  # Flush new messages
+
+        msgs = [json.loads(r.value) for r in new_records]
+        assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
+        assert set(msgs[0]['data']['values']) == {variable}
+
+
     # Check that editing is prevented when trying to modfiy a non-editable column
     assert open_editor_and_get_delegate("dep_number").widget is None
 
     # Check that editing is allowed when trying to modify a user editable column
     assert open_editor_and_get_delegate("user_number").widget is not None
 
-    change_to_value_and_close("15.4")
+    with check_kafka_send("user_number"):
+        change_to_value_and_close("15.4")
 
     # Check that the value in the table is of the correct type and value
     assert abs(get_value_from_field("user_number") - 15.4) < 1e-5
@@ -727,7 +741,8 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, qtbot):
     assert open_editor_and_get_delegate("user_boolean").widget is not None
 
     # Try to assign an empty value (i.e. deletes the cell)
-    change_to_value_and_close("")
+    with check_kafka_send("user_boolean"):
+        change_to_value_and_close("")
     assert pd.isna(get_value_from_field("user_boolean"))
 
     # Check that the value in the db matches what was typed in the table


### PR DESCRIPTION
Instead of mocking the `KafkaProducer` & `KafkaConsumer` Python objects, this runs a mock Kafka broker in a background thread, and the real client objects send messages to it.