### PR TITLE
Improve processing logs

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -296,6 +296,7 @@ class RunExtractor(Extractor):
                 for m in self.match:
                     args.extend(['--match', m])
 
+            log.debug("Running extraction subprocess with args:\n%s", args)
             p = subprocess.Popen(args, env=prepare_env(), stdin=subprocess.DEVNULL)
 
             while True:
@@ -375,13 +376,17 @@ def main(argv=None):
                            capture_output=True, check=True, text=True)
         username = p.stdout.strip()
 
-    print(f"\n----- Processing r{args.run} (p{args.proposal}) as {username} on {hostname} -----", file=sys.stderr)
-    log.info(f"run_data={args.run_data}, match={args.match}")
-    if args.mock:
-        log.info("Using mock run object for testing")
-    if args.cluster_job:
-        log.info("Extracting cluster variables in Slurm job %s",
-                 os.environ.get('SLURM_JOB_ID', '?'))
+    job_cluster = os.environ.get('SLURM_CLUSTER_NAME', '')
+    job_id = os.environ.get('SLURM_JOB_ID', '')
+    if job_id:
+        node_info = f"{hostname} (job id: {job_id}, cluster: {job_cluster})"
+    else:
+        node_info = f"{hostname} (subprocess)"
+
+    print(
+        f"\n----- Processing r{args.run} (p{args.proposal}) as {username} on {node_info} -----",
+        file=sys.stderr
+    )
 
     extr = RunExtractor(args.proposal, args.run,
                         cluster=args.cluster_job,

--- a/damnit/ctxsupport/ctxrunner.py
+++ b/damnit/ctxsupport/ctxrunner.py
@@ -763,6 +763,12 @@ def main(argv=None):
     logging.basicConfig(level=logging.INFO)
 
     if args.subcmd == "exec":
+        if args.mock:
+            log.info("Using mock run for testing")
+        log.info("proposal=%d, run=%d, run_data=%s, cluster_job=%s%s%s",
+                 args.proposal, args.run, args.run_data, args.cluster_job,
+                 f", match={args.match}" if args.match else "",
+                 f", var={args.var}" if args.var else "")
 
         pipe_whole = Pipeline.from_context_file(
             Path('context.py')
@@ -778,9 +784,13 @@ def main(argv=None):
             match=args.match,
             variables=args.var,
         )
-        log.info("Using %d variables (of %d) from context file %s",
-             len(sel.vars), len(pipe_whole.vars),
-             "" if args.cluster_job else "(cluster variables will be processed later)")
+        log.info(
+            "Using %d variables (of %d) from context file%s: %s",
+            len(sel.vars),
+            len(pipe_whole.vars),
+            "" if args.cluster_job else " (cluster variables will be processed later)",
+            sorted(sel.vars),
+        )
 
         if args.mock:
             res = sel.execute(data=mock_run())


### PR DESCRIPTION
closes #115 
closes #574 

e.g.

```bash
----- Processing r5 (p6656) as tmichela on max-wn020.desy.de (job id: 345416, cluster: solaris) -----
INFO:ctxrunner:proposal=6656, run=5, run_data=all, cluster_job=False, match=['array']
INFO:ctxrunner:Using 1 variables (of 13) from context file (cluster variables will be processed later): ['array_preview']
[...]
INFO:ctxrunner:Computed array_preview in 0.000 s
2026-05-22 16:33:55,576 INFO damnit.backend.extraction_control: Processing output will be written to process_logs/r5-p6656.out
2026-05-22 16:33:55,591 INFO damnit.backend.extraction_control: Launched Slurm (maxwell) job 22667944 to run context file

----- Processing r5 (p6656) as tmichela on max-exfl529.desy.de (job id: 22667944, cluster: maxwell) -----
INFO:ctxrunner:proposal=6656, run=5, run_data=all, cluster_job=True, match=['array']
INFO:ctxrunner:Using 5 variables (of 13) from context file: ['array', 'meta_array', 'scalar1', 'scalar2', 'timestamp']
[...]
INFO:ctxrunner:Computed scalar1 in 0.000 s
INFO:ctxrunner:Computed timestamp in 0.000 s
INFO:ctxrunner:Computed scalar2 in 0.000 s
INFO:ctxrunner:Computed array in 0.000 s
INFO:ctxrunner:Computed meta_array in 0.000 s
```