### PR TITLE
Fix: Variable names does not update inPlot drop-down

### DIFF
--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -600,6 +600,7 @@ da-dev@xfel.eu"""
             self.table_view.apply_tag_filter(
                 self.table_view._current_tag_filter
             )
+            self.plot.update_columns()
         elif msg_kind == MsgKind.processing_state_set:
             self.table.handle_processing_state_set(data)
         elif msg_kind == MsgKind.processing_finished:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -45,7 +45,8 @@ from damnit.gui.web_viewer import PlotlyPlot
 from damnit.gui.zulip_messenger import ZulipConfig
 
 from .helpers import (
-    extract_mock_run, mkcontext, reduced_data_from_dict, make_table_with_headers)
+    amore_proto, extract_mock_run, mkcontext, reduced_data_from_dict,
+    make_table_with_headers)
 
 
 # Check if a PID exists by using `kill -0`
@@ -1919,3 +1920,51 @@ def test_best_text_color_for_custom_background(mock_db):
     light_item = model.new_item(42, "scalar1", 0, {"background": [240, 240, 240]})
     assert light_item.background().color() == QColor(240, 240, 240)
     assert light_item.foreground().color() == QColor(Qt.black)
+
+
+def test_variable_title_change(mock_db, monkeypatch, qtbot):
+    db_dir, _ = mock_db
+    ctx_path = db_dir / "context.py"
+
+    old_title = "Scalar1"
+    new_title = "Scalar1 updated"
+
+    win = MainWindow(db_dir, False)
+    qtbot.addWidget(win)
+
+    def combo_items(combo_box):
+        return [combo_box.itemText(i) for i in range(combo_box.count())]
+
+    assert old_title in combo_items(win.plot._combo_box_y_axis)
+    assert new_title not in combo_items(win.plot._combo_box_y_axis)
+
+    ctx_path.write_text(
+        ctx_path.read_text().replace(
+            f'@Variable(title="{old_title}",',
+            f'@Variable(title="{new_title}",',
+        )
+    )
+
+    with monkeypatch.context() as m:
+        m.chdir(db_dir)
+        amore_proto(["read-context"])
+
+    with DamnitDB.from_dir(db_dir) as fresh_db:
+        variable_update = dict(
+            fresh_db.conn.execute("""
+                SELECT name, title, type, description, attributes
+                FROM variables
+                WHERE name = 'scalar1'
+            """).fetchone()
+        )
+
+    win.handle_update({
+        "msg_kind": MsgKind.variable_set.value,
+        "data": variable_update,
+    })
+
+    assert new_title in combo_items(win.plot._combo_box_y_axis)
+    assert old_title not in combo_items(win.plot._combo_box_y_axis)
+    assert win.table.find_column(new_title, by_title=True) == win.table.find_column(
+        "scalar1", by_title=False
+    )

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -1922,15 +1922,16 @@ def test_best_text_color_for_custom_background(mock_db):
     assert light_item.foreground().color() == QColor(Qt.black)
 
 
-def test_variable_title_change(mock_db, monkeypatch, qtbot):
+def test_variable_title_change(mock_db, mock_kafka_broker, monkeypatch, qtbot):
     db_dir, _ = mock_db
     ctx_path = db_dir / "context.py"
 
     old_title = "Scalar1"
     new_title = "Scalar1 updated"
 
-    win = MainWindow(db_dir, False)
+    win = MainWindow(db_dir)
     qtbot.addWidget(win)
+    qtbot.waitUntil(lambda: win.update_agent.running, timeout=1000)
 
     def combo_items(combo_box):
         return [combo_box.itemText(i) for i in range(combo_box.count())]
@@ -1949,20 +1950,7 @@ def test_variable_title_change(mock_db, monkeypatch, qtbot):
         m.chdir(db_dir)
         amore_proto(["read-context"])
 
-    with DamnitDB.from_dir(db_dir) as fresh_db:
-        variable_update = dict(
-            fresh_db.conn.execute("""
-                SELECT name, title, type, description, attributes
-                FROM variables
-                WHERE name = 'scalar1'
-            """).fetchone()
-        )
-
-    win.handle_update({
-        "msg_kind": MsgKind.variable_set.value,
-        "data": variable_update,
-    })
-
+    qtbot.waitUntil(lambda: new_title in combo_items(win.plot._combo_box_y_axis), timeout=1000)
     assert new_title in combo_items(win.plot._combo_box_y_axis)
     assert old_title not in combo_items(win.plot._combo_box_y_axis)
     assert win.table.find_column(new_title, by_title=True) == win.table.find_column(


### PR DESCRIPTION
closes #536 