### PR TITLE
damnit init: CLI to set up new DAMNIT folder

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -91,10 +91,13 @@ def db_path(root_path: Path):
     return root_path / DB_NAME
 
 class DamnitDB:
-    def __init__(self, path=DB_NAME, allow_old=False):
+    def __init__(self, path=DB_NAME, *, allow_old=False, create=False):
         self._path = path.absolute()
 
         db_existed = path.exists()
+        if (not create) and (not db_existed):
+            raise FileNotFoundError(path)
+
         log.debug("Opening database at %s", path)
         self.conn = sqlite3.connect(path, timeout=30)
         # Ensure the database is writable by everyone
@@ -133,8 +136,8 @@ class DamnitDB:
         self._db_id = db_id
 
     @classmethod
-    def from_dir(cls, path):
-        return cls(Path(path, DB_NAME))
+    def from_dir(cls, path, *, create=False):
+        return cls(Path(path, DB_NAME), create=create)
 
     def close(self):
         self.conn.close()
@@ -585,7 +588,7 @@ def initialize_proposal(root_path, proposal=None, context_file_src=None, user_va
             raise ValueError("Must pass a proposal number to `initialize_proposal()` if the database doesn't exist yet.")
 
         # Initialize database
-        db = DamnitDB.from_dir(root_path)
+        db = DamnitDB.from_dir(root_path, create=True)
         db.metameta["proposal"] = proposal
         db.metameta["context_python"] = DEFAULT_CONTEXT_PYTHON
     else:

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -2,6 +2,7 @@ import argparse
 
 import inspect
 import logging
+import re
 import sys
 import textwrap
 import traceback
@@ -42,6 +43,19 @@ def excepthook(exc_type, value, tb):
     import IPython
     IPython.start_ipython(argv=[], display_banner=False,
                           user_ns=target_frame.f_locals | target_frame.f_globals | {"__tb": lambda: print(tb_msg)})
+
+
+def get_existing_damnit_dir(proposal_or_dir: str | None):
+    if proposal_or_dir is None:
+        return None
+    elif (path := Path(proposal_or_dir)).is_dir():
+        return path
+    elif proposal_or_dir.isdigit():
+        proposal_name = f"p{int(proposal_or_dir):06d}"
+        return Path(find_proposal(proposal_name)) / "usr/Shared/amore"
+    else:
+        sys.exit(f"{proposal_or_dir} is not a proposal number or DAMNIT database directory")
+
 
 def handle_config_args(args, kv, converters={}):
     key = args.key
@@ -128,16 +142,7 @@ class GuiSubcmd(Subcommand):
 
     @staticmethod
     def run(args: argparse.Namespace):
-        if args.proposal_or_dir is not None:
-            if (path := Path(args.proposal_or_dir)).is_dir():
-                context_dir = path
-            elif args.proposal_or_dir.isdigit():
-                proposal_name = f"p{int(args.proposal_or_dir):06d}"
-                context_dir = Path(find_proposal(proposal_name)) / "usr/Shared/amore"
-            else:
-                sys.exit(f"{args.proposal_or_dir} is not a proposal number or DAMNIT database directory")
-        else:
-            context_dir = None
+        context_dir = get_existing_damnit_dir(args.proposal_or_dir)
 
         from .gui.main_window import run_app
         return run_app(context_dir,
@@ -512,6 +517,70 @@ class MigrateSubcmd(Subcommand):
             migrate_intermediate_v1(db, Path.cwd(), args.dry_run)
 
 
+class InitSubcmd(Subcommand):
+    name = "init"
+    help = "Set up a new DAMNIT folder"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            'proposal_or_dir',
+            help="Either a proposal number or a directory path."
+        )
+        parser.add_argument(
+            '--proposal', type=int,
+            help="Proposal number (if not in a proposal directory)"
+        )
+        parser.add_argument(
+            '--like',
+            help="Proposal number or DAMNIT directory to copy context file & "
+                 "user-editable variables from"
+        )
+        parser.add_argument(
+            '--context',
+            help="Context file to copy to the new location"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.db import initialize_proposal
+
+        if args.proposal_or_dir.isdigit():
+            proposal_num = int(args.proposal_or_dir)
+            damnit_dir = Path(find_proposal(f"p{proposal_num:06d}")) / "usr/Shared/amore"
+        else:
+            damnit_dir = Path(args.proposal_or_dir).resolve()
+            if args.proposal is not None:
+                proposal_num = args.proposal
+            elif m := re.match(r"/gpfs/exfel/u/.*/p([0-9]+)/", str(damnit_dir)):
+                proposal_num = int(m[1])
+            else:
+                sys.exit("--proposal is required if not in a proposal directory")
+
+        def check_file(p: Path):
+            if not p.is_file():
+                sys.exit(f"{p} is not a file")
+            return p
+
+        context_file_src = user_vars_src = None
+        if like_dir := get_existing_damnit_dir(args.like):
+            context_file_src = check_file(like_dir / "context.py")
+            user_vars_src = check_file(like_dir / "damnit.py")
+
+        if args.context is not None:
+            context_file_src = check_file(args.context)
+
+        damnit_dir.mkdir(parents=True, exist_ok=True)
+        print(f"Setting up DAMNIT in {damnit_dir}")
+
+        initialize_proposal(
+            damnit_dir,
+            proposal=proposal_num,
+            context_file_src=context_file_src,
+            user_vars_src=user_vars_src,
+        )
+
+
 def main(argv=None):
     # Check if script was called as amore-proto and show deprecation warning
     if Path(sys.argv[0]).name == 'amore-proto':
@@ -534,6 +603,7 @@ def main(argv=None):
         NewIdSubcmd,
         DbConfigSubcmd,
         MigrateSubcmd,
+        InitSubcmd,
     ]
     subcmd_map = {}
     for subcmd in subcmds:

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -316,7 +316,7 @@ class CombinerRunSubcmd(Subcommand):
 
 
 class CombinerNowSubcmd(Subcommand):
-    name = "now",
+    name = "now"
     help=("Combine files in the specified DAMNIT directory now. "
           "Can cause corruption if the combiner is running at the same time.")
 
@@ -575,7 +575,7 @@ class InitSubcmd(Subcommand):
         context_file_src = user_vars_src = None
         if like_dir := get_existing_damnit_dir(args.like):
             context_file_src = check_file(like_dir / "context.py")
-            user_vars_src = check_file(like_dir / "damnit.py")
+            user_vars_src = check_file(like_dir / "runs.sqlite")
 
         if args.context is not None:
             context_file_src = check_file(args.context)

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -2,6 +2,7 @@ import argparse
 
 import inspect
 import logging
+import os
 import re
 import sys
 import textwrap
@@ -346,14 +347,14 @@ class ReprocessSubcmd(Subcommand):
     @staticmethod
     def arguments(parser: argparse.ArgumentParser):
         parser.add_argument(
-            "--mock", action="store_true",
-            help="Use a fake run object instead of loading one from disk."
-                 " Note: do not use the passed `run` object in your context file with this"
-                 " flag enabled, it will not contain any useful data."
+            '--in', dest="proposal_or_dir",
+            help="Proposal number or DAMNIT directory in which to run. By "
+                 "default, uses the CWD."
         )
         parser.add_argument(
             '--proposal', type=int,
-            help="Proposal number, e.g. 1234"
+            help="Proposal number, e.g. 1234, to include data from another proposal. "
+                 "By default, uses the proposal number configured in the database."
         )
         parser.add_argument(
             '--match', type=str, action="append", default=[],
@@ -372,6 +373,12 @@ class ReprocessSubcmd(Subcommand):
             help="The maximum number of jobs that will run at once (default is the `concurrent_jobs` database setting)"
         )
         parser.add_argument(
+            "--mock", action="store_true",
+            help="Use a fake run object instead of loading one from disk."
+                 " Note: do not use the passed `run` object in your context file with this"
+                 " flag enabled, it will not contain any useful data."
+        )
+        parser.add_argument(
             'run', nargs='+',
             help="Run number, e.g. 96. Multiple runs can be specified at once, "
                  "or pass 'all' to reprocess all runs in the database."
@@ -381,6 +388,9 @@ class ReprocessSubcmd(Subcommand):
     def run(args: argparse.Namespace):
         # Hide some logging from Kafka to make things more readable
         logging.getLogger('kafka').setLevel(logging.WARNING)
+
+        if damnit_dir := get_existing_damnit_dir(args.proposal_or_dir):
+            os.chdir(damnit_dir)
 
         from .backend.extraction_control import reprocess
         reprocess(

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -1,9 +1,11 @@
+import argparse
+
 import inspect
 import logging
 import sys
 import textwrap
 import traceback
-from argparse import ArgumentParser, SUPPRESS
+from argparse import ArgumentParser
 from pathlib import Path
 
 from termcolor import colored
@@ -70,215 +72,62 @@ def handle_config_args(args, kv, converters={}):
         for k, v in kv.items():
             print(f"{k}={v!r}")
 
-def main(argv=None):
-    # Check if script was called as amore-proto and show deprecation warning
-    if Path(sys.argv[0]).name == 'amore-proto':
-        print(colored("Warning: 'amore-proto' has been renamed to 'damnit'. Please update your scripts.", 'yellow'), file=sys.stderr)
 
-    ap = ArgumentParser()
-    ap.add_argument('--debug', action='store_true',
-                    help="Show debug logs.")
-    ap.add_argument('--debug-repl', action='store_true',
-                    help="Drop into an IPython repl if an exception occurs. Local variables at the point of the exception will be available.")
-    subparsers = ap.add_subparsers(required=True, dest='subcmd')
+class Subcommand:
+    name: str
+    help: str | None = None
 
-    gui_ap = subparsers.add_parser('gui', help="Launch application")
-    gui_ap.add_argument(
-        'proposal_or_dir', nargs='?',
-        help="Either a proposal number or a database directory."
-    )
-    gui_ap.add_argument(
-        '--no-kafka', action='store_true',
-        help="Don't try connecting to XFEL's Kafka broker"
-    )
-    gui_ap.add_argument(
-        "--software-opengl", action="store_true",
-        help="Force software OpenGL. Use this if displaying interactive Plotly plots shows a black screen."
-             "Active by default on Maxwell if not started on a display node."
-    )
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        pass
 
-    listen_ap = subparsers.add_parser(
-        'listen', help="Watch for new runs & extract data from them"
-    )
-    listen_args_grp = listen_ap.add_mutually_exclusive_group()
-    listen_args_grp.add_argument(
-        "listener_dir", type=Path, default=Path.cwd(), nargs="?",
-        help="Path to the listener database directory"
-    )
-    listen_args_grp.add_argument(
-        '--test', action='store_true',
-        help="Manually enter 'migrated' runs for testing"
-    )
-    listen_args_grp.add_argument(
-        '--daemonize', action='store_true',
-        help="Start the listener under a separate process managed by supervisord."
-    )
+    @staticmethod
+    def run(args: argparse.Namespace):
+        raise NotImplementedError
 
-    listener_ap = subparsers.add_parser("listener", help="Manage the DAMNIT listener.")
-    listener_subparser = listener_ap.add_subparsers(dest="listener_subcmd", required=True)
 
-    listener_config_ap = listener_subparser.add_parser(
-        "config", help="See or change the config for the DAMNIT listener"
-    )
-    listener_config_ap.add_argument(
-        '-d', '--delete', action='store_true',
-        help="Delete the specified key",
-    )
-    listener_config_ap.add_argument(
-        '--num', action='store_true',
-        help="Set the given value as a number instead of a string"
-    )
-    listener_config_ap.add_argument(
-        'key', nargs='?',
-        help="The config key to see/change. If not given, list the whole configuration"
-    )
-    listener_config_ap.add_argument(
-        'value', nargs='?',
-        help="A new value for the given key"
-    )
+class SubcommandGroup(Subcommand):
+    subcmds: list
+    cmd_dest: str
 
-    add_grp = listener_subparser.add_parser("add", help="Add a database to monitor")
-    add_grp.add_argument(
-        "proposal", type=int,
-        help="Proposal number"
-    )
-    add_grp.add_argument(
-        "db_dir", type=Path, nargs='?',
-        help="Path to the database directory"
-    )
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.subcmd_map = {sc.name: sc for sc in cls.subcmds}
 
-    remove_grp = listener_subparser.add_parser("rm", help="Remove a database from being monitored")
-    remove_grp.add_argument(
-        "db_dir", type=Path,
-        help="Path to the database directory to remove"
-    )
+    @classmethod
+    def arguments(cls, parser: argparse.ArgumentParser):
+        subparsers = parser.add_subparsers(dest=cls.cmd_dest, required=True)
+        for subcmd in cls.subcmds:
+            sub_ap = subparsers.add_parser(subcmd.name, help=subcmd.help)
+            subcmd.arguments(sub_ap)
 
-    databases_grp = listener_subparser.add_parser(
-        "databases",
-        help="Display the DAMNIT databases currently being monitored"
-    )
+    @classmethod
+    def run(cls, args: argparse.Namespace):
+        return cls.subcmd_map[getattr(args, cls.cmd_dest)].run(args)
 
-    combiner_ap = subparsers.add_parser("combiner", help="Manage the DAMNIT combiner.")
-    combiner_subparser = combiner_ap.add_subparsers(dest="combiner_subcmd", required=True)
-    combiner_start_grp = combiner_subparser.add_parser("run", help="Run the DAMNIT combiner")
 
-    combiner_now_grp = combiner_subparser.add_parser("now",
-         help="Combine files in the specified DAMNIT directory now. "
-              "Can cause corruption if the combiner is running at the same time."
-    )
-    combiner_now_grp.add_argument("db_dir", type=Path)
+class GuiSubcmd(Subcommand):
+    name = "gui"
+    help = "Launch application"
 
-    reprocess_ap = subparsers.add_parser(
-        'reprocess',
-        help="Extract data from specified runs. This does not send live updates yet."
-    )
-    reprocess_ap.add_argument(
-        "--mock", action="store_true",
-        help="Use a fake run object instead of loading one from disk."
-             " Note: do not use the passed `run` object in your context file with this"
-             " flag enabled, it will not contain any useful data."
-    )
-    reprocess_ap.add_argument(
-        '--proposal', type=int,
-        help="Proposal number, e.g. 1234"
-    )
-    reprocess_ap.add_argument(
-        '--match', type=str, action="append", default=[],
-        help="String to match against variable titles (case-insensitive). Not a regex, simply `str in var.title`."
-    )
-    reprocess_ap.add_argument(
-        '--watch', action='store_true',
-        help="Run jobs one-by-one with live output in the terminal"
-    )
-    reprocess_ap.add_argument(
-        '--direct', action='store_true',
-        help="Run processing in subprocesses on this node, instead of via Slurm"
-    )
-    reprocess_ap.add_argument(
-        '--concurrent-jobs', type=int, default=-1,
-        help="The maximum number of jobs that will run at once (default is the `concurrent_jobs` database setting)"
-    )
-    reprocess_ap.add_argument(
-        'run', nargs='+',
-        help="Run number, e.g. 96. Multiple runs can be specified at once, "
-             "or pass 'all' to reprocess all runs in the database."
-    )
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            'proposal_or_dir', nargs='?',
+            help="Either a proposal number or a database directory."
+        )
+        parser.add_argument(
+            '--no-kafka', action='store_true',
+            help="Don't try connecting to XFEL's Kafka broker"
+        )
+        parser.add_argument(
+            "--software-opengl", action="store_true",
+            help="Force software OpenGL. Use this if displaying interactive Plotly plots shows a black screen."
+                 "Active by default on Maxwell if not started on a display node."
+        )
 
-    readctx_ap = subparsers.add_parser(
-        'read-context',
-        help="Re-read the context file and update variables in the database"
-    )
-    readctx_ap.add_argument(
-        '--no-kafka', action='store_true',
-        help="Don't try connecting to XFEL's Kafka broker"
-    )
-
-    proposal_ap = subparsers.add_parser(
-        'proposal',
-        help="Get or set the proposal number to collect metadata from"
-    )
-    proposal_ap.add_argument(
-        'proposal', nargs='?', type=int,
-        help="Proposal number to set, e.g. 1234"
-    )
-
-    new_id_ap = subparsers.add_parser(
-        'new-id',
-        help="Set a new (random) database ID. Useful if a copy has been made which should not share an ID with the original."
-    )
-    new_id_ap.add_argument(
-        'db_dir', type=Path, default=Path.cwd(), nargs='?',
-        help="Path to the database directory"
-    )
-
-    config_ap = subparsers.add_parser(
-        'db-config',
-        help="See or change config in this database"
-    )
-    config_ap.add_argument(
-        '-d', '--delete', action='store_true',
-        help="Delete the specified key",
-    )
-    config_ap.add_argument(
-        '--num', action='store_true',
-        help="Set the given value as a number instead of a string"
-    )
-    config_ap.add_argument(
-        'key', nargs='?',
-        help="The config key to see/change. If not given, list all config"
-    )
-    config_ap.add_argument(
-        'value', nargs='?',
-        help="A new value for the given key"
-    )
-
-    migrate_ap = subparsers.add_parser(
-        "migrate",
-        help="Execute migrations to help upgrading. Do NOT execute a migration unless you know what you're doing."
-    )
-    migrate_ap.add_argument(
-        "--dry-run", action="store_true"
-    )
-    migrate_subparsers = migrate_ap.add_subparsers(dest="migrate_subcmd")
-    migrate_subparsers.add_parser(
-        "v0-to-v1",
-        help="Migrate the SQLite database and HDF5 files from v0 to v1."
-    )
-    migrate_subparsers.add_parser(
-        "intermediate-v1",
-        help="Migrate the SQLite database HDF5 files from an initial implementation of v1 to the final"
-             " v1. Don't use this unless you know what you're doing."
-    )
-
-    args = ap.parse_args(argv)
-    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
-                        format="%(asctime)s %(levelname)-8s %(name)-38s %(message)s",
-                        datefmt="%Y-%m-%d %H:%M:%S")
-
-    if args.debug_repl:
-        sys.excepthook = excepthook
-
-    if args.subcmd == 'gui':
+    @staticmethod
+    def run(args: argparse.Namespace):
         if args.proposal_or_dir is not None:
             if (path := Path(args.proposal_or_dir)).is_dir():
                 context_dir = path
@@ -295,7 +144,29 @@ def main(argv=None):
                        software_opengl=args.software_opengl,
                        connect_to_kafka=not args.no_kafka)
 
