### PR TITLE
Show logs from the combiner service (in journal)

### DIFF
--- a/damnit/backend/combine.py
+++ b/damnit/backend/combine.py
@@ -134,6 +134,8 @@ class FileSubmissionProcessor:
         combine(src, dst)
 
         with DamnitDB.from_dir(damnit_dir) as db:
+            log.info("Updating database in %s with %s variables for p%d r%d from %s",
+                     damnit_dir, len(new_data), prop, run, provenance)
             add_to_db(new_data, db, prop, run, provenance=provenance)
             self.send_update(new_data, db.kafka_topic, prop, run)
 
@@ -192,6 +194,10 @@ def interrupted(signum, frame):
 
 
 def main():
+    logging.basicConfig(level=logging.DEBUG)
+    # Exclude debug level logging from kafka-python
+    logging.getLogger('kafka').setLevel(logging.INFO)
+
     # Treat SIGTERM like SIGINT (Ctrl-C) & do a clean shutdown
     signal.signal(signal.SIGTERM, interrupted)
 

--- a/systemd/damnit-combiner.service
+++ b/systemd/damnit-combiner.service
@@ -9,6 +9,7 @@ Type=notify
 WorkingDirectory=%h/srv/damnit-combiner
 ExecStart=/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/.pixi/envs/default/bin/python -m damnit.backend.combine
 Restart=on-failure
+SyslogIdentifier=combiner
 
 [Install]
 WantedBy=damnit-services.target

--- a/systemd/damnit-listener.service
+++ b/systemd/damnit-listener.service
@@ -9,6 +9,7 @@ Type=notify
 WorkingDirectory=%h/srv/damnit-listener
 ExecStart=/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/.pixi/envs/default/bin/damnit listen
 Restart=on-failure
+SyslogIdentifier=listener
 
 [Install]
 WantedBy=damnit-services.target


### PR DESCRIPTION
In #512 I missed the call to `logging.basicConfig()` (or something equivalent) to actually send the logs from the combiner anywhere. This caused some confusion when trying to debug it.

I've also added `SysLogIdentifier` options for systemd - this makes it easier to distinguish the services in the combined view that `damnit-logs` gives. Without it, the name used is the executable that's running, e.g. `damnit`.