### PR TITLE
Count a variable as skipped if its dependencies are skipped

### DIFF
--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -515,7 +515,7 @@ class ContextFile:
                     log.warning(f"Skipping {name} because of missing dependencies: {', '.join(missing_deps)}")
                     # get error message from transient dependencies
                     dep_errors = [(dep, errors[dep]) for dep in missing_deps if dep in errors]
-                    if dep_errors:
+                    if dep_errors and not all(isinstance(e, Skip) for _, e in dep_errors):
                         errors[name] = DependencyError(dep_errors)
                     else:
                         deps = [f"{os.linesep}- '{d}'" for d in missing_deps]


### PR DESCRIPTION
At present, a dependent variable is recorded as skipped if its dependencies return None, but as having an error if its dependencies raise `Skip`:

<img width="404" height="129" alt="Screenshot From 2026-04-24 16-51-21" src="https://github.com/user-attachments/assets/8e6700ef-83c1-4d0e-804f-fbf127791c0a" />

With this change, the `Skip` is propagated instead, making it easier to see which variables actually hit an error:

<img width="289" height="83" alt="image" src="https://github.com/user-attachments/assets/30d6f3da-1c95-4035-97a2-1c7059c027ea" />