-    elif args.subcmd == 'listen':
+
+class ListenSubcmd(Subcommand):
+    name = "listen"
+    help = "Watch for new runs & extract data from them"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        listen_args_grp = parser.add_mutually_exclusive_group()
+        listen_args_grp.add_argument(
+            "listener_dir", type=Path, default=Path.cwd(), nargs="?",
+            help="Path to the listener database directory"
+        )
+        listen_args_grp.add_argument(
+            '--test', action='store_true',
+            help="Manually enter 'migrated' runs for testing"
+        )
+        listen_args_grp.add_argument(
+            '--daemonize', action='store_true',
+            help="Start the listener under a separate process managed by supervisord."
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend import start_listener
 
         if args.daemonize:
@@ -308,51 +179,201 @@ def main(argv=None):
 
             return listen(args.listener_dir)
 
-    elif args.subcmd == "listener":
+
+class ListenerConfigSubcmd(Subcommand):
+    name = "config"
+    help = "See or change the config for the DAMNIT listener"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            '-d', '--delete', action='store_true',
+            help="Delete the specified key",
+        )
+        parser.add_argument(
+            '--num', action='store_true',
+            help="Set the given value as a number instead of a string"
+        )
+        parser.add_argument(
+            'key', nargs='?',
+            help="The config key to see/change. If not given, list the whole configuration"
+        )
+        parser.add_argument(
+            'value', nargs='?',
+            help="A new value for the given key"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend.listener import ListenerDB
 
         db = ListenerDB(Path.cwd())
-        if args.listener_subcmd == "config":
-            handle_config_args(args, db.settings,
-                               # Convert `static_mode` to a bool
-                               dict(static_mode=lambda x: bool(int(x))))
-        elif args.listener_subcmd == "add":
-            official_dir = Path(find_proposal(f"p{args.proposal:06d}")) / "usr/Shared/amore"
+        handle_config_args(args, db.settings,
+                           # Convert `static_mode` to a bool
+                           dict(static_mode=lambda x: bool(int(x))))
 
-            if args.db_dir is None:
-                db_dir = official_dir
-                official = True
+
+class ListenerAddSubcmd(Subcommand):
+    name = "add"
+    help = "Add a database to monitor"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "proposal", type=int,
+            help="Proposal number"
+        )
+        parser.add_argument(
+            "db_dir", type=Path, nargs='?',
+            help="Path to the database directory"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.listener import ListenerDB
+
+        db = ListenerDB(Path.cwd())
+        official_dir = Path(find_proposal(f"p{args.proposal:06d}")) / "usr/Shared/amore"
+
+        if args.db_dir is None:
+            db_dir = official_dir
+            official = True
+        else:
+            db_dir = args.db_dir
+            official = db_dir == official_dir
+
+        db.add_proposal_db(args.proposal, db_dir, official=official)
+        print(f"Added proposal {args.proposal} at {db_dir}")
+
+
+class ListenerRmSubcmd(Subcommand):
+    name = "rm"
+    help = "Remove a database from being monitored"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "db_dir", type=Path,
+            help="Path to the database directory to remove"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.listener import ListenerDB
+
+        db = ListenerDB(Path.cwd())
+        db.remove_proposal_db(args.db_dir)
+        print(f"Removed database at {args.db_dir}")
+
+
+class ListenerDatabasesSubcmd(Subcommand):
+    name = "databases"
+    help = "Display the DAMNIT databases currently being monitored"
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.listener import ListenerDB
+
+        db = ListenerDB(Path.cwd())
+        all_proposals = db.all_proposals()
+        sorted_proposals = sorted(all_proposals.keys())
+        for p in sorted_proposals:
+            if len(all_proposals[p]) > 1:
+                print(f"p{p}:")
+                for x in all_proposals[p]:
+                    print("   ", x.db_dir, "" if x.official else " (unofficial)", sep="")
             else:
-                db_dir = args.db_dir
-                official = db_dir == official_dir
+                x = all_proposals[p][0]
+                print(f"p{p}: {x.db_dir}", "" if x.official else "(unofficial)")
 
-            db.add_proposal_db(args.proposal, db_dir, official=official)
-            print(f"Added proposal {args.proposal} at {db_dir}")
-        elif args.listener_subcmd == "rm":
-            db.remove_proposal_db(args.db_dir)
-            print(f"Removed database at {args.db_dir}")
-        elif args.listener_subcmd == "databases":
-            db = ListenerDB(Path.cwd())
-            all_proposals = db.all_proposals()
-            sorted_proposals = sorted(all_proposals.keys())
-            for p in sorted_proposals:
-                if len(all_proposals[p]) > 1:
-                    print(f"p{p}:")
-                    for x in all_proposals[p]:
-                        print("   ", x.db_dir, "" if x.official else " (unofficial)", sep="")
-                else:
-                    x = all_proposals[p][0]
-                    print(f"p{p}: {x.db_dir}", "" if x.official else "(unofficial)")
 
-    elif args.subcmd == "combiner":
-        if args.combiner_subcmd == 'run':
-            from .backend.combine import main
-            return main()
-        elif args.combiner_subcmd == 'now':
-            from .backend.combine import gather_all_fragments
-            gather_all_fragments(args.db_dir)
+class ListenerSubcmd(SubcommandGroup):
+    name = "listener"
+    help = "Manage the DAMNIT listener."
+    cmd_dest = "listener_subcmd"
+    subcmds = [
+        ListenerConfigSubcmd,
+        ListenerAddSubcmd,
+        ListenerRmSubcmd,
+        ListenerDatabasesSubcmd,
+    ]
 
-    elif args.subcmd == 'reprocess':
+
+class CombinerRunSubcmd(Subcommand):
+    name = "run"
+    help = "Run the DAMNIT combiner"
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.combine import main
+        return main()
+
+
+class CombinerNowSubcmd(Subcommand):
+    name = "now",
+    help=("Combine files in the specified DAMNIT directory now. "
+          "Can cause corruption if the combiner is running at the same time.")
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument("db_dir", type=Path)
+
+    @staticmethod
+    def run(args: argparse.Namespace):
+        from .backend.combine import gather_all_fragments
+        gather_all_fragments(args.db_dir)
+
+
+class CombinerSubcmd(SubcommandGroup):
+    name = "combiner"
+    help = "Manage the DAMNIT combiner."
+    cmd_dest = "combiner_subcmd"
+    subcmds = [
+        CombinerRunSubcmd,
+        CombinerNowSubcmd,
+    ]
+
+
+class ReprocessSubcmd(Subcommand):
+    name = "reprocess"
+    help = "Extract data from specified runs."
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--mock", action="store_true",
+            help="Use a fake run object instead of loading one from disk."
+                 " Note: do not use the passed `run` object in your context file with this"
+                 " flag enabled, it will not contain any useful data."
+        )
+        parser.add_argument(
+            '--proposal', type=int,
+            help="Proposal number, e.g. 1234"
+        )
+        parser.add_argument(
+            '--match', type=str, action="append", default=[],
+            help="String to match against variable titles (case-insensitive). Not a regex, simply `str in var.title`."
+        )
+        parser.add_argument(
+            '--watch', action='store_true',
+            help="Run jobs one-by-one with live output in the terminal"
+        )
+        parser.add_argument(
+            '--direct', action='store_true',
+            help="Run processing in subprocesses on this node, instead of via Slurm"
+        )
+        parser.add_argument(
+            '--concurrent-jobs', type=int, default=-1,
+            help="The maximum number of jobs that will run at once (default is the `concurrent_jobs` database setting)"
+        )
+        parser.add_argument(
+            'run', nargs='+',
+            help="Run number, e.g. 96. Multiple runs can be specified at once, "
+                 "or pass 'all' to reprocess all runs in the database."
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         # Hide some logging from Kafka to make things more readable
         logging.getLogger('kafka').setLevel(logging.WARNING)
 
@@ -362,11 +383,37 @@ def main(argv=None):
             limit_running=args.concurrent_jobs,
         )
 
