### PR TITLE
fix(gui): update text color based on custom background color

### DIFF
--- a/damnit/gui/table.py
+++ b/damnit/gui/table.py
@@ -29,6 +29,15 @@ THUMBNAIL_SIZE = (100, 35)  # w, h (pixels)
 STATIC_COLUMNS = ["Status", "Proposal", "Run", "Timestamp", "Comment"]
 
 
+def best_text_color(background: QtGui.QColor) -> QtGui.QColor:
+    brightness = (
+        background.red() * 299
+        + background.green() * 587
+        + background.blue() * 114
+    ) / 1000
+    return QtGui.QColor(Qt.black) if brightness >= 186 else QtGui.QColor(Qt.white)
+
+
 class FilterHeaderView(QtWidgets.QHeaderView):
     def __init__(self, parent=None):
         super().__init__(Qt.Horizontal, parent)
@@ -1236,7 +1245,9 @@ class DamnitTableModel(QtGui.QStandardItemModel):
             if bold:
                 item.setFont(self._bold_font)
             if (bg := attrs.get('background')) is not None:
-                item.setBackground(QtGui.QBrush(QtGui.QColor(*bg)))
+                bg_color = QtGui.QColor(*bg)
+                item.setBackground(QtGui.QBrush(bg_color))
+                item.setForeground(QtGui.QBrush(best_text_color(bg_color)))
 
         self._apply_provenance_style(item, provenance)
         return item

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -29,7 +29,12 @@ from damnit.gui.open_dialog import OpenDBDialog
 from damnit.gui.plot import HistogramPlotWindow, ScatterPlotWindow
 from damnit.gui.standalone_comments import TimeComment
 from damnit.gui.roles import LINE_DATA_ROLE, PROVENANCE_ROLE
-from damnit.gui.table import DamnitTableModel, STATIC_COLUMNS, TableView
+from damnit.gui.table import (
+    DamnitTableModel,
+    STATIC_COLUMNS,
+    TableView,
+    best_text_color,
+)
 from damnit.gui.table_filter import (CategoricalFilter, FilterProxy,
                                      CategoricalFilterWidget, FilterMenu,
                                      NumericFilter, NumericFilterWidget,
@@ -1874,3 +1879,16 @@ def test_item_delegate_paints_provenance_marker_smoke(qtbot):
     marker_bytes = image_bytes(marker_image)
 
     assert base_bytes != marker_bytes
+
+
+def test_best_text_color_for_custom_background(mock_db):
+    _, db = mock_db
+    model = DamnitTableModel(db, {}, None)
+
+    dark_item = model.new_item(42, "scalar1", 0, {"background": [12, 12, 12]})
+    assert dark_item.background().color() == QColor(12, 12, 12)
+    assert dark_item.foreground().color() == QColor(Qt.white)
+
+    light_item = model.new_item(42, "scalar1", 0, {"background": [240, 240, 240]})
+    assert light_item.background().color() == QColor(240, 240, 240)
+    assert light_item.foreground().color() == QColor(Qt.black)


### PR DESCRIPTION
Before:

<img width="504" height="296" alt="Screenshot 2026-04-29 at 18 11 18" src="https://github.com/user-attachments/assets/2a582b71-1e4e-4d94-9f4a-828ab322130d" />
<img width="504" height="296" alt="Screenshot 2026-04-29 at 18 11 28" src="https://github.com/user-attachments/assets/8ec40b65-0e18-46d4-b730-bdc69ac2c97f" />

After:

<img width="512" height="265" alt="Screenshot 2026-04-29 at 18 10 26" src="https://github.com/user-attachments/assets/ff9d97d0-5afd-4445-b2e4-d07b4239d412" />
<img width="504" height="295" alt="Screenshot 2026-04-29 at 18 10 36" src="https://github.com/user-attachments/assets/541e60fe-6dab-4e5d-891d-ce3d44026108" />
