### PR TITLE
feat(context): improve dependency error display

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -34,6 +34,7 @@ import xarray as xr
 from damnit_ctx import (Cell, GroupBoundVariable, GroupError, RunData, Skip,
                         Variable, _normalize_tags, is_group_instance,
                         isinstance_no_import)
+from damnit_exceptions import ContextFileErrors, DependencyError
 
 log = logging.getLogger("ctxrunner")
 
@@ -48,14 +49,6 @@ class DataType(Enum):
     Image = "image"
     Timestamp = "timestamp"
     PlotlyFigure = "PlotlyFigure"
-
-
-class ContextFileErrors(RuntimeError):
-    def __init__(self, problems):
-        self.problems = problems
-
-    def __str__(self):
-        return "\n".join(self.problems)
 
 
 def _group_name(group):
@@ -421,7 +414,7 @@ class ContextFile:
 
     def vars_to_dict(self, inc_transient=False):
         """Get a plain dict of variable metadata to store in the database
-        
+
         args:
             inc_transient (bool): include transient Variables in the dict
         """
@@ -529,12 +522,12 @@ class ContextFile:
                 if missing_deps:
                     log.warning(f"Skipping {name} because of missing dependencies: {', '.join(missing_deps)}")
                     # get error message from transient dependencies
-                    error_message = ''
-                    for dep in missing_deps:
-                        if self.vars[dep].transient and dep in errors:
-                            error_message += f'\ndependency ({dep}) failed: {repr(errors[f"{dep}"])}'
-                    if error_message:
-                        errors[name] = Exception(error_message)
+                    dep_errors = [(dep, errors[dep]) for dep in missing_deps if dep in errors]
+                    if dep_errors:
+                        errors[name] = DependencyError(dep_errors)
+                    else:
+                        deps = [f"{os.linesep}- '{d}'" for d in missing_deps]
+                        errors[name] = Skip(f"Dependencies returned no data:{''.join(deps)}")
                     continue
                 elif missing_input:
                     log.warning(f"Skipping {name} because of missing input variables: {', '.join(missing_input)}")

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -17,6 +17,8 @@ import h5py
 import numpy as np
 import xarray as xr
 