-    elif args.subcmd == 'read-context':
+
+class ReadctxSubcmd(Subcommand):
+    name = "read-context"
+    help="Re-read the context file and update variables in the database"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            '--no-kafka', action='store_true',
+            help="Don't try connecting to XFEL's Kafka broker"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend.extract_data import Extractor
         Extractor(connect_to_kafka=not args.no_kafka).update_db_vars()
 
-    elif args.subcmd == 'proposal':
+
+class ProposalSubcmd(Subcommand):
+    name = "proposal"
+    help="Get or set the proposal number to collect metadata from"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            'proposal', nargs='?', type=int,
+            help="Proposal number to set, e.g. 1234"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend.db import DamnitDB
         db = DamnitDB()
         currently_set = db.metameta.get('proposal', None)
@@ -378,20 +425,82 @@ def main(argv=None):
             db.metameta['proposal'] = args.proposal
             print(f"Changed proposal to {args.proposal} (was {currently_set})")
 
-    elif args.subcmd == 'new-id':
+
+class NewIdSubcmd(Subcommand):
+    name = "new-id"
+    help=("Set a new (random) database ID. Useful if a copy has been made "
+          "which should not share an ID with the original.")
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            'db_dir', type=Path, default=Path.cwd(), nargs='?',
+            help="Path to the database directory"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from secrets import token_hex
         from .backend.db import DamnitDB
 
         db = DamnitDB.from_dir(args.db_dir)
         db.metameta["db_id"] = token_hex(20)
 
