### PR TITLE
perf(api): improve loading time of the damnit table

### DIFF
--- a/damnit/api.py
+++ b/damnit/api.py
@@ -508,6 +508,7 @@ class Damnit:
                 for the columns in the dataframe.
         """
         import pandas as pd
+
         df = pd.read_sql_query("""
             SELECT proposal, run, start_time, added_at
             FROM run_info
@@ -549,11 +550,16 @@ class Damnit:
         if not variable_data.empty:
             values_wide = variable_data.pivot(index=["proposal", "run"],
                                               columns="name",
-                                              values="value").reset_index()
-            # Keep run start time from `run_info`.
-            values_wide.drop(columns=["start_time"], errors="ignore", inplace=True)
-            df = df.merge(values_wide, on=["proposal", "run"], how="left")
-    
+                                              values="value")
+            missing_cells = variable_data.assign(_present=True).pivot(
+                index=["proposal", "run"], columns="name", values="_present"
+            ).isna()
+
+            for name in missing_cells.columns[missing_cells.any()]:
+                values_wide[name] = values_wide[name].astype(object)
+                values_wide.loc[missing_cells[name], name] = pd.NA
+            df = df.merge(values_wide.reset_index(), on=["proposal", "run"], how="left")
+
             for row in variable_data.itertuples(index=False):
                 if row.summary_type is not None:
                     key = (row.proposal, row.run)
@@ -595,72 +601,11 @@ class Damnit:
             renames["start_time"] = "Timestamp"
 
             df.rename(columns=renames, inplace=True)
+
         return df
 
     def __repr__(self):
         return f"<Damnit database for p{self.proposal}>"
-
-
-        - Images will be replaced with an `<image>` string.
-        - Runs that were pre-created through the GUI but never taken by the DAQ
-          will not be included.
-
-        Args:
-            with_titles (bool): Whether to use variable titles instead of names
-                for the columns in the dataframe.
-        """
-        import pandas as pd
-
-        df = pd.read_sql_query("SELECT * FROM runs", self._db.conn)
-
-        # Convert the start_time into a datetime column
-        start_time = pd.to_datetime(df["start_time"], unit="s", utc=True)
-        df["start_time"] = start_time.dt.tz_convert("Europe/Berlin")
-
-        # Delete added_at, this is internal
-        del df["added_at"]
-
-        # Ensure that there's always a comment column for consistency, it may
-        # not be present if no comments were made.
-        if "comment" not in df:
-            df.insert(3, "comment", None)
-
-        # interpret blobs
-        def blob2type(value, summary_type=None):
-            if isinstance(value, bytes):
-                if summary_type == "complex":
-                    return blob2complex(value)
-                match BlobTypes.identify(value):
-                    case BlobTypes.png | BlobTypes.numpy:
-                        return "<image>"
-                    case BlobTypes.unknown | _:
-                        return "<unknown>"
-            else:
-                return value
-
-        def interpret_blobs(row):
-            summary_types = self._db.conn.execute(
-                "SELECT name, summary_type FROM run_variables WHERE proposal=? AND run=? AND summary_type IS NOT NULL",
-                (row["proposal"], row["run"])).fetchall()
-            summary_types = { row[0]: row[1] for row in summary_types }
-
-            for col in row.keys():
-                row[col] = blob2type(row[col], summary_types.get(col))
-            return row
-
-        df = df.apply(interpret_blobs, axis=1)
-
-        # Use the full variable titles
-        if with_titles:
-            results = self._db.conn.execute("SELECT name, title FROM variables").fetchall()
-            renames = { row[0]: row[1] for row in results }
-            renames["proposal"] = "Proposal"
-            renames["run"] = "Run"
-            renames["start_time"] = "Timestamp"
-
-            df.rename(columns=renames, inplace=True)
-
-        return df
 
 
 def submit(proposal: int, run: int, variables, *, provenance,

--- a/damnit/api.py
+++ b/damnit/api.py
@@ -499,6 +499,109 @@ class Damnit:
         displayed in the GUI:
 
         - Images will be replaced with an `<image>` string.
+        - Trendline summaries will be replaced with a `<sparkline>` string.
+        - Runs that were pre-created through the GUI but never taken by the DAQ
+          will not be included.
+
+        Args:
+            with_titles (bool): Whether to use variable titles instead of names
+                for the columns in the dataframe.
+        """
+        import pandas as pd
+        df = pd.read_sql_query("""
+            SELECT proposal, run, start_time, added_at
+            FROM run_info
+            WHERE start_time IS NOT NULL
+            ORDER BY proposal, run
+        """, self._db.conn)
+
+        # Get variable values from `run_variables` and pivot them into columns
+        variable_data = pd.read_sql_query("""
+            SELECT
+                v.proposal,
+                v.run,
+                v.name,
+                CASE
+                    WHEN typeof(v.value) = 'blob' AND v.summary_type = 'complex' THEN v.value
+                    WHEN typeof(v.value) = 'blob' AND v.summary_type = 'trendline' THEN '<sparkline>'
+                    WHEN typeof(v.value) = 'blob' AND v.summary_type = 'numpy' THEN '<ndarray>'
+                    -- If the summary type is missing, we assume the blobs are thumbnails (PNG or numpy)
+                    -- TODO: should we always add summary types for blobs in the future?
+                    WHEN typeof(v.value) = 'blob' AND (v.summary_type IS NULL OR v.summary_type = '') THEN '<thumbnail>'
+                    WHEN typeof(v.value) = 'blob' THEN '<blob>'
+                    ELSE v.value
+                END AS value,
+                v.summary_type
+            FROM run_variables AS v
+            INNER JOIN (
+                SELECT proposal, run, name, max(version) AS version
+                FROM run_variables
+                GROUP BY proposal, run, name
+            ) AS latest
+            ON latest.proposal = v.proposal
+            AND latest.run = v.run
+            AND latest.name = v.name
+            AND latest.version = v.version
+            ORDER BY v.proposal, v.run
+        """, self._db.conn)
+
+        summary_types_by_run = {}
+        if not variable_data.empty:
+            values_wide = variable_data.pivot(index=["proposal", "run"],
+                                              columns="name",
+                                              values="value").reset_index()
+            # Keep run start time from `run_info`.
+            values_wide.drop(columns=["start_time"], errors="ignore", inplace=True)
+            df = df.merge(values_wide, on=["proposal", "run"], how="left")
+    
+            for row in variable_data.itertuples(index=False):
+                if row.summary_type is not None:
+                    key = (row.proposal, row.run)
+                    summary_types_by_run.setdefault(key, {})[row.name] = row.summary_type
+
+        # Keep all known variables as columns, even if they have no value yet.
+        for name in self._db.variable_names():
+            if name not in ("proposal", "run", "start_time", "added_at") and name not in df:
+                df[name] = None
+
+        # Convert the start_time into a datetime column
+        start_time = pd.to_datetime(df["start_time"], unit="s", utc=True)
+        df["start_time"] = start_time.dt.tz_convert("Europe/Berlin")
+
+        # Delete added_at, this is internal
+        del df["added_at"]
+
+        # Ensure that there's always a comment column for consistency, it may
+        # not be present if no comments were made.
+        if "comment" not in df:
+            df.insert(3, "comment", None)
+
+        def interpret_blobs(row):
+            summary_types = summary_types_by_run.get((row["proposal"], row["run"]), {})
+
+            for col in row.keys():
+                if summary_types.get(col) == "complex":
+                    row[col] = blob2complex(row[col])
+            return row
+
+        df = df.apply(interpret_blobs, axis=1)
+
+        # Use the full variable titles
+        if with_titles:
+            results = self._db.conn.execute("SELECT name, title FROM variables").fetchall()
+            renames = { row[0]: row[1] for row in results }
+            renames["proposal"] = "Proposal"
+            renames["run"] = "Run"
+            renames["start_time"] = "Timestamp"
+
+            df.rename(columns=renames, inplace=True)
+        return df
+
+    def __repr__(self):
+        return f"<Damnit database for p{self.proposal}>"
+
+
+        - Images will be replaced with an `<image>` string.
         - Runs that were pre-created through the GUI but never taken by the DAQ
           will not be included.
 
