### PR TITLE
Parameters

### DIFF
--- a/damnit/backend/combine.py
+++ b/damnit/backend/combine.py
@@ -64,7 +64,7 @@ def combine(src: Path, dst: Path):
             if not grp.startswith("."):
                 copy_h5_obj(fsrc, fdst, grp)
 
-        for special_grp in [".reduced", ".preview", ".errors"]:
+        for special_grp in [".reduced", ".preview", ".errors", ".parameters"]:
             for k in fsrc.get(special_grp, ()):
                 copy_h5_obj(fsrc, fdst, f"{special_grp}/{k}")
 

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -260,6 +260,30 @@ class DamnitDB:
         return {k: v for (k, v) in self._get_user_variables().items()
                 if (VariableAttributes.PARAM_DEFAULT in v.attributes)}
 
+    def get_parameter_values(self, proposals_runs):
+        params = self.get_parameters()
+        res = {}
+        new_runs = False
+        for prop, run in proposals_runs:
+            rows = self.conn.execute(
+                "SELECT name, value FROM run_variables WHERE proposal=? AND run=?",
+                (prop, run)
+            ).fetchall()
+            if not rows:
+                new_runs = True
+            for name, value in rows:
+                if name in params:
+                    res.setdefault(name, set()).add(value)
+
+        if new_runs:
+            for name, var in params.items():
+                value = (
+                    var.attributes.get(VariableAttributes.PARAM_VALUE_NEW_RUN) or
+                    var.attributes[VariableAttributes.PARAM_DEFAULT]
+                )
+                res.setdefault(name, set()).add(value)
+        return res
+
     def update_computed_variables(self, vars: dict):
         vars_in_db = {}
         with self.conn:

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -232,17 +232,14 @@ class DamnitDB:
 
         self.update_views()
 
-    def get_user_variables(self):
+    def _get_user_variables(self):
         user_variables = {}
         rows = self.conn.execute("""
             SELECT name, title, type, description, attributes FROM variables
             WHERE type IS NOT NULL
         """)
         for rr in rows:
-            attrs = rr['attributes']
-            if attrs and ('param_default' in json.loads(attrs)):
-                continue  # This is a parameter
-
+            attrs = json.loads(rr['attributes']) if rr['attributes'] else {}
             var_name = rr["name"]
             new_var = UserEditableVariable(
                 var_name,
@@ -255,6 +252,14 @@ class DamnitDB:
         log.debug("Loaded %d user variables", len(user_variables))
         return user_variables
 
+    def get_user_variables(self):
+        return {k: v for (k, v) in self._get_user_variables().items()
+                if ('param_default' not in v.attributes)}
+
+    def get_parameters(self):
+        return {k: v for (k, v) in self._get_user_variables().items()
+                if ('param_default' in v.attributes)}
+
     def update_computed_variables(self, vars: dict):
         vars_in_db = {}
         with self.conn:
@@ -264,7 +269,6 @@ class DamnitDB:
             self.conn.execute("BEGIN IMMEDIATE")
             for row in self.conn.execute("""
                 SELECT name, title, type, description, attributes FROM variables
-                WHERE type IS NULL
             """).fetchall():
                 var = dict(row)
                 if isinstance(var['attributes'], str):
@@ -278,7 +282,7 @@ class DamnitDB:
             for n, v in updates.items():
                 attrs = vars_in_db.get(n, {}).get('attributes') or {}
                 attrs |= (v['attributes'] or {})
-                v['attributes'] = (attrs or None)
+                v['attributes'] = (json.dumps(attrs) if attrs else None)
 
             # Write new & changed variables
             # TODO: what if a new computed variable name matches an existing user var?

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -239,13 +239,17 @@ class DamnitDB:
             WHERE type IS NOT NULL
         """)
         for rr in rows:
+            attrs = rr['attributes']
+            if attrs and ('param_default' in json.loads(attrs)):
+                continue  # This is a parameter
+
             var_name = rr["name"]
             new_var = UserEditableVariable(
                 var_name,
                 title=rr["title"],
                 variable_type=rr["type"],
                 description=rr["description"],
-                attributes=rr["attributes"],
+                attributes=attrs,
             )
             user_variables[var_name] = new_var
         log.debug("Loaded %d user variables", len(user_variables))
@@ -263,24 +267,30 @@ class DamnitDB:
                 WHERE type IS NULL
             """).fetchall():
                 var = dict(row)
+                if isinstance(var['attributes'], str):
+                    var['attributes'] = json.loads(var['attributes'])
                 vars_in_db[var.pop("name")] = var
 
             updates = {n: v for (n, v) in vars.items()
                        if v != vars_in_db.get(n, None)}
             log.debug("Updating stored metadata for %d computed variables",
                       len(updates))
+            for n, v in updates.items():
+                attrs = vars_in_db.get(n, {}).get('attributes') or {}
+                attrs |= (v['attributes'] or {})
+                v['attributes'] = (attrs or None)
 
             # Write new & changed variables
             # TODO: what if a new computed variable name matches an existing user var?
             self.conn.executemany("""
-                INSERT INTO variables VALUES (?, NULL, ?, ?, ?)
+                INSERT INTO variables VALUES (?, ?, ?, ?, ?)
                 ON CONFLICT (name) DO UPDATE SET
                     type=excluded.type,
                     title=excluded.title,
                     description=excluded.description,
                     attributes=excluded.attributes
             """, [
-                (n, v['title'], v['description'], v['attributes'])
+                (n, v['type'], v['title'], v['description'], v['attributes'])
                 for (n, v) in updates.items()
             ])
 
@@ -396,6 +406,23 @@ class DamnitDB:
 
             if is_new:
                 self.update_views()
+
+    def update_variables_attrs(self, vars_attrs: dict):
+        attrs_in_db = dict(
+            self.conn.execute("SELECT name, attributes FROM variables").fetchall()
+        )
+        to_set = []
+        for name, new_attrs in vars_attrs.items():
+            new_attrs = (attrs_in_db[name] or {}) | new_attrs
+            to_set.append({
+                'name': name, 'attributes': json.dumps(new_attrs) if new_attrs else None
+            })
+
+        with self.conn:
+            self.conn.executemany(
+                "UPDATE variables SET attributes=:attributes WHERE name=:name",
+                to_set,
+            )
 
     def delete_variable(self, name: str):
         with self.conn:

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -274,6 +274,8 @@ class DamnitDB:
             ).fetchall()
             for name, value in rows:
                 if name in params:
+                    if params[name].variable_type == 'boolean':
+                        value = bool(value)  # 1/0 -> True/False
                     res[name] = value
         else:
             # New run

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -17,7 +17,7 @@ from typing import Any, Optional
 
 import numpy as np
 
-from ..definitions import UPDATE_TOPIC, DEFAULT_CONTEXT_PYTHON
+from ..definitions import UPDATE_TOPIC, DEFAULT_CONTEXT_PYTHON, VariableAttributes
 from .db_migrations import apply_migrations, latest_version
 from .user_variables import UserEditableVariable
 
@@ -254,11 +254,11 @@ class DamnitDB:
 
     def get_user_variables(self):
         return {k: v for (k, v) in self._get_user_variables().items()
-                if ('param_default' not in v.attributes)}
+                if (VariableAttributes.PARAM_DEFAULT not in v.attributes)}
 
     def get_parameters(self):
         return {k: v for (k, v) in self._get_user_variables().items()
-                if ('param_default' in v.attributes)}
+                if (VariableAttributes.PARAM_DEFAULT in v.attributes)}
 
     def update_computed_variables(self, vars: dict):
         vars_in_db = {}
@@ -417,7 +417,8 @@ class DamnitDB:
         )
         to_set = []
         for name, new_attrs in vars_attrs.items():
-            new_attrs = (attrs_in_db[name] or {}) | new_attrs
+            old_attrs = json.loads(attrs_in_db[name]) if attrs_in_db[name] else {}
+            new_attrs = old_attrs | new_attrs
             to_set.append({
                 'name': name, 'attributes': json.dumps(new_attrs) if new_attrs else None
             })

--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -260,28 +260,28 @@ class DamnitDB:
         return {k: v for (k, v) in self._get_user_variables().items()
                 if (VariableAttributes.PARAM_DEFAULT in v.attributes)}
 
-    def get_parameter_values(self, proposals_runs):
-        params = self.get_parameters()
-        res = {}
-        new_runs = False
-        for prop, run in proposals_runs:
+    def get_parameter_values(self, proposal: int, run: int, params: dict):
+        res = {n: v.attributes[VariableAttributes.PARAM_DEFAULT]
+               for (n, v) in params.items()}
+        run_in_db = self.conn.execute(
+            "SELECT count(*) FROM run_info WHERE proposal=? AND RUN=?",
+            (proposal, run)
+        ).fetchone()[0]
+        if run_in_db:
             rows = self.conn.execute(
                 "SELECT name, value FROM run_variables WHERE proposal=? AND run=?",
-                (prop, run)
+                (proposal, run)
             ).fetchall()