-    elif args.subcmd == 'db-config':
+
+class DbConfigSubcmd(Subcommand):
+    name = "db-config"
+    help = "See or change config in this database"
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            '-d', '--delete', action='store_true',
+            help="Delete the specified key",
+        )
+        parser.add_argument(
+            '--num', action='store_true',
+            help="Set the given value as a number instead of a string"
+        )
+        parser.add_argument(
+            'key', nargs='?',
+            help="The config key to see/change. If not given, list all config"
+        )
+        parser.add_argument(
+            'value', nargs='?',
+            help="A new value for the given key"
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend.db import DamnitDB
 
         db = DamnitDB()
         handle_config_args(args, db.metameta)
 
-    elif args.subcmd == "migrate":
+
+class MigrateSubcmd(Subcommand):
+    name = "migrate"
+    help = ("Execute migrations to help upgrading. Do NOT execute a migration "
+            "unless you know what you're doing.")
+
+    @staticmethod
+    def arguments(parser: argparse.ArgumentParser):
+        parser.add_argument(
+            "--dry-run", action="store_true"
+        )
+        migrate_subparsers = parser.add_subparsers(dest="migrate_subcmd")
+        migrate_subparsers.add_parser(
+            "v0-to-v1",
+            help="Migrate the SQLite database and HDF5 files from v0 to v1."
+        )
+        migrate_subparsers.add_parser(
+            "intermediate-v1",
+            help="Migrate the SQLite database HDF5 files from an initial implementation of v1 to the final"
+                 " v1. Don't use this unless you know what you're doing."
+        )
+
+    @staticmethod
+    def run(args: argparse.Namespace):
         from .backend.db import DamnitDB
         from .migrations import migrate_intermediate_v1, migrate_v0_to_v1
 
@@ -401,6 +510,47 @@ def main(argv=None):
             migrate_v0_to_v1(db, Path.cwd(), args.dry_run)
         elif args.migrate_subcmd == "intermediate-v1":
             migrate_intermediate_v1(db, Path.cwd(), args.dry_run)
+
+
+def main(argv=None):
+    # Check if script was called as amore-proto and show deprecation warning
+    if Path(sys.argv[0]).name == 'amore-proto':
+        print(colored("Warning: 'amore-proto' has been renamed to 'damnit'. Please update your scripts.", 'yellow'), file=sys.stderr)
+
+    ap = ArgumentParser()
+    ap.add_argument('--debug', action='store_true',
+                    help="Show debug logs.")
+    ap.add_argument('--debug-repl', action='store_true',
+                    help="Drop into an IPython repl if an exception occurs. Local variables at the point of the exception will be available.")
+    subparsers = ap.add_subparsers(required=True, dest='subcmd')
+    subcmds = [
+        GuiSubcmd,
+        ListenSubcmd,
+        ListenerSubcmd,
+        CombinerSubcmd,
+        ReprocessSubcmd,
+        ReadctxSubcmd,
+        ProposalSubcmd,
+        NewIdSubcmd,
+        DbConfigSubcmd,
+        MigrateSubcmd,
+    ]
+    subcmd_map = {}
+    for subcmd in subcmds:
+        sub_ap = subparsers.add_parser(subcmd.name, help=subcmd.help)
+        subcmd.arguments(sub_ap)
+        subcmd_map[subcmd.name] = subcmd
+
+    args = ap.parse_args(argv)
+    logging.basicConfig(level=logging.DEBUG if args.debug else logging.INFO,
+                        format="%(asctime)s %(levelname)-8s %(name)-38s %(message)s",
+                        datefmt="%Y-%m-%d %H:%M:%S")
+
+    if args.debug_repl:
+        sys.excepthook = excepthook
+
+    return subcmd_map[args.subcmd].run(args)
+
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -547,7 +547,7 @@ class InitSubcmd(Subcommand):
                  "user-editable variables from"
         )
         parser.add_argument(
-            '--context',
+            '--context', type=Path,
             help="Context file to copy to the new location"
         )
 