@@ -558,9 +661,6 @@ class Damnit:
             df.rename(columns=renames, inplace=True)
 
         return df
-
-    def __repr__(self):
-        return f"<Damnit database for p{self.proposal}>"
 
 
 def submit(proposal: int, run: int, variables, *, provenance,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from textwrap import dedent
 
 import numpy as np
+import pandas as pd
 import plotly.express as px
 import pytest
 import xarray as xr
@@ -14,7 +15,7 @@ from damnit.context import Pipeline
 from .helpers import extract_mock_run
 
 
-def test_damnit(mock_db_with_data):
+def test_damnit(mock_db_with_data, monkeypatch):
     db_dir, db = mock_db_with_data
 
     damnit = Damnit(db_dir)
@@ -43,6 +44,28 @@ def test_damnit(mock_db_with_data):
 
     df = damnit.table(with_titles=True)
     assert "Scalar1" in df.columns
+
+    # test missing run variable cells are represented as pd.NA
+    monkeypatch.chdir(db_dir)
+    extract_mock_run(2)
+    extract_mock_run(3)
+    extract_mock_run(4)
+
+    # Simulate a run where this variable has no row in `run_variables`.
+    with db.conn:
+        db.conn.execute(
+            "DELETE FROM run_variables WHERE proposal=? AND run=? AND name=?",
+            (db.metameta["proposal"], 4, "scalar1"),
+        )
+
+    df = Damnit(db_dir).table().set_index("run")
+    assert df.loc[1, "scalar1"] == 42
+    assert df.loc[3, "scalar1"] is None
+    assert df.loc[4, "scalar1"] is pd.NA
+
+    assert df.loc[4, "trendline"] == "<sparkline>"
+    assert df.loc[4, "array_preview"] == "<thumbnail>"
+
 
 def test_run_variables(mock_db_with_data, mock_kafka_broker, monkeypatch):
     db_dir, db = mock_db_with_data


### PR DESCRIPTION
Loads the table faster with `Damnit.table()` by loading data from the table `run_variables` rather than from the `runs` view.
E.g. proposal 6656: `~15s` -> `<1s`