### PR TITLE
fix: allow subclass groups to have fields without defaults

### DIFF
--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -402,7 +402,7 @@ def Group(
 
         cls.__post_init__ = __post_init__
 
-        return dataclass(cls)
+        return dataclass(cls, kw_only=True)
 
     if _cls is None:
         return wrap

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -962,11 +962,10 @@ def test_group_decorated_subclass_non_default_field(mock_run):
 
     b = B(value=3)
     """
-    with pytest.raises(TypeError):
-        mkcontext(code)
-    # results = ctx.execute(mock_run, 1000, 123, {})
-    # assert results.cells["b.base_val"].data == 1
-    # assert results.cells["b.combined"].data == 4
+    ctx = mkcontext(code)
+    results = ctx.execute(mock_run, 1000, 123, {})
+    assert results.cells["b.base_val"].data == 1
+    assert results.cells["b.combined"].data == 4
 
 
 def test_group_duplicate_names_raise():


### PR DESCRIPTION
allow group subclass to have non-default fields when a parent group has some, by forcing Group dataclasses to be kw_only.

this is required for the current workflow where non mandatory dependency variables are set as None. This is the case where we want to mandate a reference to be set.