--- a/damnit/migrations.py
+++ b/damnit/migrations.py
@@ -214,7 +214,7 @@ def migrate_v0_to_v1(db, db_dir, dry_run):
 
     new_db_path = db_dir / "runs.v1.sqlite"
     new_db_path.unlink(missing_ok=True)  # Clear any previous attempt
-    new_db = DamnitDB(new_db_path)
+    new_db = DamnitDB(new_db_path, create=True)
 
     # Copy the metadata
     for k, v in db.metameta.items():
@@ -309,7 +309,7 @@ def migrate_intermediate_v1(db, db_dir, dry_run):
     # Create a new database, overwriting any previous attempts
     new_db_path = db_dir / "runs.v1.sqlite"
     new_db_path.unlink(missing_ok=True)
-    new_db = DamnitDB(new_db_path)
+    new_db = DamnitDB(new_db_path, create=True)
 
     # Copy everything but `run_variables` to the new database
     for k, v in db.metameta.items():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -172,7 +172,7 @@ def mock_run():
 
 @pytest.fixture
 def mock_db(tmp_path, mock_ctx, monkeypatch):
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
     db.metameta['proposal'] = 1234
 
     (tmp_path / "context.py").write_text(mock_ctx.code)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -219,3 +219,17 @@ def test_init(tmp_path):
     assert (damnit_dir / "runs.sqlite").is_file()
     with DamnitDB.from_dir(damnit_dir) as db:
         assert db.metameta['proposal'] == 4321