-            if not rows:
-                new_runs = True
             for name, value in rows:
                 if name in params:
-                    res.setdefault(name, set()).add(value)
-
-        if new_runs:
+                    res[name] = value
+        else:
+            # New run
             for name, var in params.items():
-                value = (
-                    var.attributes.get(VariableAttributes.PARAM_VALUE_NEW_RUN) or
-                    var.attributes[VariableAttributes.PARAM_DEFAULT]
-                )
-                res.setdefault(name, set()).add(value)
+                vnr = var.attributes.get(VariableAttributes.PARAM_VALUE_NEW_RUN)
+                if vnr is not None:
+                    res[name] = vnr
+
         return res
 
     def update_computed_variables(self, vars: dict):

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -121,6 +121,9 @@ def load_reduced_data(h5_path):
             )
             for name, dset in f['.reduced'].items()
         } | {
+            name: ReducedData(get_dset_value(dset))
+            for name, dset in f['.parameters'].items()
+        } | {
             name: ReducedData(None, attributes={
                 'error': get_dset_value(dset),
                 'error_cls': dset.attrs.get("type", "")

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -217,7 +217,8 @@ class Extractor:
 
 class RunExtractor(Extractor):
     def __init__(self, proposal, run, cluster=False, run_data=RunData.ALL,
-                 match=(), variables=(), mock=False, uuid=None, sandbox_args=None):
+                 match=(), variables=(), params=(), mock=False, uuid=None,
+                 sandbox_args=None):
         super().__init__(sandbox_args=sandbox_args)
         self.proposal = proposal
         self.run = run
@@ -225,6 +226,7 @@ class RunExtractor(Extractor):
         self.run_data = run_data
         self.match = match
         self.variables = variables
+        self.params = params
         self.mock = mock
         self.uuid = uuid or str(uuid4())
         self.sandbox_args = sandbox_args
@@ -295,6 +297,8 @@ class RunExtractor(Extractor):
             else:
                 for m in self.match:
                     args.extend(['--match', m])
+            for param in self.params:
+                args.extend(["--param", param])
 
             p = subprocess.Popen(args, env=prepare_env(), stdin=subprocess.DEVNULL)
 
@@ -357,6 +361,7 @@ def main(argv=None):
     ap.add_argument('--cluster-job', action="store_true")
     ap.add_argument('--match', action="append", default=[])
     ap.add_argument('--var',  action="append", default=[])
+    ap.add_argument('--params', type=json.loads, default="{}")
     ap.add_argument('--mock', action='store_true')
     ap.add_argument('--update-vars', action='store_true')
     ap.add_argument('--processing-id', type=str)
@@ -388,6 +393,7 @@ def main(argv=None):
                         run_data=RunData(args.run_data),
                         match=args.match,
                         variables=args.var,
+                        params=args.params,
                         mock=args.mock,
                         uuid=args.processing_id,
                         sandbox_args=args.sandbox_args)

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -364,7 +364,7 @@ def main(argv=None):
     ap.add_argument('--cluster-job', action="store_true")
     ap.add_argument('--match', action="append", default=[])
     ap.add_argument('--var',  action="append", default=[])
-    ap.add_argument('--params', type=json.loads, default="{}")
+    ap.add_argument('--param', action="append", default=[])
     ap.add_argument('--mock', action='store_true')
     ap.add_argument('--update-vars', action='store_true')
     ap.add_argument('--processing-id', type=str)
@@ -396,7 +396,7 @@ def main(argv=None):
                         run_data=RunData(args.run_data),
                         match=args.match,
                         variables=args.var,
-                        params=args.params,
+                        params=args.param,
                         mock=args.mock,
                         uuid=args.processing_id,
                         sandbox_args=args.sandbox_args)

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -318,9 +318,38 @@ class RunExtractor(Extractor):
             for line in tf:
                 pth = line.decode().strip()
                 if pth and Path(pth).is_file():
-                    self.kafka_prd.send(FILE_SUBMIT_TOPIC, file_submit_msg(
-                        self.db.path.parent, self.proposal, self.run, pth
-                    ))
+                    if os.environ.get("DAMNIT_SELF_COMBINE") == "1":
+                        self._self_combine(Path(pth))
+                    else:
+                        # Normal: tell the combiner service about the new file
+                        self.kafka_prd.send(FILE_SUBMIT_TOPIC, file_submit_msg(
+                            self.db.path.parent, self.proposal, self.run, pth
+                        ))
+
+    def _self_combine(self, src: Path):
+        """For testing, used with DAMNIT_SELF_COMBINE=1
+
+        File corruption can occur if the combiner service writes to the same
+        file at the same time.
+        """
+        from .combine import combine
+
+        dst = Path.cwd() / "extracted_data" / f"p{self.proposal}_r{self.run}.h5"
+
+        with h5py.File(src) as f:
+            provenance = f.attrs.get("provenance", "")
+        new_data = load_reduced_data(src)
+        combine(src, dst)
+
+        log.info("Updating database in %s with %s variables for p%d r%d from %s",
+                 Path.cwd(), len(new_data), self.proposal, self.run, provenance)
+        add_to_db(new_data, self.db, self.proposal, self.run, provenance=provenance)
+        self.kafka_prd.send(self.db.kafka_topic, msg_dict(
+            MsgKind.run_values_updated, {
+                'run': self.run,
+                'proposal': self.proposal,
+                'values': {name: None for name in new_data.keys()}
+        }))
 
     def extract_and_ingest(self):
         self._notify_running()
@@ -385,6 +414,7 @@ def main(argv=None):
 
     print(f"\n----- Processing r{args.run} (p{args.proposal}) as {username} on {hostname} -----", file=sys.stderr)
     log.info(f"run_data={args.run_data}, match={args.match}")
