### PR TITLE
Convert tags on group variable back to tuple

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -245,7 +245,9 @@ def _expand_group(group):
             else:
                 annotations[arg_name] = annotation
 
-        new_var.tags = set(group.tags) | set(_normalize_tags(new_var.tags))
+        new_var.tags = tuple(sorted(
+            set(group.tags) | set(_normalize_tags(new_var.tags))
+        ))
         new_var._annotation_overrides = annotations
         expanded[new_var.name] = new_var
 

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -62,7 +62,7 @@ def test_group_expands_variables_and_prefixes():
     assert "xgm_sa2.pulse_energy" in ctx.vars
     var = ctx.vars["xgm_sa2.pulse_energy"]
     assert var.title == "XGM Diag/Pulse Energy"
-    assert var.tags == {"XGM", "Energy"}
+    assert var.tags == ("Energy", "XGM")
 
 
 def test_group_linking_resolves_dependencies():
@@ -633,8 +633,8 @@ def test_group_execute_intra_dependencies_and_overrides(mock_run):
     assert results.cells["g.adjusted"].data == 15
     assert ctx.vars["g.adjusted"].arg_dependencies() == {"base": "g.base"}
     assert ctx.vars["g.adjusted"].title == "MyDiag/Adjusted"
-    assert ctx.vars["g.base"].tags == {"Override", "Base"}
-    assert ctx.vars["g.adjusted"].tags == {"Override"}
+    assert ctx.vars["g.base"].tags == ("Base", "Override")
+    assert ctx.vars["g.adjusted"].tags == ("Override",)
 
 
 def test_group_linking_exec_and_dependency_paths(mock_run):
@@ -905,11 +905,11 @@ def test_group_inheritance_and_reset(mock_run):
 
     assert ctx.vars["derived.base"].title == "derived/BaseVar"
     assert ctx.vars["derived.child"].title == "derived/ChildVar"
-    assert ctx.vars["derived.base"].tags == {"BaseTag"}
+    assert ctx.vars["derived.base"].tags == ("BaseTag",)
 
     assert ctx.vars["alt.base"].title == "Alt/BaseVar"
     assert ctx.vars["alt.alt"].title == "Alt/AltVar"
-    assert ctx.vars["alt.base"].tags == {"AltTag"}
+    assert ctx.vars["alt.base"].tags == ("AltTag",)
 
 
 def test_group_inherited_dataclass_fields(mock_run):


### PR DESCRIPTION
Because a set can't be serialised as JSON.

Fixes an issue sending updates to the frontend.