+
+
+def test_init_prop_num(tmp_path, mock_db, monkeypatch):
+    old_dir, _ = mock_db
+    prop_dir = tmp_path / "p4321"
+    monkeypatch.setattr("damnit.cli.find_proposal", lambda p: prop_dir)
+
+    main(["init", "4321", "--like", str(old_dir)])  # Smoketest --like
+
+    damnit_dir = prop_dir / "usr" / "Shared" / "amore"
+    assert damnit_dir.is_dir()
+    assert (damnit_dir / "context.py").is_file()
+    with DamnitDB.from_dir(damnit_dir) as db:
+        assert db.metameta['proposal'] == 4321

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 import pytest
 from testpath import MockCommand
 
+from damnit.backend.db import DamnitDB
 from damnit.backend.listener import ListenerDB
 from damnit.cli import main, excepthook as ipython_excepthook
 
@@ -204,3 +205,17 @@ def test_cli_command_name(capsys, monkeypatch):
         captured = capsys.readouterr()
         assert "Warning: 'amore-proto' has been renamed to 'damnit'" in captured.err  # Shows deprecation
         assert 'usage:' in captured.out  # Help text is shown
+
+
+def test_init(tmp_path):
+    ctx_code = "a = 3\n"
+    egctx = (tmp_path / "egctx.py")
+    egctx.write_text(ctx_code)
+    damnit_dir = tmp_path / 'new'
+
+    main(["init", str(damnit_dir), "--context", str(egctx), "--proposal", "4321"])
+
+    assert (damnit_dir / "context.py").read_text() == ctx_code
+    assert (damnit_dir / "runs.sqlite").is_file()
+    with DamnitDB.from_dir(damnit_dir) as db:
+        assert db.metameta['proposal'] == 4321

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -105,7 +105,7 @@ def test_tag_cleanup(tmp_path):
     Tests that the SQLite trigger correctly cleans up orphaned tags
     when variable-tag associations are removed or variables are deleted.
     """
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
 
     # helper function
     def _var_def(title, tags=None):
@@ -196,7 +196,7 @@ def test_numpy_blob_conversion():
 
 
 def test_numpy_summary_type_and_storage(tmp_path):
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
     db.ensure_run(1234, 1)
     arr = np.arange(10, dtype=np.float64)
 
@@ -219,7 +219,7 @@ def test_numpy_summary_type_and_storage(tmp_path):
 
 
 def test_new_db_schema_is_latest(tmp_path):
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
 
     # Schema version should match the latest known migration
     assert db.metameta["data_format_version"] == latest_version()
@@ -241,7 +241,7 @@ def test_new_db_schema_is_latest(tmp_path):
 
 def test_upgrade_from_v2_creates_backup_and_applies_missing(tmp_path):
     # Start with a fresh (latest) DB, then downgrade state to v2 (no tags tables, no trigger)
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
     with db.conn:
         db.conn.execute("DROP TRIGGER IF EXISTS delete_orphan_tags_after_variable_tag_delete")
         db.conn.execute("DROP TABLE IF EXISTS variable_tags")
@@ -283,7 +283,7 @@ def test_min_openable_version_guard(tmp_path):
 
 
 def test_open_readonly(tmp_path):
-    db = DamnitDB.from_dir(tmp_path)
+    db = DamnitDB.from_dir(tmp_path, create=True)
     # Delete a known recent addition to the schema that old databases will not have
     del db.metameta["damnit_python"]
     db.close()

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -447,7 +447,7 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
 
     # Create the directory and database file to fake the database already existing
     db_dir.mkdir(parents=True)
-    DamnitDB.from_dir(db_dir)
+    DamnitDB.from_dir(db_dir, create=True)
 
     # Autoconfigure with database present
     with helper_patch() as initialize_proposal:


### PR DESCRIPTION
Various other commands which might currently implicitly set up a new database, like `damnit db-config`, will instead fail if not run in/on a DAMNIT folder. This also adds `damnit reprocess --in 11437 123`, since it's come up a few times that cd-ing to the location first is unintuitive.

I'd recommend reviewing commit-by-commit.