+    log.info(f"params={args.param}")
     if args.mock:
         log.info("Using mock run object for testing")
     if args.cluster_job:

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -347,11 +347,12 @@ def reprocess(runs, proposal=None, match=(), params=(), mock=False, watch=False,
         # will work just leaving it as a string.
         param_dict[name] = value_s
 
-    with DamnitDB.from_dir(Path.cwd()) as db:
-        submitter = ExtractionSubmitter(Path.cwd(), db)
-        if proposal is None:
-            proposal = submitter.proposal
-        rows = db.conn.execute("SELECT proposal, run FROM runs").fetchall() if runs == ['all'] else None
+    db = DamnitDB.from_dir(Path.cwd())
+    submitter = ExtractionSubmitter(Path.cwd(), db)
+    if proposal is None:
+        proposal = submitter.proposal
+
+    param_info = db.get_parameters()
 
     if runs == ['all']:
         # Dictionary of proposal numbers to sets of available runs
@@ -359,6 +360,8 @@ def reprocess(runs, proposal=None, match=(), params=(), mock=False, watch=False,
         # Lists of (proposal, run) tuples
         props_runs = []
         unavailable_runs = []
+
+        rows = db.conn.execute("SELECT proposal, run FROM run_info").fetchall()
 
         if mock:
             props_runs = rows
@@ -395,14 +398,18 @@ def reprocess(runs, proposal=None, match=(), params=(), mock=False, watch=False,
 
         props_runs = [(proposal, r) for r in sorted(runs & available_runs)]
 
-    reqs = [
-        ExtractionRequest(run, prop, RunData.ALL, match=match, params=param_dict, mock=mock)
-        for prop, run in props_runs
-    ]
+    reqs = [ExtractionRequest(
+        run, prop, RunData.ALL,
+        match=match,
+        params=db.get_parameter_values(prop, run, param_info) | param_dict,
+        mock=mock
+    ) for prop, run in props_runs]
     # To reduce DB write contention, only update the computed variables in the
     # first job when we're submitting a whole bunch.
     for req in reqs[1:]:
         req.update_vars = False
+
+    db.close()
 
     if direct:
         for req in reqs:

--- a/damnit/backend/extraction_control.py
+++ b/damnit/backend/extraction_control.py
@@ -3,6 +3,7 @@
 See extract_data.py for what happens inside the jobs this launches.
 """
 import getpass
+import json
 import logging
 import os
 import shlex
@@ -98,6 +99,7 @@ class ExtractionRequest:
     cluster: bool = False
     match: tuple = ()
     variables: tuple = ()   # Overrides match if present
+    params: dict = field(default_factory=dict)
     mock: bool = False
     update_vars: bool = True
     processing_id: str = field(default_factory=lambda : str(uuid4()))
@@ -117,6 +119,8 @@ class ExtractionRequest:
         else:
             for m in self.match:
                 cmd.extend(['--match', m])
+        for n, v in self.params.items():
+            cmd.extend(['--param', f"{n}={v}"])
         if self.mock:
             cmd.append('--mock')
         if self.update_vars:
@@ -326,8 +330,23 @@ class ExtractionSubmitter:
         return opts
 
 
-def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=False, limit_running=-1):
+def reprocess(runs, proposal=None, match=(), params=(), mock=False, watch=False, direct=False, limit_running=-1):
     """Called by the 'damnit reprocess' subcommand"""
+    param_dict = {}
+    for p in params:
+        name, eq, value_s = p.partition("=")
+        if not eq:
+            raise ValueError(
+                f'Invalid parameter argument {p!r} (should be "name=value")'
+            )
+        if not all(part.isidentifier() for part in name.split(".")):
+            raise ValueError(f"{name!r} is not a valid parameter name")
+        if name in param_dict:
+            raise ValueError(f"Parameter {name} is defined more than once")
+        # We don't know the expected type here, but the way we pass it down
+        # will work just leaving it as a string.
+        param_dict[name] = value_s
+
     with DamnitDB.from_dir(Path.cwd()) as db:
         submitter = ExtractionSubmitter(Path.cwd(), db)
         if proposal is None:
@@ -377,7 +396,7 @@ def reprocess(runs, proposal=None, match=(), mock=False, watch=False, direct=Fal
         props_runs = [(proposal, r) for r in sorted(runs & available_runs)]
 
     reqs = [
-        ExtractionRequest(run, prop, RunData.ALL, match=match, mock=mock)
+        ExtractionRequest(run, prop, RunData.ALL, match=match, params=param_dict, mock=mock)
         for prop, run in props_runs
     ]
     # To reduce DB write contention, only update the computed variables in the

--- a/damnit/backend/listener.py
+++ b/damnit/backend/listener.py
@@ -219,13 +219,24 @@ class EventProcessor:
                     # Fail fast if read-only - https://stackoverflow.com/a/44707371/434217
                     db.conn.execute("pragma user_version=0;")
 
+                    # Look up parameter values before ensure_run(), to get the
+                    # values set for new runs if appropriate.
+                    params = db.get_parameters()
+                    param_values = db.get_parameter_values(proposal, run, params)
+
                     db.ensure_run(proposal, run, record.timestamp / 1000)
                     log.info(f"Added p%d r%d ({run_data.value} data) to database", proposal, run)
 
                     # Set the default to the stable DAMNIT module if not already set
                     damnit_python = db.metameta.setdefault("damnit_python", DEFAULT_DAMNIT_PYTHON)
                     submitter = ExtractionSubmitter(db.path.parent, db)
-                    req = ExtractionRequest(run, proposal, run_data, sandbox_args, damnit_python)
+                    req = ExtractionRequest(
+                        run, proposal,
+                        run_data=run_data,
+                        sandbox_args=sandbox_args,
+                        damnit_python=damnit_python,
+                        params=param_values,
+                    )
 
                 try:
                     submitter.submit(req)

--- a/damnit/backend/user_variables.py
+++ b/damnit/backend/user_variables.py
@@ -1,4 +1,4 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Optional
 
 
@@ -104,7 +104,7 @@ class UserEditableVariable:
     title: str  # Human friendly title: 'XGM intensity (μJ)
     variable_type: str   # e.g. 'integer', 'string' - see above
     description: Optional[str] = ""
-    attributes: Optional[str] = ""
+    attributes: dict = field(default_factory=dict)
 
     def get_type_class(self):
         return value_types_by_name[self.variable_type]

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -361,6 +361,10 @@ class ReprocessSubcmd(Subcommand):
             help="String to match against variable titles (case-insensitive). Not a regex, simply `str in var.title`."
         )
         parser.add_argument(
+            '--param', type=str, action="append", default=[],
+            help="Parameter to set for reprocessing, e.g. threshold=2.2 or normalise=true"
+        )
+        parser.add_argument(
             '--watch', action='store_true',
             help="Run jobs one-by-one with live output in the terminal"
         )
@@ -394,7 +398,13 @@ class ReprocessSubcmd(Subcommand):
 
         from .backend.extraction_control import reprocess
         reprocess(
-            args.run, args.proposal, args.match, args.mock, args.watch, args.direct,
+            runs=args.run,
+            proposal=args.proposal,
+            match=args.match,
+            params=args.param,
+            mock=args.mock,
+            watch=args.watch,
+            direct=args.direct,
             limit_running=args.concurrent_jobs,
         )
 

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -550,6 +550,9 @@ class ContextFile:
         # Add back any dependencies of the selected variables
         new_vars.update({name: self.vars[name] for name in self.all_dependencies(*new_vars.values())})
 
+        # Add back any parameters
+        new_vars.update(self.params)
+
         return ContextFile(new_vars, self.code)
 
     def execute(self, run_data, run_number, proposal, *, param_values, label="") -> 'Results':
@@ -663,7 +666,7 @@ class ContextFile:
             if var.transient:
                 errors.pop(name, None)
 
-        return Results(res, errors, param_values, self)
+        return Results(res, errors, param_values=param_values, ctx=self)
 
 
 def get_start_time(xd_run):
@@ -754,7 +757,10 @@ class Results:
 
     def save(self, damnit_dir: Path, proposal: int, run: int):
         return save_fragment(
-            damnit_dir, proposal, run, self.cells, self.errors, self.param_values,
+            damnit_dir, proposal, run,
+            vars=self.cells,
+            errors=self.errors,
+            param_values=self.param_values,
             provenance="context.py"
         )
 

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -422,6 +422,27 @@ class ContextFile:
         if problems:
             raise ContextFileErrors(problems)
 
+    def prepare_param_values(self, cli_params: list[str]) -> dict:
+        res = {}
+        for p in cli_params:
+            name, eq, value_s = p.partition("=")
+            if not eq:
+                raise ValueError(f"Malformed parameter specification {p!r}")
+            if (param_spec := self.params.get(name)) is None:
+                raise KeyError(f"No parameter named {name!r} in context file")
+
+            t = param_spec.type_
+            if t is str:
+                res[name] = value_s
+            elif (t is int) or (t is float):
+                res[name] = t(value_s)
+            elif t is bool:
+                res[name] = (value_s.lower() == 'true')
+            else:
+                TypeError(f"Unexpected type {t} for parameter {name}")
+
+        return res
+
     def direct_dependencies(self, variable: Variable) -> set[str]:
         """return a set of names of direct dependencies of the passed Variable
         """
@@ -522,14 +543,18 @@ class ContextFile:
 
         return ContextFile(new_vars, self.code)
 
-    def execute(self, run_data, run_number, proposal, input_vars, *, label="") -> 'Results':
+    def execute(self, run_data, run_number, proposal, *, param_values, label="") -> 'Results':
         label = f"[{label}] " if label and label != 'default' else ""
-        dep_results = {'start_time': 
+        dep_results = {'start_time':
             get_start_time(run_data) if isinstance(run_data, extra_data.DataCollection) else time.time()
         }
         res = {'start_time': Cell(dep_results['start_time'])}
         errors = {}
         metadata = None
+
+        for name, param in self.params.items():
+            if param.default is not None:
+                param_values.setdefault(name, param.default)
 
         for name in self.ordered_vars():
             t0 = time.perf_counter()
@@ -538,7 +563,7 @@ class ContextFile:
             try:
                 kwargs = {}
                 missing_deps = []
-                missing_input = []
+                missing_params = []
 
                 annotations = var.annotations()
                 for arg_name, param in inspect.signature(var.func).parameters.items():
@@ -561,12 +586,12 @@ class ContextFile:
                             missing_deps.extend(fnmatch.filter(self.vars, dep_name))
 
                     # Input variable passed from outside
-                    elif annotation.startswith("input#"):
-                        inp_name = annotation.removeprefix("input#")
-                        if inp_name in input_vars:
-                            kwargs[arg_name] = input_vars[inp_name]
+                    elif annotation.startswith("param#"):
+                        param_name = annotation.removeprefix("param#")
+                        if param_name in param_values:
+                            kwargs[arg_name] = param_values[param_name]
                         elif param.default is inspect.Parameter.empty:
-                            missing_input.append(inp_name)
+                            missing_params.append(param_name)
 
                     # Mymdc fields
                     elif annotation.startswith("mymdc#"):
@@ -597,10 +622,10 @@ class ContextFile:
                         deps = [f"{os.linesep}- '{d}'" for d in missing_deps]
                         errors[name] = Skip(f"Dependencies returned no data:{''.join(deps)}")
                     continue
-                elif missing_input:
+                elif missing_params:
                     log.warning(
-                        "%sSkipping %s because of missing input variables: %s",
-                        label, name, ", ".join(missing_input)
+                        "%sSkipping %s because of missing parameter values: %s",
+                        label, name, ", ".join(missing_params)
                     )
                     continue
 
@@ -757,6 +782,7 @@ def main(argv=None):
     exec_ap.add_argument('--cluster-job', action="store_true")
     exec_ap.add_argument('--match', action="append", default=[])
     exec_ap.add_argument('--var', action="append", default=[])
+    exec_ap.add_argument('--param', action="append", default=[])
     exec_ap.add_argument('--record-output', type=Path)
 
     ctx_ap = subparsers.add_parser("ctx", help="Evaluate context file and pickle it to a file")
@@ -775,6 +801,7 @@ def main(argv=None):
             run_number=args.run,
             name="default"
         )
+        param_values = pipe_whole._context.prepare_param_values(args.param)
 
         sel = pipe_whole.select(
             run_data=RunData(args.run_data),
@@ -789,7 +816,7 @@ def main(argv=None):
         if args.mock:
             res = sel.execute(data=mock_run())
         else:
-            res = sel.execute()
+            res = sel.execute(param_values=param_values)
 
         frag_path = res.save(Path.cwd(), args.proposal, args.run)
         if args.record_output:

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -511,6 +511,15 @@ class ContextFile:
             }
             for (name, v) in self.vars.items()
             if not v.transient or inc_transient
+        } | {
+            name: {
+                'title': p.title,
+                'description': p.description,
+                'tags': p.tags,
+                'attributes': {'param_default': p.default},
+                'type': p.type_name(),
+            }
+            for (name, p) in self.params.items()
         }
 
     def filter(self, run_data=RunData.ALL, cluster=None, name_matches=(), variables=()):
@@ -654,7 +663,7 @@ class ContextFile:
             if var.transient:
                 errors.pop(name, None)
 
-        return Results(res, errors, self)
+        return Results(res, errors, param_values, self)
 
 
 def get_start_time(xd_run):
@@ -737,14 +746,16 @@ def add_to_h5_file(path) -> h5py.File:
 
 
 class Results:
-    def __init__(self, cells, errors, ctx):
+    def __init__(self, cells, errors, param_values, ctx):
         self.cells = cells
         self.errors = errors
+        self.param_values = param_values
         self.ctx = ctx
 
     def save(self, damnit_dir: Path, proposal: int, run: int):
         return save_fragment(
-            damnit_dir, proposal, run, self.cells, self.errors, provenance="context.py"
+            damnit_dir, proposal, run, self.cells, self.errors, self.param_values,
+            provenance="context.py"
         )
 
 

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -33,6 +33,7 @@ from damnit_ctx import (
     Cell,
     GroupBoundVariable,
     GroupError,
+    Parameter,
     Pipeline,
     RunData,
     Skip,
@@ -342,6 +343,7 @@ def build_context_from_code(code, path):
         exec(codeobj, context)
 
     vars_by_name = {v.name: v for v in context.values() if isinstance(v, Variable)}
+    vars_by_name |= {n: p for (n, p) in context.items() if isinstance(p, Parameter)}
 
     if state is None or not state.used:
         return _build_context_file(
@@ -360,8 +362,10 @@ def build_context_from_code(code, path):
 
 class ContextFile:
 
-    def __init__(self, vars, code):
-        self.vars = vars
+    def __init__(self, contents, code):
+        self.contents = contents
+        self.vars = {k: v for (k, v) in contents.items() if isinstance(v, Variable)}
+        self.params = {k: v for (k, v) in contents.items() if isinstance(v, Parameter)}
         self.code = code
 
         # Check for cycles

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -555,7 +555,7 @@ class ContextFile:
 
         return ContextFile(new_vars, self.code)
 
-    def execute(self, run_data, run_number, proposal, *, param_values, label="") -> 'Results':
+    def execute(self, run_data, run_number, proposal, param_values, *, label="") -> 'Results':
         label = f"[{label}] " if label and label != 'default' else ""
         dep_results = {'start_time':
             get_start_time(run_data) if isinstance(run_data, extra_data.DataCollection) else time.time()

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -879,4 +879,20 @@ class Parameter:
     type_: type
     default: Any = None
     title: str | None = None
-    help: str = ""
+    description: str = ""
+    tags: tuple[str] = ()
+
+    def __post_init__(self):
+        if self.type_ not in (str, int, float, bool):
+            raise ValueError("Parameter type should be str/int/float/bool")
+
+    def type_name(self):  # Naming scheme matching user-editable variables
+        if self.type_ is str:
+            return 'string'
+        elif self.type_ is int:
+            return 'integer'
+        elif self.type_ is float:
+            return 'number'
+        elif self.type_ is bool:
+            return 'boolean'
+        raise ValueError(f"Unexpected parameter type {self.type_}")

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -532,7 +532,7 @@ class Pipeline:
             *,
             name: str | None = None,
             data: Any | None = None,
-            input_vars: dict[str, Any] | None = None,
+            param_values: dict[str, Any] | None = None,
             _context: "ContextFile" = None,
     ):
         """Initialize a Pipeline.
@@ -542,14 +542,14 @@ class Pipeline:
             proposal: Proposal number for meta access or run opening.
             run_number: Run number for meta access or run opening.
             data: Object passed to Variable functions.
-            input_vars: dict for input# dependencies.
+            param_values: dict for param# dependencies.
             _context: Precompiled context (e.g. from Pipeline.from_str() or select()).
         """
         self._name = name
         self.proposal = proposal
         self.run_number = run_number
         self.data = data
-        self.input_vars = dict(input_vars or {})
+        self.param_values = dict(param_values or {})
         # Compiled ContextFile for this pipeline.
         self._context = _context
         # Results from the last execute() call, if any.
@@ -597,7 +597,7 @@ class Pipeline:
         if self._name is not None:
             return self._name
 
-        parts = list(self.input_vars) + [str(self.proposal), str(self.run_number)]
+        parts = list(self.param_values) + [str(self.proposal), str(self.run_number)]
         if self._context is not None:
             parts += list(self._context.vars)
         base = "|".join(parts)
@@ -609,7 +609,7 @@ class Pipeline:
             proposal=self.proposal,
             run_number=self.run_number,
             data=self.data,
-            input_vars=self.input_vars.copy(),
+            param_values=self.param_values.copy(),
             _context=self._context,
         )
         return clone
@@ -672,7 +672,7 @@ class Pipeline:
 
         Notes:
             - The returned Pipeline inherits context fields (proposal, run_number,
-              data, input_vars, name) from self.
+              data, param_values, name) from self.
             - The compiled context code is taken from self.
         """
         if not isinstance(other, Pipeline):
@@ -712,7 +712,7 @@ class Pipeline:
             proposal: int | None = None,
             run_number: int | None = None,
             data: Any | None = None,
-            input_vars: dict[str, Any] | None = None,
+            param_values: dict[str, Any] | None = None,
     ):
         """Return a new Pipeline with updated context fields."""
         new_pipe = self.copy()
@@ -724,8 +724,8 @@ class Pipeline:
             new_pipe.run_number = run_number
         if data is not None:
             new_pipe.data = data
-        if input_vars is not None:
-            new_pipe.input_vars = dict(input_vars)
+        if param_values is not None:
+            new_pipe.param_values = dict(param_values)
         return new_pipe
 
     def _normalize_run_data(self, value):
@@ -803,7 +803,7 @@ class Pipeline:
         new_pipe._context = filtered
         return new_pipe
 
-    def execute(self, *, data=None, input_vars=None):
+    def execute(self, *, data=None, param_values=None):
         """Execute the Pipeline and return Results.
 
         If ``data`` or ``self.data`` is provided, it is passed directly to
@@ -828,11 +828,11 @@ class Pipeline:
 
             data_obj = extra_data.open_run(self.proposal, self.run_number)
 
-        merged_input = dict(self.input_vars)
-        if input_vars is not None:
-            merged_input.update(dict(input_vars))
+        merged_params = dict(self.param_values)
+        if param_values is not None:
+            merged_params.update(dict(param_values))
         res = ctx.execute(
-            data_obj, self.run_number, self.proposal, merged_input,
+            data_obj, self.run_number, self.proposal, merged_params,
             label=self.name
         )
         self._last_results = res

--- a/damnit/ctxsupport/damnit_ctx.py
+++ b/damnit/ctxsupport/damnit_ctx.py
@@ -872,3 +872,11 @@ def pipeline_scope():
     finally:
         # Reset default pipeline state
         _DEFAULT_PIPELINE_STATE.reset(token)
+
+
+@dataclass()
+class Parameter:
+    type_: type
+    default: Any = None
+    title: str | None = None
+    help: str = ""

--- a/damnit/ctxsupport/damnit_writing.py
+++ b/damnit/ctxsupport/damnit_writing.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from enum import Enum
 from pathlib import Path
 from tempfile import mkstemp
+from typing import Any
 
 import h5py
 import numpy as np
@@ -232,6 +233,7 @@ class DamnitFileWriter:
         file.require_group('.reduced')  # Summaries
         file.require_group('.preview')
         file.require_group('.errors')
+        file.require_group('.parameters')
 
     def store_summary(self, name, obj, attrs):
         if isinstance(obj, PNGData):  # PNG thumbnail
@@ -288,9 +290,12 @@ class DamnitFileWriter:
         ds = self.file.create_dataset(f'.errors/{name}', data=str(exc))
         ds.attrs['type'] = type(exc).__name__
 
+    def store_parameter(self, name, value):
+        self.file[f'.errors/{name}'] = value
+
 
 def save_fragment(damnit_dir: Path, proposal: int, run: int, vars: dict[str, Cell],
-           errors: dict[str, Exception], provenance=""):
+           errors: dict[str, Exception], param_values: dict[str, Any], provenance=""):
     """Save one or more results into a fragment file, to be combined later"""
     results_dir = damnit_dir / "extracted_data"
     results_dir.mkdir(parents=True, exist_ok=True)
@@ -316,6 +321,9 @@ def save_fragment(damnit_dir: Path, proposal: int, run: int, vars: dict[str, Cel
 
         for name, exc in errors.items():
             writer.store_error(name, exc)
+
+        for name, val in param_values.items():
+            writer.store_parameter(name, exc)
 
     os.chmod(f.final_path, 0o666)
 

--- a/damnit/ctxsupport/damnit_writing.py
+++ b/damnit/ctxsupport/damnit_writing.py
@@ -291,7 +291,7 @@ class DamnitFileWriter:
         ds.attrs['type'] = type(exc).__name__
 
     def store_parameter(self, name, value):
-        self.file[f'.errors/{name}'] = value
+        self.file[f'.parameters/{name}'] = value
 
 
 def save_fragment(damnit_dir: Path, proposal: int, run: int, vars: dict[str, Cell],
@@ -323,7 +323,7 @@ def save_fragment(damnit_dir: Path, proposal: int, run: int, vars: dict[str, Cel
             writer.store_error(name, exc)
 
         for name, val in param_values.items():
-            writer.store_parameter(name, exc)
+            writer.store_parameter(name, val)
 
     os.chmod(f.final_path, 0o666)
 

--- a/damnit/definitions.py
+++ b/damnit/definitions.py
@@ -1,4 +1,5 @@
 import os
+from enum import StrEnum
 
 # Kafka for sending updates around
 if "AMORE_BROKER" in os.environ:
@@ -11,3 +12,8 @@ FILE_SUBMIT_TOPIC = "test.damnit.file_submissions"
 
 DEFAULT_CONTEXT_PYTHON = os.path.realpath("/gpfs/exfel/sw/software/euxfel-environment-management/current-python-env/bin/python")
 DEFAULT_DAMNIT_PYTHON = "/gpfs/exfel/sw/software/xfel_anaconda3/amore-mid/.pixi/envs/default/bin/python"
+
+# Attribute names
+class VariableAttributes(StrEnum):
+    PARAM_DEFAULT = "param_default"
+    PARAM_VALUE_NEW_RUN = "param_value_new_run"

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -1014,9 +1014,9 @@ da-dev@xfel.eu"""
                              self.table.computed_columns(by_title=True))
 
         dlg = ProcessingDialog(
-            str(prop), sel_runs,
+            prop, sel_runs,
             var_ids_titles=var_ids_titles,
-            parameters=self.db.get_parameters(),
+            db=self.db,
             parent=self,
         )
         if dlg.exec() == QtWidgets.QDialog.Accepted:

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -33,7 +33,7 @@ from .new_context_dialog import NewContextFileDialog
 from .open_dialog import OpenDBDialog
 from .plot import (ImagePlotWindow, PlottingControls, ScatterPlotWindow,
                    Xarray1DPlotWindow)
-from .process import ProcessingDialog
+from .process import ProcessingDialog, ParamsNewRunsDialog
 from .standalone_comments import TimeComment
 from .table import DamnitTableModel, TableView, prettify_notation
 from .theme import Theme, ThemeManager, set_lexer_theme
@@ -192,6 +192,10 @@ class MainWindow(QtWidgets.QMainWindow):
 
     def _menu_create_user_var(self) -> None:
         dialog = AddUserVariableDialog(self)
+        dialog.exec()
+
+    def _menu_edit_params_new_runs(self) -> None:
+        dialog = ParamsNewRunsDialog(self.db, self)
         dialog.exec()
 
     def _menu_bar_help(self) -> None:
@@ -415,6 +419,11 @@ da-dev@xfel.eu"""
         self.action_create_var.setEnabled(False)
         self.context_dir_changed.connect(lambda _: self.action_create_var.setEnabled(True))
 
+        self.action_params_new_runs = QtWidgets.QAction("Edit parameters for new runs", self)
+        self.action_params_new_runs.triggered.connect(self._menu_edit_params_new_runs)
+        self.action_params_new_runs.setEnabled(False)
+        self.context_dir_changed.connect(lambda _: self.action_params_new_runs.setEnabled(True))
+
         self.action_export = QtWidgets.QAction(QtGui.QIcon(icon_path("export.png")), "&Export", self)
         self.action_export.setStatusTip("Export to Excel/CSV")
         self.action_export.setEnabled(False)
@@ -442,6 +451,7 @@ da-dev@xfel.eu"""
         )
         fileMenu.addAction(action_autoconfigure)
         fileMenu.addAction(self.action_create_var)