+from damnit_exceptions import GroupError, Skip
+
 __all__ = [
     "Cell",
     "Group",
@@ -285,14 +287,6 @@ class Cell:
         if (max_diff := self._max_diff()) is not None:
             d['max_diff'] = max_diff
         return d
-
-
-class Skip(Exception):
-    pass
-
-
-class GroupError(Exception):
-    pass
 
 
 def _normalize_tags(tags) -> tuple[str]:

--- a/damnit/ctxsupport/damnit_exceptions.py
+++ b/damnit/ctxsupport/damnit_exceptions.py
@@ -1,0 +1,60 @@
+"""Exception classes specific to DAMNIT context execution."""
+
+def _format_dependency_errors(dep_errors):
+    def format_entry(dep_name, exc, prefix, is_last):
+        connector = "└ " if is_last else "├ "
+        line_prefix = f"{prefix}{connector}"
+        child_prefix = f"{prefix}{'   ' if is_last else '│  '}"
+
+        if isinstance(exc, DependencyError):
+            lines = [f"{line_prefix}({dep_name}) skipped"]
+            if not exc.dep_errors:
+                lines.append(f"{child_prefix}<no details>")
+                return lines
+            last_idx = len(exc.dep_errors)
+            for idx, (sub_dep, sub_exc) in enumerate(exc.dep_errors, start=1):
+                lines.extend(format_entry(
+                    sub_dep,
+                    sub_exc,
+                    child_prefix,
+                    idx == last_idx,
+                ))
+            return lines
+
+        msg = str(exc)
+        if not msg:
+            return [f"{line_prefix}({dep_name}) failed: {type(exc).__name__}"]
+
+        msg_lines = msg.splitlines()
+        summary = f"{type(exc).__name__}: {msg_lines[0]}"
+        lines = [f"{line_prefix}({dep_name}) failed: {summary}"]
+        lines.extend(f"{child_prefix}{line}" for line in msg_lines[1:])
+        return lines
+
+    lines = ["Skipped due to missing dependency:"]
+    last_idx = len(dep_errors)
+    for idx, (dep, exc) in enumerate(dep_errors, start=1):
+        lines.extend(format_entry(dep, exc, "", idx == last_idx))
+    return "\n".join(lines)
+
+
+class DependencyError(RuntimeError):
+    def __init__(self, dep_errors):
+        self.dep_errors = list(dep_errors)
+        super().__init__(_format_dependency_errors(self.dep_errors))
+
+
+class ContextFileErrors(RuntimeError):
+    def __init__(self, problems):
+        self.problems = problems
+
+    def __str__(self):
+        return "\n".join(self.problems)
+
+
+class Skip(Exception):
+    pass
+
+
+class GroupError(Exception):
+    pass

--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -1123,7 +1123,9 @@ class DamnitTableModel(QtGui.QStandardItemModel):
                 colour = 'lightgrey'
             case cls:
                 colour = 'orange'
-                msg = f"{cls}: {msg} (see processing log for details)"
+                msg = f'{msg}\n(see processing log for details)'
+                if cls != 'DependencyError':
+                    msg = f"{cls}: {msg}"
         item.setToolTip(msg)
         item.setData(QtGui.QColor(colour), Qt.ItemDataRole.DecorationRole)
         return item

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -242,7 +242,7 @@ def test_context_file(mock_ctx, tmp_path):
 
     no_parenthesis = """
     from damnit.context import Variable
-    
+
     @Variable
     def foo(run):
         return 42
@@ -1422,9 +1422,37 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
     def var5(run):
         raise NotImplementedError
 
+    @Variable(transient=True)
+    def var6(run, var3: 'var#var3'):
+        return var3
+
+    @Variable()
+    def var7(run, var5: 'var#var5', var6: 'var#var6'):
+        return var5 + var6
+
+    @Variable(transient=True)
+    def var8(run, data: 'var#var7'):
+        return data
+
+    @Variable
+    def var9(run, data: 'var#var8'):
+        return data
+
     @Variable()
     def summary(run, data: 'var#var?'):
         return len(data)
+
+    @Variable
+    def res_is_none(run):
+        return
+
+    @Variable(transient=True)
+    def trans_is_none(run):
+        return None
+
+    @Variable
+    def dep_is_none(run, data: 'var#res_is_none', data1: 'var#trans_is_none'):
+        return data + data1
     """
     ctx = mkcontext(ctx_code)
     results = ctx.execute(mock_run, 1000, 123, {})
@@ -1432,10 +1460,15 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
     results.save_hdf5(results_hdf5_path)
 
     with h5py.File(results_hdf5_path) as f:
-        for i in [1, 2, 4]:
+        for i in [1, 2, 4, 7, 9]:
             assert f'.errors/var{i}' in f
             assert f'.reduced/var{i}' not in f
             assert f'var{i}' not in f
+
+        assert '.errors/dep_is_none' in f
+        assert '.errors/res_is_none' not in f
+        assert 'res_is_none' not in f
+        assert 'dep_is_none' not in f
 
     reduced_data = load_reduced_data(results_hdf5_path)
     add_to_db(reduced_data, db, 1000, 123)
@@ -1454,7 +1487,26 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
     attrs = db.conn.execute(
         "SELECT attributes FROM run_variables WHERE name='var4'"
     ).fetchone()[0]
-    assert json.loads(attrs) == {"error": "\ndependency (var3) failed: ZeroDivisionError('division by zero')", "error_cls": "Exception"}
+    assert json.loads(attrs) == {
+        "error": (
+            "Skipped due to missing dependency:\n"
+            "└ (var3) failed: ZeroDivisionError: division by zero"
+        ),
+        "error_cls": "DependencyError",
+    }
+
+    attrs = db.conn.execute(
+        "SELECT attributes FROM run_variables WHERE name='var7'"
+    ).fetchone()[0]
+    assert json.loads(attrs) == {
+        "error": (
+            "Skipped due to missing dependency:\n"
+            "├ (var5) failed: NotImplementedError\n"
+            "└ (var6) skipped\n"
+            "   └ (var3) failed: ZeroDivisionError: division by zero"
+        ),
+        "error_cls": "DependencyError",
+    }
 
     attrs = db.conn.execute(
         "SELECT attributes FROM run_variables WHERE name='summary'"
@@ -1462,6 +1514,12 @@ def test_capture_errors(mock_run, mock_db, tmp_path):
     data = json.loads(attrs)
     assert '(var5)' in data['error']
     assert '(var3)' in data['error']
+
+    attrs = db.conn.execute(
+        "SELECT attributes FROM run_variables WHERE name='dep_is_none'"
+    ).fetchone()[0]
+    data = json.loads(attrs)
+    assert data['error_cls'] == 'Skip'
 
 
 def test_pattern_matching_dependency(mock_run):


### PR DESCRIPTION
Improve: formatting variable dependency chain visualization.
Fix: in some cases the failing dependency were omitted, e.g. dep>transient dep>dep>transient dep.
Fix: now also show skipped variables due to dependencies returning no data.

for example, before:
```text
dependency (PopIn.images) failed: Exception('\ndependency (PopIn.raw_images) failed: Exception("\\ndependency (PopIn.keydata) failed: SourceNameError(\'HED_pop_in\')")')
dependency (PopIn.dark_data) failed: RuntimeError('Unable to determine dark run for DarkReference.')
```

after:
```text
Skipped due to missing dependency:
├ (PopIn.images) skipped
│  └ (PopIn.raw_images) skipped
│     └ (PopIn.keydata) failed: SourceNameError: This data has no source named 'HED_pop_in'.
│        See data.all_sources for available sources.
└ (PopIn.dark_data) failed: RuntimeError: Unable to determine dark run for DarkReference.
```