### PR TITLE
Add support for returning matplotlib Axes as Cell previews

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -222,6 +222,8 @@ class Cell:
                     )
                 elif not (np.issubdtype(preview.dtype, np.number) or preview.dtype == bool):
                     raise TypeError("preview array should be numeric")
+            elif isinstance_no_import(preview, 'matplotlib.axes', 'Axes'):
+                preview = preview.get_figure()
             elif not (
                     isinstance_no_import(preview, 'matplotlib.figure', 'Figure') or
                     isinstance_no_import(preview, 'plotly.graph_objs', 'Figure')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -604,6 +604,7 @@ def test_results_cell(mock_run, tmp_path):
     ctx_code = """
     from damnit_ctx import Variable, Cell
     import numpy as np
+    import matplotlib.pyplot as plt
 
     @Variable()
     def var1(run):
@@ -615,7 +616,9 @@ def test_results_cell(mock_run, tmp_path):
 
     @Variable()
     def var3(run):
-        return Cell(np.arange(7), summary_value=4)
+        plt.figure()
+        plt.plot([1, 2, 3])
+        return Cell(np.arange(7), summary_value=4, preview=plt.gca())
     """
     bad_obj_ctx = mkcontext(ctx_code)
     results = bad_obj_ctx.execute(mock_run, 1000, 123, {})


### PR DESCRIPTION
We already support returning `Axes` directly, so it makes sense to also support them as previews.

CC @philsmt 