+        fileMenu.addAction(self.action_params_new_runs)
         fileMenu.addAction(self.action_process)
         fileMenu.addAction(self.action_export)
         fileMenu.addAction(action_adeqt)

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -1003,7 +1003,12 @@ da-dev@xfel.eu"""
         var_ids_titles = zip(self.table.computed_columns(),
                              self.table.computed_columns(by_title=True))
 
-        dlg = ProcessingDialog(str(prop), sel_runs, var_ids_titles, parent=self)
+        dlg = ProcessingDialog(
+            str(prop), sel_runs,
+            var_ids_titles=var_ids_titles,
+            parameters=self.db.get_parameters(),
+            parent=self,
+        )
         if dlg.exec() == QtWidgets.QDialog.Accepted:
             submitter = ExtractionSubmitter(self.context_dir, self.db)
 
@@ -1029,7 +1034,11 @@ da-dev@xfel.eu"""
     def show_adeqt(self):
         from adeqt import AdeqtWindow
         if self.adeqt_window is None:
-            ns = {'window': self, 'table': self.table, 'editor': self._editor}
+            ns = {'window': self,
+                  'table': self.table,
+                  'editor': self._editor,
+                  'db': self.db,
+            }
             self.adeqt_window = AdeqtWindow(ns, parent=self)
         self.adeqt_window.show()
 

