### PR TITLE
Don't re-read db_id from database each time we send an update

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -125,10 +125,11 @@ class DamnitDB:
                 self.upgrade_schema(data_format_version)
 
         # A random ID for the update topic
-        if 'db_id' not in self.metameta:
+        if (db_id := self.metameta.get('db_id')) is None:
             # The ID is not a secret and doesn't need to be cryptographically
             # secure, but the secrets module is convenient to get a random string.
-            self.metameta.setdefault('db_id', token_hex(20))
+            db_id = self.metameta.setdefault('db_id', token_hex(20))
+        self._db_id = db_id
 
     @classmethod
     def from_dir(cls, path):
@@ -146,7 +147,7 @@ class DamnitDB:
 
     @property
     def kafka_topic(self):
-        return UPDATE_TOPIC.format(self.metameta['db_id'])
+        return UPDATE_TOPIC.format(self._db_id)
 
     @property
     def path(self):


### PR DESCRIPTION
While the context file is running, the parent process sends out a 'still running' message every 10 seconds. @turkot ran into a 'database locked' error while getting the ID for the Kafka topic to send these messages on.

<details><summary>Traceback</summary>

```text
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/extract_data.py", line 402, in <module>
    main()
    ~~~~^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/extract_data.py", line 397, in main
    extr.extract_and_ingest()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/extract_data.py", line 324, in extract_and_ingest
    self.extract_in_subprocess()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/extract_data.py", line 306, in extract_in_subprocess
    self._notify_running()
    ~~~~~~~~~~~~~~~~~~~~^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/extract_data.py", line 268, in _notify_running
    self.kafka_prd.send(self.db.kafka_topic, self.running_msg)
                        ^^^^^^^^^^^^^^^^^^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/db.py", line 149, in kafka_topic
    return UPDATE_TOPIC.format(self.metameta['db_id'])
                               ~~~~~~~~~~~~~^^^^^^^^^
  File "/gpfs/exfel/sw/software/xfel_anaconda3/amore-beta/damnit/backend/db.py", line 487, in __getitem__
    row = self.conn.execute(
          ~~~~~~~~~~~~~~~~~^
        f"SELECT value FROM {self.table} WHERE key=?", (key,)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ).fetchone()
    ^
sqlite3.OperationalError: database is locked
```
</details>

We're looking up the db_id when we create a `DamnitDB` object anyway, this simply stores it on the instance so we don't query the database to send these updates.