### PR TITLE
fix: ensure previous variable data is cleared when combining fragments

### DIFF
--- a/damnit/backend/combine.py
+++ b/damnit/backend/combine.py
@@ -20,6 +20,7 @@ from .extract_data import load_reduced_data, add_to_db
 from .service import notify_ready
 
 FRAGMENT_PATTERN = re.compile(r"p(\d+)_r(\d+).(.+).ready.h5$")
+SPECIAL_GROUPS = (".reduced", ".preview", ".errors")
 
 # If the file doesn't exist N seconds after the Kafka message was sent, move on
 NO_FILE_TIMEOUT = 30
@@ -32,8 +33,6 @@ log = logging.getLogger(__name__)
 # reading such objects back to an xarray dataset and saving them again.
 # https://github.com/HDFGroup/hdf5/issues/6200
 def copy_h5_obj(fsrc: h5py.File, fdst: h5py.File, path: str):
-    fdst.pop(path, None)
-
     objtype = fsrc[path].attrs.get('_damnit_objtype', '')
     if objtype in (DataType.DataArray.value, DataType.Dataset.value):
         with h5netcdf.File(fsrc) as nf:
@@ -45,6 +44,30 @@ def copy_h5_obj(fsrc: h5py.File, fdst: h5py.File, path: str):
                 xobj.dump_to_store(store)
     else:
         fsrc.copy(path, fdst, path, expand_refs=True)
+
+
+def fragment_variables(fsrc: h5py.File) -> set[str]:
+    """Return names of all modified variables from the fragment file.
+    """
+    names = {key for key in fsrc if not key.startswith(".")}
+    for special_grp in SPECIAL_GROUPS:
+        names |= set(fsrc.get(special_grp, ()))
+    return names
+
+
+def delete_variable(fdst: h5py.File, name):
+    fdst.pop(name, None)
+    for special_grp in SPECIAL_GROUPS:
+        fdst.pop(f"{special_grp}/{name}", None)
+
+
+def copy_variable(fsrc: h5py.File, fdst: h5py.File, name: str):
+    if name in fsrc:
+        copy_h5_obj(fsrc, fdst, name)
+
+    for special_grp in SPECIAL_GROUPS:
+        if name in fsrc.get(special_grp, ()):
+            copy_h5_obj(fsrc, fdst, f"{special_grp}/{name}") 
 
 
 def combine(src: Path, dst: Path):
@@ -60,13 +83,9 @@ def combine(src: Path, dst: Path):
         return
 
     with h5py.File(src) as fsrc, h5py.File(dst, 'r+') as fdst:
-        for grp in fsrc:
-            if not grp.startswith("."):
-                copy_h5_obj(fsrc, fdst, grp)
-
-        for special_grp in [".reduced", ".preview", ".errors"]:
-            for k in fsrc.get(special_grp, ()):
-                copy_h5_obj(fsrc, fdst, f"{special_grp}/{k}")
+        for name in fragment_variables(fsrc):
+            delete_variable(fdst, name)
+            copy_variable(fsrc, fdst, name)
 
     src.unlink()
 

--- a/tests/test_combine.py
+++ b/tests/test_combine.py
@@ -1,45 +1,138 @@
 import json
 
+import h5py
 import numpy as np
-from kafka import TopicPartition
 
 from damnit.api import Damnit, submit
+from damnit.context import Cell
 from damnit.backend.combine import FileSubmissionProcessor
 from damnit.backend.db import MsgKind
 from damnit.definitions import FILE_SUBMIT_TOPIC
 
+
+class SubmitHelper:
+    def __init__(self, broker, db, db_dir):
+        self.broker = broker
+        self.db = db
+        self.db_dir = db_dir
+        self.combiner = FileSubmissionProcessor(
+            consumer_config={'auto_offset_reset': 'earliest'}
+        )
+
+    def submit_and_combine(self, proposal, run, data, provenance='test', errors=None):
+        with self.broker.assert_produces(FILE_SUBMIT_TOPIC):
+            submit(proposal, run, data,
+                   provenance=provenance,
+                   damnit_dir=self.db_dir,
+                   errors=errors,
+            )
+
+        with self.broker.assert_produces(self.db.kafka_topic) as new_records:
+            self.combiner.handle_one_message()
+            self.combiner.producer.flush(timeout=5)
+
+        return new_records
+
+    def shutdown(self):
+        self.combiner.shutdown()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.shutdown()
+
+
 def test_combiner_service(mock_db, mock_kafka_broker):
     db_dir, db = mock_db
 