--- a/damnit/gui/process.py
+++ b/damnit/gui/process.py
@@ -9,8 +9,10 @@ from PyQt5.QtWidgets import QDialogButtonBox
 from extra_data.read_machinery import find_proposal
 from superqt import QSearchableListWidget
 
+from damnit.backend.db import DamnitDB
 from ..context import RunData
 from ..backend.extraction_control import ExtractionRequest
+from ..definitions import VariableAttributes
 
 log = logging.getLogger(__name__)
 
@@ -226,39 +228,51 @@ class ParametersFormLayout(QtWidgets.QFormLayout):
     def __init__(self, parameters: dict, values, parent=None):
         super().__init__(parent)
         self.widgets_by_name = {}
+        self.initial_values = {}
         for name, param in parameters.items():
             value = values.get(name)
+            if value is None:
+                value = param.attributes[VariableAttributes.PARAM_DEFAULT]
+            self.initial_values[name] = value
             w = self.widgets_by_name[name] = self.widget_for(param, value)
             self.addRow(param.title or name, w)
 
-    @staticmethod
-    def widget_for(param, value=None):
-        if value is None:
-            value = param.attributes['param_default']
+    def widget_for(self, param, value=None):
         match param.variable_type:
             case 'integer':
                 w = QtWidgets.QSpinBox()
+                changed_sig = w.valueChanged
                 if value is not None:
                     w.setValue(value)
             case 'number':
                 w = QtWidgets.QDoubleSpinBox()
