### PR TITLE
Hide warnings about 'self' in parameter annotations

### DIFF
--- a/damnit/gui/editor.py
+++ b/damnit/gui/editor.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import sys
 import traceback
 from enum import Enum
@@ -86,10 +87,9 @@ class ContextFileCheckerThread(QThread):
         # Disgusting hack to avoid getting warnings for "var#foo", "meta#foo",
         # and "mymdc#foo" type annotations. This needs some tweaking to avoid
         # missing real errors.
+        undef_annotation_re = re.compile(r"undefined name '(var|self|meta|mymdc)'$")
         pyflakes_output = "\n".join([line for line in out_buffer.getvalue().split("\n")
-                                     if not line.endswith("undefined name 'var'") \
-                                     and not line.endswith("undefined name 'meta'") \
-                                     and not line.endswith("undefined name 'mymdc'")])
+                                     if not undef_annotation_re.search(line)])
 
         if len(pyflakes_output) > 0:
             res, info = ContextTestResult.WARNING, pyflakes_output

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -300,6 +300,12 @@ da-dev@xfel.eu"""
         self.launch_update_computed_vars()
         self.start_watching_context_file()
 
+        if m := re.match(r"/gpfs/exfel/u/usr/.*/p(\d+)/Shared/amore$",
+                         str(self.context_dir.resolve())):
+            self.setWindowTitle(f"DAMNIT: p{m[1].lstrip('0')}")
+        else:
+            self.setWindowTitle(f"DAMNIT: {self.context_dir.absolute()}")
+
     def _save_context_finished(self, saved):
         if saved:
             self.launch_update_computed_vars()


### PR DESCRIPTION
Get rid of these:

<img width="619" height="259" alt="image" src="https://github.com/user-attachments/assets/2e445f07-96ca-4ab7-a039-54df5ee99ca0" />

Also, while I was making a minor change on the GUI, put the proposal number or folder path in the window title, so it's easier to work with multiple DAMNIT windows.