-    combiner = FileSubmissionProcessor(consumer_config={
-        'auto_offset_reset': 'earliest',  # Read from the 1st submission message
-    })
-
-    with mock_kafka_broker.assert_produces(FILE_SUBMIT_TOPIC):
-        submit(1234, 56, {
+    with SubmitHelper(mock_kafka_broker, db, db_dir) as sh:
+        new_records = sh.submit_and_combine(1234, 56, {
             # We need start_time in the DB for the API to see the run
             "array": np.arange(10), "start_time": 1776335722
-        }, provenance="test", damnit_dir=db_dir)
+        })
 
-    with mock_kafka_broker.assert_produces(db.kafka_topic) as new_records:
-        combiner.handle_one_message()
-        combiner.producer.flush(timeout=5)
+        msgs = [json.loads(r.value) for r in new_records]
+        assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
+        assert set(msgs[0]['data']['values']) == {"array", "start_time"}
 
-    msgs = [json.loads(r.value) for r in new_records]
-    assert [m['msg_kind'] for m in msgs] == [MsgKind.run_values_updated.value]
-    assert set(msgs[0]['data']['values']) == {"array", "start_time"}
+        api_obj = Damnit(db_dir)
+        np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(10))
 
-    api_obj = Damnit(db_dir)
-    np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(10))
+        sh.submit_and_combine(1234, 56, {"array": np.arange(15)})
 
-    # Overwrite the variable with a second fragment
-    with mock_kafka_broker.assert_produces(FILE_SUBMIT_TOPIC):
-        submit(
-            1234, 56, {"array": np.arange(15)}, provenance="test", damnit_dir=db_dir
+        np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(15))
+
+
+def test_combiner_clears_previous_data(mock_db, mock_kafka_broker):
+    db_dir, db = mock_db
+    h5_path = db_dir / "extracted_data" / "p1234_r56.h5"
+
+    with SubmitHelper(mock_kafka_broker, db, db_dir) as sh:
+
+        sh.submit_and_combine(1234, 56, {
+            "array": np.arange(10),
+            "start_time": 1776335722,
+        })
+
+        with h5py.File(h5_path) as f:
+            assert "array" in f
+            assert ".reduced/array" in f
+            assert ".errors/array" not in f
+
+        sh.submit_and_combine(
+            1234, 56, {}, errors={"array": RuntimeError("boom")}
         )
 
-    with mock_kafka_broker.assert_produces(db.kafka_topic):
-        combiner.handle_one_message()
-        combiner.producer.flush(timeout=5)
+        with h5py.File(h5_path) as f:
+            assert "array" not in f
+            assert ".reduced/array" not in f
+            assert ".errors/array" in f
 
-    np.testing.assert_array_equal(api_obj[56, "array"].read(), np.arange(15))
+        attrs = db.conn.execute(
+            "SELECT attributes FROM run_variables WHERE proposal=? AND run=? AND name=?",
+            (1234, 56, "array"),
+        ).fetchone()[0]
+        assert json.loads(attrs) == {
+            "error": "boom",
+            "error_cls": "RuntimeError",
+        }
+
+        sh.submit_and_combine(
+            1234, 56, {"array": np.arange(15)},
+        )
+
+        with h5py.File(h5_path) as f:
+            assert "array" in f
+            assert ".reduced/array" in f
+            assert ".errors/array" not in f
+            np.testing.assert_array_equal(f["array/data"][()], np.arange(15))
+
+        attrs = db.conn.execute(
+            "SELECT attributes FROM run_variables WHERE proposal=? AND run=? AND name=?",
+            (1234, 56, "array"),
+        ).fetchone()[0]
+        assert attrs is None
+
+
+def test_combine_special_group_only(mock_db, mock_kafka_broker):
+    db_dir, db = mock_db
+    h5_path = db_dir / "extracted_data" / "p1234_r56.h5"
+
+    with SubmitHelper(mock_kafka_broker, db, db_dir) as sh:
+
+        sh.submit_and_combine(1234, 56,
+            {"summary_only": Cell(data=None, summary_value=7), "preview_only": Cell(data=None, preview=np.arange(4))},
+            errors={"error_only": Exception("boom")}
+        )
+
+        with h5py.File(h5_path) as f:
+            assert ".reduced/summary_only" in f
+            assert ".preview/preview_only" in f
+            assert ".errors/error_only" in f
+            assert "summary_only" not in f
+            assert "preview_only" not in f
+            assert "error_only" not in f
+            assert f[".reduced/summary_only"][()] == 7
+            np.testing.assert_array_equal(f[".preview/preview_only"][()], np.arange(4))
+            assert f[".errors/error_only"].asstr()[()] == "boom"


### PR DESCRIPTION
While working on another feature, I noticed that previous data wasn't completely deleted when a variable was reprocessed.
This ensure all previous data and metadata for the fragment variable(s) is removed from the combined h5 file.