+                changed_sig = w.valueChanged
                 if value is not None:
                     w.setValue(value)
             case 'string':
                 w = QtWidgets.QLineEdit()
+                changed_sig = w.textChanged
                 if value is not None:
                     w.setText(value)
             case 'boolean':
                 w = QtWidgets.QCheckBox()
+                changed_sig = w.stateChanged
                 w.setCheckState(
                     Qt.CheckState.Checked if value else Qt.CheckState.Unchecked
                 )
             case x:
                 raise ValueError(f"Unexpected parameter type {x!r}")
 
+        changed_sig.connect(self.mark_changed)
         if param.description:
             w.setToolTip(param.description)
         return w
+
+    def mark_changed(self):
+        for name, widget in self.widgets_by_name.items():
+            label = self.labelForField(widget)
+            changed = self.get_value(name) != self.initial_values[name]
+            label.setStyleSheet("QLabel {font-weight: bold}" if changed else "")
 
     def get_value(self, name):
         w = self.widgets_by_name[name]
@@ -273,6 +287,48 @@ class ParametersFormLayout(QtWidgets.QFormLayout):
 
     def get_values(self):
         return {n: self.get_value(n) for n in self.widgets_by_name}
+
+    def get_modified_values(self):
+        return {n: v for (n, v) in self.get_values().items()
+                if v != self.initial_values[n]}
+
+
+class ParamsNewRunsDialog(QtWidgets.QDialog):
+    def __init__(self, db: DamnitDB, parent=None):
+        self.db = db
+        super().__init__(parent)
+
+        self.setWindowTitle("Parameters for new runs")
+        self.setMinimumSize(200, 200)
+        vbox = QtWidgets.QVBoxLayout()
+        self.setLayout(vbox)
+
+        params_dict = db.get_parameters()
+        values = {
+            n: v for (n, p) in params_dict.items()
+            if (v := p.attributes.get(VariableAttributes.PARAM_VALUE_NEW_RUN)) is not None
+        }
+        self.form = ParametersFormLayout(params_dict, values)
+        vbox.addLayout(self.form)
+
+        info = QtWidgets.QLabel(
+            "The values here will be used for new runs."
+            "They will not affect reprocessing runs already in DAMNIT."
+        )
+        info.setWordWrap(True)
+        vbox.addWidget(info)
+
+        dlg_buttons = QDialogButtonBox(QDialogButtonBox.Save | QDialogButtonBox.Cancel)
+        dlg_buttons.accepted.connect(self.accept)
+        dlg_buttons.rejected.connect(self.reject)
+        vbox.addWidget(dlg_buttons)
+
+    def accept(self):
+        self.db.update_variables_attrs({
+            n: {VariableAttributes.PARAM_VALUE_NEW_RUN: v}
+            for (n, v) in self.form.get_modified_values().items()
+        })
+        super().accept()
 
 
 

--- a/damnit/gui/process.py
+++ b/damnit/gui/process.py
@@ -77,7 +77,8 @@ class ProcessingDialog(QtWidgets.QDialog):
     all_vars_selected = False
     no_vars_selected = False
 
-    def __init__(self, proposal: str, runs: list[int], var_ids_titles, parent=None):
+    def __init__(self, proposal: str, runs: list[int], var_ids_titles,
+                 parameters=None, param_values=None, parent=None):
         super().__init__(parent)
 
         self.setWindowTitle("Process runs")
@@ -92,6 +93,12 @@ class ProcessingDialog(QtWidgets.QDialog):
         hbox1.addLayout(grid1)
         vbox2 = QtWidgets.QVBoxLayout()
         hbox1.addLayout(vbox2)
+        if parameters:
+            params_grp = QtWidgets.QGroupBox("Parameters", self)
+            params_grp.setLayout(
+                ParametersFormLayout(parameters, (param_values or {}))
+            )
+            hbox1.addWidget(params_grp)
 
         self.edit_prop = QtWidgets.QLineEdit(proposal)
         #self.edit_prop.setInputMask('999900;_')  # 4-6 digits
@@ -213,6 +220,59 @@ class ProcessingDialog(QtWidgets.QDialog):
         for req in l[1:]:
             req.update_vars = False
         return l
+
+
+class ParametersFormLayout(QtWidgets.QFormLayout):
+    def __init__(self, parameters: dict, values, parent=None):
+        super().__init__(parent)
+        self.widgets_by_name = {}
+        for name, param in parameters.items():
+            value = values.get(name)
+            w = self.widgets_by_name[name] = self.widget_for(param, value)
+            self.addRow(param.title or name, w)
+
+    @staticmethod
+    def widget_for(param, value=None):
+        if value is None:
+            value = param.attributes['param_default']
+        match param.variable_type:
+            case 'integer':
+                w = QtWidgets.QSpinBox()
+                if value is not None:
+                    w.setValue(value)
+            case 'number':
+                w = QtWidgets.QDoubleSpinBox()
+                if value is not None:
+                    w.setValue(value)
+            case 'string':
+                w = QtWidgets.QLineEdit()
+                if value is not None:
+                    w.setText(value)
+            case 'boolean':
+                w = QtWidgets.QCheckBox()
+                w.setCheckState(
+                    Qt.CheckState.Checked if value else Qt.CheckState.Unchecked
+                )
+            case x:
+                raise ValueError(f"Unexpected parameter type {x!r}")
+
+        if param.description:
+            w.setToolTip(param.description)
+        return w
+
+    def get_value(self, name):
+        w = self.widgets_by_name[name]
+        if isinstance(w, (QtWidgets.QSpinBox, QtWidgets.QDoubleSpinBox)):
+            return w.value()
+        elif isinstance(w, QtWidgets.QLineEdit):
+            return w.text()
+        elif isinstance(w, QtWidgets.QCheckBox):
+            return w.checkState() == Qt.CheckState.Checked
+        else:
+            raise ValueError(f"Unexpected widget type {w!r}")
+
+    def get_values(self):
+        return {n: self.get_value(n) for n in self.widgets_by_name}
 
 
 

--- a/damnit/gui/process.py
+++ b/damnit/gui/process.py
@@ -2,6 +2,7 @@ import logging
 import re
 from pathlib import Path
 
+import numpy as np
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QDialogButtonBox
@@ -19,6 +20,9 @@ log = logging.getLogger(__name__)
 run_range_re = re.compile(r"(\d+)(-\d+)?$")
 
 RUNS_MSG = "Enter run numbers & ranges e.g. '17, 20-32'"
+
+INT_MIN = -2147483648
+
 
 deselected_vars = set()
 
@@ -79,8 +83,9 @@ class ProcessingDialog(QtWidgets.QDialog):
     all_vars_selected = False
     no_vars_selected = False
 
-    def __init__(self, proposal: str, runs: list[int], var_ids_titles,
-                 parameters=None, param_values=None, parent=None):
+    def __init__(self, proposal: int, runs: list[int], var_ids_titles,
+                 db: DamnitDB, parent=None):
+        self.db = db
         super().__init__(parent)
 
         self.setWindowTitle("Process runs")
@@ -95,15 +100,18 @@ class ProcessingDialog(QtWidgets.QDialog):
         hbox1.addLayout(grid1)
         vbox2 = QtWidgets.QVBoxLayout()
         hbox1.addLayout(vbox2)
-        if parameters:
-            params_grp = QtWidgets.QGroupBox("Parameters", self)
-            params_grp.setLayout(
-                ParametersFormLayout(parameters, (param_values or {}))
-            )
-            hbox1.addWidget(params_grp)
+        self.parameters = db.get_parameters()
+        self.params_form = None
+        if self.parameters:
+            self.params_box = QtWidgets.QGroupBox("Parameters", self)
+            self.params_box.setLayout(QtWidgets.QVBoxLayout())
+            hbox1.addWidget(self.params_box)
+        else:
+            self.params_box = None
 
-        self.edit_prop = QtWidgets.QLineEdit(proposal)
+        self.edit_prop = QtWidgets.QLineEdit(str(proposal))
         #self.edit_prop.setInputMask('999900;_')  # 4-6 digits
+        self.edit_prop.textChanged.connect(self.validate_runs)
         grid1.addWidget(QtWidgets.QLabel("Proposal:"), 0, 0)
         grid1.addWidget(self.edit_prop, 0, 1)
 
@@ -159,6 +167,7 @@ class ProcessingDialog(QtWidgets.QDialog):
             self.runs_hint.setText(msg)
         else:
             self.runs_hint.setText(RUNS_MSG)
+        self.set_params_form()
         self.validate()
 
     def validate_vars(self):
@@ -172,6 +181,26 @@ class ProcessingDialog(QtWidgets.QDialog):
     def validate(self):
         valid = bool(self.selected_runs) and not self.no_vars_selected
         self.dlg_buttons.button(QDialogButtonBox.Ok).setEnabled(valid)
+
+    def set_params_form(self):
+        if self.params_box is None:
+            return
+
+        param_value_sets = self.db.get_parameter_values([
+            (self.proposal_num(), r) for r in self.selected_runs
+        ])
+        # Use ... as a marker for varying
+        param_values = {
+            n: s.pop() if len(s) == 1 else ... for (n, s) in param_value_sets.items()
+        }
+        param_layout = self.params_box.layout()
+        while (child := param_layout.takeAt(0)) is not None:
+            if w := child.widget():
+                w.deleteLater()
+
+        new_form = ParametersForm(self.parameters, param_values, parent=self)
+        param_layout.addWidget(new_form)
+        self.params_form = new_form
 
     def _var_list_items(self):
         for i in range(self.vars_list.count()):
@@ -202,15 +231,15 @@ class ProcessingDialog(QtWidgets.QDialog):
         super().reject()
 
     # Results (along with .selected_runs)
-    def proposal_num(self) -> str:
-        return self.edit_prop.text()
+    def proposal_num(self) -> int:
+        return int(self.edit_prop.text())
 
     def selected_vars(self):
         return [itm.data(Qt.UserRole) for itm in self._var_list_items()
                 if itm.checkState() == Qt.Checked]
 
     def extraction_requests(self) -> list[ExtractionRequest]:
-        prop = int(self.proposal_num())
+        prop = self.proposal_num()
         # If all variables are selected, don't specify them explicitly, so that
         # newly added functions will also be executed.
         if self.all_vars_selected:
@@ -224,9 +253,11 @@ class ProcessingDialog(QtWidgets.QDialog):
         return l
 
 
-class ParametersFormLayout(QtWidgets.QFormLayout):
+class ParametersForm(QtWidgets.QWidget):
     def __init__(self, parameters: dict, values, parent=None):
         super().__init__(parent)
+        form_layout = QtWidgets.QFormLayout()
+        self.setLayout(form_layout)
         self.widgets_by_name = {}
         self.initial_values = {}
         for name, param in parameters.items():
@@ -235,31 +266,45 @@ class ParametersFormLayout(QtWidgets.QFormLayout):
                 value = param.attributes[VariableAttributes.PARAM_DEFAULT]
             self.initial_values[name] = value
             w = self.widgets_by_name[name] = self.widget_for(param, value)
-            self.addRow(param.title or name, w)
+            form_layout.addRow(param.title or name, w)
 
     def widget_for(self, param, value=None):
         match param.variable_type:
             case 'integer':
                 w = QtWidgets.QSpinBox()
+                w.setMinimum(INT_MIN)
                 changed_sig = w.valueChanged
-                if value is not None:
-                    w.setValue(value)
+                if value is ...:
+                    w.setSpecialValueText("Multiple values")
+                    w.setValue(INT_MIN)  # Special value
+                else:
+                    w.setValue(value or 0)
             case 'number':
                 w = QtWidgets.QDoubleSpinBox()
+                w.setMinimum(-np.inf)
                 changed_sig = w.valueChanged
-                if value is not None:
-                    w.setValue(value)
+                if value is ...:
+                    w.setSpecialValueText("Multiple values")
+                    w.setValue(-np.inf)  # Special value
+                else:
+                    w.setValue(value or 0.)
             case 'string':
                 w = QtWidgets.QLineEdit()
                 changed_sig = w.textChanged
-                if value is not None:
-                    w.setText(value)
+                if value is ...:
+                    w.setPlaceholderText("Multiple values")
+                else:
+                    w.setText(value or '')
             case 'boolean':
                 w = QtWidgets.QCheckBox()
                 changed_sig = w.stateChanged
-                w.setCheckState(
-                    Qt.CheckState.Checked if value else Qt.CheckState.Unchecked
-                )
+                if value is ...:
+                    w.setTristate(True)
+                    w.setCheckState(Qt.CheckState.PartiallyChecked)
+                else:
+                    w.setCheckState(
+                        Qt.CheckState.Checked if value else Qt.CheckState.Unchecked
+                    )
             case x:
                 raise ValueError(f"Unexpected parameter type {x!r}")
 
@@ -269,19 +314,28 @@ class ParametersFormLayout(QtWidgets.QFormLayout):
         return w
 
     def mark_changed(self):
+        layout = self.layout()
         for name, widget in self.widgets_by_name.items():
-            label = self.labelForField(widget)
+            label = layout.labelForField(widget)
             changed = self.get_value(name) != self.initial_values[name]
             label.setStyleSheet("QLabel {font-weight: bold}" if changed else "")
 
     def get_value(self, name):
         w = self.widgets_by_name[name]
         if isinstance(w, (QtWidgets.QSpinBox, QtWidgets.QDoubleSpinBox)):
-            return w.value()
+            val = w.value()
+            if w.specialValueText() and val == w.minimum():
+                return ...
+            return val
         elif isinstance(w, QtWidgets.QLineEdit):
-            return w.text()
+            val = w.text()
+            if (not val) and w.placeholderText():
+                return ...
         elif isinstance(w, QtWidgets.QCheckBox):
-            return w.checkState() == Qt.CheckState.Checked
+            state = w.checkState()
+            if state == Qt.CheckState.PartiallyChecked:
+                return ...
+            return state == Qt.CheckState.Checked
         else:
             raise ValueError(f"Unexpected widget type {w!r}")
 
@@ -308,8 +362,8 @@ class ParamsNewRunsDialog(QtWidgets.QDialog):
             n: v for (n, p) in params_dict.items()
             if (v := p.attributes.get(VariableAttributes.PARAM_VALUE_NEW_RUN)) is not None
         }
-        self.form = ParametersFormLayout(params_dict, values)
-        vbox.addLayout(self.form)
+        self.form = ParametersForm(params_dict, values)
+        vbox.addWidget(self.form)
 
         info = QtWidgets.QLabel(
             "The values here will be used for new runs."

--- a/damnit/gui/process.py
+++ b/damnit/gui/process.py
@@ -186,10 +186,13 @@ class ProcessingDialog(QtWidgets.QDialog):
         if self.params_box is None:
             return
 
-        param_value_sets = self.db.get_parameter_values([
-            (self.proposal_num(), r) for r in self.selected_runs
-        ])
-        # Use ... as a marker for varying
+        prop = self.proposal_num()
+        param_value_sets = {n: set() for n in self.parameters}
+        for run in self.selected_runs:
+            run_params = self.db.get_parameter_values(prop, run, self.parameters)
+            for k, v in run_params.items():
+                param_value_sets[k].add(v)
+        # Use ... as a marker for varying values
         param_values = {
             n: s.pop() if len(s) == 1 else ... for (n, s) in param_value_sets.items()
         }
@@ -246,10 +249,21 @@ class ProcessingDialog(QtWidgets.QDialog):
             var_ids = ()
         else:
             var_ids = tuple(self.selected_vars())
-        l = [ExtractionRequest(r, prop, RunData.ALL, variables=var_ids)
-             for r in self.selected_runs]
-        for req in l[1:]:
-            req.update_vars = False
+        if self.params_form:
+            set_params = self.params_form.get_modified_values()
+        else:
+            set_params = {}
+
+        l = [ExtractionRequest(
+            r,
+            prop,
+            RunData.ALL,
+            variables=var_ids,
+            params=self.db.get_parameter_values(prop, r, self.parameters) | set_params,
+            update_vars=False,
+        ) for r in self.selected_runs]
+        if l:
+            l[0].update_vars = True
         return l
 
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -5,8 +5,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -118,8 +116,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -197,8 +193,6 @@ environments:
     - url: https://conda.anaconda.org/conda-forge/
     indexes:
     - https://pypi.org/simple
-    options:
-      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -529,6 +523,7 @@ packages:
   - pytest-venv ; extra == 'test'
   - testpath ; extra == 'test'
   requires_python: '>=3.10'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4e/8c/f3147f5c4b73e7550fe5f9352eaa956ae838d5c51eb58e7a25b9f3e2643b/decorator-5.2.1-py3-none-any.whl
   name: decorator
   version: 5.2.1

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -274,12 +274,12 @@ def test_context_file(mock_ctx, tmp_path):
         mkcontext(invalid_var_data)
 
 
-def run_ctx_helper(context, run, run_number, proposal, caplog, input_vars=None):
+def run_ctx_helper(context, run, run_number, proposal, caplog, param_values=None):
     # Track all error messages during creation. This is necessary because a
     # variable that throws an error will be logged by Results, the exception
     # will not bubble up.
     with caplog.at_level(logging.ERROR):
-        results = context.execute(run, run_number, proposal, input_vars or {})
+        results = context.execute(run, run_number, proposal, param_values or {})
 
     # Check that there were no errors
     assert caplog.records == []
@@ -648,26 +648,25 @@ def test_results_empty_array(mock_run, tmp_path, caplog):
         assert caplog.records[0].msg.startswith("Failed to produce summary data")
 
 
-@pytest.mark.skip(reason="Depending on user variables is currently disabled")
-def test_results_with_user_vars(mock_ctx_user, mock_user_vars, mock_run, caplog):
+def test_results_with_params(mock_ctx_user, mock_user_vars, mock_run, caplog):
 
     proposal = 1234
     run_number = 1000
 
-    user_var_values = {
+    param_values = {
         "user_integer": 12,
         "user_number": 10.2,
         "user_boolean": True,
         "user_string": "foo"
     }
 
-    results = run_ctx_helper(mock_ctx_user, mock_run, run_number, proposal, caplog, input_vars=user_var_values)
+    results = run_ctx_helper(mock_ctx_user, mock_run, run_number, proposal, caplog, param_values=param_values)
 
     # Tests if computations that depends on user variable return the correct results
-    assert results.cells["dep_integer"].data == user_var_values["user_integer"] + 1
-    assert results.cells["dep_number"].data == user_var_values["user_number"]
+    assert results.cells["dep_integer"].data == param_values["user_integer"] + 1
+    assert results.cells["dep_number"].data == param_values["user_number"]
     assert results.cells["dep_boolean"].data == False
-    assert results.cells["dep_string"].data == user_var_values["user_string"] * 2
+    assert results.cells["dep_string"].data == param_values["user_string"] * 2
 
 def test_results_preview(mock_run, tmp_path):
     ctx_code = """

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -3,7 +3,7 @@ from graphlib import CycleError
 import pytest
 
 from damnit.context import GroupError
-from damnit.ctxsupport.ctxrunner import expand_groups
+from damnit.ctxsupport.ctxrunner import find_vars_params
 from damnit.ctxsupport.damnit_ctx import (Group, GroupBoundVariable, Variable,
                                           is_group_instance)
 
@@ -38,7 +38,7 @@ def test_group_variable_reference():
     # group names aren't assigned yet
     assert group2.grp_ref.name is None
     
-    expand_groups({"group1": group1, "group2": group2,}, {"var": var})
+    find_vars_params({"var": var, "group1": group1, "group2": group2,})
 
     # now group names are assigned from context
     assert group2.grp_ref.grp_var.name == "group1.grp_var"
@@ -318,6 +318,10 @@ def test_group_nested_variable_field_chain(mock_run):
     outer = Outer(name="outer", mid=mid, factor=2)
     """
     ctx = mkcontext(code)
+    assert list(ctx.vars) == [  # In order of appearance
+        "base", "leaf.scaled", "mid.total", "outer.final", "outer.extra"
+    ]
+
     results = ctx.execute(mock_run, 1000, 123, {})
     assert results.cells["base"].data == 5
     assert results.cells["leaf.scaled"].data == 10

--- a/tests/test_ctx_groups.py
+++ b/tests/test_ctx_groups.py
@@ -3,7 +3,7 @@ from graphlib import CycleError
 import pytest
 
 from damnit.context import GroupError
-from damnit.ctxsupport.ctxrunner import find_vars_params
+from damnit.ctxsupport.ctxrunner import expand_groups
 from damnit.ctxsupport.damnit_ctx import (Group, GroupBoundVariable, Variable,
                                           is_group_instance)
 
@@ -38,7 +38,7 @@ def test_group_variable_reference():
     # group names aren't assigned yet
     assert group2.grp_ref.name is None
     
-    find_vars_params({"var": var, "group1": group1, "group2": group2,})
+    expand_groups({"group1": group1, "group2": group2,}, {"var": var})
 
     # now group names are assigned from context
     assert group2.grp_ref.grp_var.name == "group1.grp_var"
@@ -318,10 +318,6 @@ def test_group_nested_variable_field_chain(mock_run):
     outer = Outer(name="outer", mid=mid, factor=2)
     """
     ctx = mkcontext(code)
-    assert list(ctx.vars) == [  # In order of appearance
-        "base", "leaf.scaled", "mid.total", "outer.final", "outer.extra"
-    ]
-
     results = ctx.execute(mock_run, 1000, 123, {})
     assert results.cells["base"].data == 5
     assert results.cells["leaf.scaled"].data == 10

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -345,20 +345,20 @@ def test_pipeline_build_context_rejects_duplicate_group_names():
 
 
 def test_pipeline_with_context_updates():
-    input_vars = {"x": 1}
+    param_values = {"x": 1}
     data_obj = object()
-    pipe = Pipeline(name="a", proposal=1, run_number=2, data=data_obj, input_vars=input_vars)
-    new_pipe = pipe.with_context(name="b", proposal=3, input_vars={"y": 2})
+    pipe = Pipeline(name="a", proposal=1, run_number=2, data=data_obj, param_values=param_values)
+    new_pipe = pipe.with_context(name="b", proposal=3, param_values={"y": 2})
 
-    assert (pipe.name, pipe.proposal, pipe.run_number, pipe.data, pipe.input_vars) == (
+    assert (pipe.name, pipe.proposal, pipe.run_number, pipe.data, pipe.param_values) == (
         "a", 1, 2, data_obj, {"x": 1}
     )
-    assert (new_pipe.name, new_pipe.proposal, new_pipe.run_number, new_pipe.data, new_pipe.input_vars) == (
+    assert (new_pipe.name, new_pipe.proposal, new_pipe.run_number, new_pipe.data, new_pipe.param_values) == (
         "b", 3, 2, data_obj, {"y": 2}
     )
 
-    input_vars["x"] = 999
-    assert pipe.input_vars == {"x": 1}
+    param_values["x"] = 999
+    assert pipe.param_values == {"x": 1}
 
 
 def test_pipeline_select_filters():
@@ -442,18 +442,18 @@ def test_pipeline_execute(mock_run):
         from damnit_ctx import Variable
 
         @Variable
-        def val(run, x: "input#x"):
+        def val(run, x: "param#x"):
             return x
     """)
     pipe = Pipeline.from_str(code).with_context(
         data=mock_run,
         proposal=1,
         run_number=1,
-        input_vars={"x": 1},
+        param_values={"x": 1},
     )
 
     assert pipe.results is None
-    res = pipe.execute(input_vars={"x": 2})
+    res = pipe.execute(param_values={"x": 2})
     assert res.cells["val"].data == 2
 
 
@@ -525,15 +525,15 @@ def test_pipeline_copy():
     def b(run):
         return 2
 
-    pipe = Pipeline(input_vars={"x": 1}).add(a)
+    pipe = Pipeline(param_values={"x": 1}).add(a)
 
     clone = pipe.copy()
-    clone.input_vars["x"] = 2
-    clone.input_vars["y"] = 3
+    clone.param_values["x"] = 2
+    clone.param_values["y"] = 3
     clone.add(b)
 
-    assert pipe.input_vars == {"x": 1}
-    assert clone.input_vars == {"x": 2, "y": 3}
+    assert pipe.param_values == {"x": 1}
+    assert clone.param_values == {"x": 2, "y": 3}
     assert set(pipe.vars) == {"a"}
     assert set(clone.vars) == {"a", "b"}
 


### PR DESCRIPTION
Supports simple parameters: boolean, integer, float or string (the same types available for user-editable variables).

Parameters go in the context file like this:

```python
use_xgm_pulses = Parameter(bool, default=False,
                           description="Use pulse count from XGM instead of bunch pattern")

@Variable(title="Pulses", summary="mean")
def pulses(run, use_xgm: "param#use_xgm_pulses"):
    ...
```

The values can be edited for new runs:

<img width="465" height="279" alt="image" src="https://github.com/user-attachments/assets/39f6d33e-25e5-46d6-b4bb-e516aa93f7a0" /> 
<img width="281" height="261" alt="image" src="https://github.com/user-attachments/assets/c82994d0-d109-4ffc-82d1-330fae97095a" />

And changed when reprocessing:

<img width="717" height="365" alt="image" src="https://github.com/user-attachments/assets/cf5f931b-0b5e-4a15-9f89-49c3bebbb97b" />

They can also be set for `damnit reprocess`, with `--param use_xgm_pulses=True`.

TODO:

- [ ] Use set parameter values in listener
- [ ] Force select affected variables in the reprocess dialog when changing parameters (this requires the GUI to know more about variables than it does so far)
- [ ] Tests
- [ ] Documentation