### PR TITLE
Minor GUI simplifications

### DIFF
--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -7,7 +7,6 @@ file (see ctxrunner.py).
 import argparse
 import copy
 import getpass
-import json
 import os
 import logging
 import pickle
@@ -24,10 +23,9 @@ from uuid import uuid4
 import h5py
 import numpy as np
 
-from kafka import KafkaProducer
-
 from ..context import ContextFile, Pipeline, RunData
-from ..definitions import update_brokers, FILE_SUBMIT_TOPIC
+from ..definitions import FILE_SUBMIT_TOPIC
+from ..util import kafka_producer
 from .db import DamnitDB, ReducedData, BlobTypes, MsgKind, msg_dict
 from .extraction_control import ExtractionRequest, ExtractionSubmitter
 
@@ -158,10 +156,7 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run, provenance):
 
 def notify_new_file(damnit_dir, proposal: int, run: int, file_path: str):
     msg = file_submit_msg(damnit_dir, proposal, run, file_path)
-    prod = KafkaProducer(
-        bootstrap_servers=update_brokers(),
-        value_serializer=lambda d: json.dumps(d).encode('utf-8')
-    )
+    prod = kafka_producer()
     prod.send(FILE_SUBMIT_TOPIC, msg)
     prod.close(timeout=10)
 
@@ -183,15 +178,9 @@ def file_submit_msg(damnit_dir: Path, proposal: int, run: int, file_path: str):
 class Extractor:
     _proposal = None
 
-    def __init__(self, sandbox_args=None, connect_to_kafka=True):
+    def __init__(self, sandbox_args=None):
         self.db = DamnitDB()
-        if connect_to_kafka:
-            self.kafka_prd = KafkaProducer(
-                bootstrap_servers=update_brokers(),
-                value_serializer=lambda d: json.dumps(d).encode('utf-8'),
-            )
-        else:
-            self.kafka_prd = None
+        self.kafka_prd = kafka_producer()
 
         context_python = self.db.metameta.get("context_python")
         self.pipe_whole, error_info = get_context_file(
@@ -208,12 +197,11 @@ class Extractor:
     def update_db_vars(self):
         updates = self.db.update_computed_variables(self.pipe_whole.vars_to_dict())
 
-        if self.kafka_prd is not None:
-            for name, var in updates.items():
-                self.kafka_prd.send(self.db.kafka_topic, msg_dict(
-                    MsgKind.variable_set, {'name': name} | var
-                ))
-            self.kafka_prd.flush()
+        for name, var in updates.items():
+            self.kafka_prd.send(self.db.kafka_topic, msg_dict(
+                MsgKind.variable_set, {'name': name} | var
+            ))
+        self.kafka_prd.flush()
 
 class RunExtractor(Extractor):
     def __init__(self, proposal, run, cluster=False, run_data=RunData.ALL,

--- a/damnit/cli.py
+++ b/damnit/cli.py
@@ -132,10 +132,6 @@ class GuiSubcmd(Subcommand):
             help="Either a proposal number or a database directory."
         )
         parser.add_argument(
-            '--no-kafka', action='store_true',
-            help="Don't try connecting to XFEL's Kafka broker"
-        )
-        parser.add_argument(
             "--software-opengl", action="store_true",
             help="Force software OpenGL. Use this if displaying interactive Plotly plots shows a black screen."
                  "Active by default on Maxwell if not started on a display node."
@@ -147,8 +143,7 @@ class GuiSubcmd(Subcommand):
 
         from .gui.main_window import run_app
         return run_app(context_dir,
-                       software_opengl=args.software_opengl,
-                       connect_to_kafka=not args.no_kafka)
+                       software_opengl=args.software_opengl)
 
 
 class ListenSubcmd(Subcommand):
@@ -404,16 +399,9 @@ class ReadctxSubcmd(Subcommand):
     help="Re-read the context file and update variables in the database"
 
     @staticmethod
-    def arguments(parser: argparse.ArgumentParser):
-        parser.add_argument(
-            '--no-kafka', action='store_true',
-            help="Don't try connecting to XFEL's Kafka broker"
-        )
-
-    @staticmethod
     def run(args: argparse.Namespace):
         from .backend.extract_data import Extractor
-        Extractor(connect_to_kafka=not args.no_kafka).update_db_vars()
+        Extractor().update_db_vars()
 
 
 class ProposalSubcmd(Subcommand):

--- a/damnit/gui/kafka.py
+++ b/damnit/gui/kafka.py
@@ -1,11 +1,11 @@
 import json
 import logging
 
-from kafka import KafkaConsumer, KafkaProducer
 from PyQt5 import QtCore
 
 from ..backend.db import MsgKind, msg_dict
-from ..definitions import update_brokers, UPDATE_TOPIC
+from ..definitions import UPDATE_TOPIC
+from ..util import kafka_producer, kafka_consumer
 
 log = logging.getLogger(__name__)
 
@@ -13,17 +13,11 @@ log = logging.getLogger(__name__)
 class UpdateAgent(QtCore.QObject):
     message = QtCore.pyqtSignal(object)
 
-    def __init__(self, db_id: str) -> None:
+    def __init__(self, db_id: str, dummy=False) -> None:
         QtCore.QObject.__init__(self)
         self.update_topic = UPDATE_TOPIC.format(db_id)
-
-        self.kafka_cns = KafkaConsumer(
-            self.update_topic, bootstrap_servers=update_brokers()
-        )
-        self.kafka_prd = KafkaProducer(
-            bootstrap_servers=update_brokers(),
-            value_serializer=lambda d: json.dumps(d).encode('utf-8')
-        )
+        self.kafka_prd = kafka_producer(dummy=dummy)
+        self.kafka_cns = kafka_consumer(self.update_topic, dummy=dummy)
         self.running = False
 
     def listen_loop(self) -> None:

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -64,10 +64,9 @@ class MainWindow(QtWidgets.QMainWindow):
     db_id = None
     _columns_dialog = None
 
-    def __init__(self, context_dir: Path = None, connect_to_kafka: bool = True, background_activity=True):
+    def __init__(self, context_dir: Path = None, background_activity=True):
         super().__init__()
 
-        self._connect_to_kafka = connect_to_kafka
         # Background activity includes watching the context file & parsing it
         # in a child process; it can be disabled to make unit testing easier.
         self._background_activity = background_activity
@@ -327,8 +326,6 @@ da-dev@xfel.eu"""
         proc.finished.connect(proc.deleteLater)
         proc.setWorkingDirectory(str(self.context_dir))
         read_context_args = ['-m', 'damnit.cli', 'read-context']
-        if not self._connect_to_kafka:
-            read_context_args.append("--no-kafka")
         proc.start(sys.executable, read_context_args)
         proc.closeWriteChannel()
         # The subprocess will send updates for any changes: see .handle_update()
@@ -377,8 +374,7 @@ da-dev@xfel.eu"""
         self.table_view.add_new_columns([title], [True], [before_pos - n_static_cols - 1])
         self.table.add_editable_column(name)
 
-        if self._connect_to_kafka:
-            self.update_agent.variable_set(name, title, description, variable_type)
+        self.update_agent.variable_set(name, title, description, variable_type)
 
     def open_column_dialog(self):
         if self._columns_dialog is None:
@@ -615,9 +611,6 @@ da-dev@xfel.eu"""
 
 
     def _updates_thread_launcher(self) -> None:
-        if not self._connect_to_kafka:
-            return
-
         assert self.db_id is not None
 
         try:
@@ -626,6 +619,7 @@ da-dev@xfel.eu"""
             QtWidgets.QMessageBox.warning(self, "Broker connection failed",
                                           f"Could not connect to any Kafka brokers at: {' '.join(update_brokers())}\n\n" +
                                           "DAMNIT can operate offline, but it will not receive any updates from new or reprocessed runs.")
+            self.update_agent = UpdateAgent(self.db_id, dummy=True)
             return
 
         self._updates_thread = QtCore.QThread()
@@ -968,8 +962,7 @@ da-dev@xfel.eu"""
 
         log.debug("Saving data for variable %s for prop %d run %d", name, prop, run)
         self.db.set_variable(prop, run, name, ReducedData(value), provenance="manual-input")
-        if self._connect_to_kafka:
-            self.update_agent.run_values_updated(prop, run, name)
+        self.update_agent.run_values_updated(prop, run, name)
 
     def check_zulip_messenger(self):
         if not isinstance(self.zulip_messenger, ZulipMessenger):
@@ -1029,11 +1022,10 @@ da-dev@xfel.eu"""
                 self.show_status_message(
                     f"Launched processing for {len(reqs)} runs", 10_000
                 )
-                if self._connect_to_kafka:
-                    for req, (job_id, cluster) in zip(reqs, submitted):
-                        self.update_agent.processing_submitted(
-                            req.submitted_info(cluster, job_id)
-                        )
+                for req, (job_id, cluster) in zip(reqs, submitted):
+                    self.update_agent.processing_submitted(
+                        req.submitted_info(cluster, job_id)
+                    )
 
     adeqt_window = None
 
@@ -1237,7 +1229,7 @@ def prompt_setup_db(context_dir: Path, prop_no=None, parent=None):
     return True
 
 
-def run_app(context_dir, software_opengl=False, connect_to_kafka=True):
+def run_app(context_dir, software_opengl=False):
     QtWidgets.QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     QtWidgets.QApplication.setAttribute(
         QtCore.Qt.ApplicationAttribute.AA_DontUseNativeMenuBar,
@@ -1270,7 +1262,7 @@ def run_app(context_dir, software_opengl=False, connect_to_kafka=True):
     profile = QWebEngineProfile.defaultProfile()
     scheme_handler.install(profile)
 
-    window = MainWindow(context_dir=context_dir, connect_to_kafka=connect_to_kafka)
+    window = MainWindow(context_dir=context_dir)
     window.show()
     return application.exec()
 

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -53,7 +53,6 @@ class Settings(Enum):
 
 class MainWindow(QtWidgets.QMainWindow):
 
-    context_dir_changed = QtCore.pyqtSignal(str)
     save_context_finished = QtCore.pyqtSignal(bool)  # True if saved
     check_context_file_timer = None
     vars_ctx_size_mtime = None
@@ -210,7 +209,7 @@ da-dev@xfel.eu"""
         )
         dialog.exec()
 
-    def _menu_bar_autoconfigure(self) -> None:
+    def _menu_bar_open(self) -> None:
         open_dialog = OpenDBDialog(self)
         context_dir, prop_no = open_dialog.run_get_result()
         if context_dir is None:
@@ -219,7 +218,8 @@ da-dev@xfel.eu"""
             # User said no to setting up a new database
             return
 
-        self.autoconfigure(context_dir)
+        new_window = MainWindow(context_dir)
+        new_window.show()
 
     def save_settings(self):
         self._settings_db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -294,7 +294,6 @@ da-dev@xfel.eu"""
         self.plot.update_columns()
 
         self.show_default_status_message()
-        self.context_dir_changed.emit(str(path))
         if self._background_activity:
             self.launch_update_computed_vars()
             self.start_watching_context_file()
@@ -397,14 +396,14 @@ da-dev@xfel.eu"""
         menu_bar = self.menuBar()
         menu_bar.setNativeMenuBar(False)
 
-        action_autoconfigure = QtWidgets.QAction(
-            QtGui.QIcon("autoconfigure.png"), "Connect with &autoconfiguration", self
+        action_open = QtWidgets.QAction(
+            QtGui.QIcon("autoconfigure.png"), "Open &another DAMNIT folder", self
         )
-        action_autoconfigure.setShortcut("Shift+A")
-        action_autoconfigure.setStatusTip(
-            "Autoconfigure AMORE by selecting the proposal folder."
+        action_open.setShortcut("Shift+A")
+        action_open.setStatusTip(
+            "Open another DAMNIT proposal or folder in a new window."
         )
-        action_autoconfigure.triggered.connect(self._menu_bar_autoconfigure)
+        action_open.triggered.connect(self._menu_bar_open)
 
         self.action_create_var = QtWidgets.QAction(
             QtGui.QIcon.fromTheme("accessories-text-editor"),
@@ -438,7 +437,7 @@ da-dev@xfel.eu"""
         fileMenu = menu_bar.addMenu(
             QtGui.QIcon(icon_path("AMORE.png")), "&AMORE"
         )
-        fileMenu.addAction(action_autoconfigure)
+        fileMenu.addAction(action_open)
         fileMenu.addAction(self.action_create_var)
         fileMenu.addAction(self.action_process)
         fileMenu.addAction(self.action_export)

--- a/damnit/gui/main_window.py
+++ b/damnit/gui/main_window.py
@@ -64,7 +64,7 @@ class MainWindow(QtWidgets.QMainWindow):
     db_id = None
     _columns_dialog = None
 
-    def __init__(self, context_dir: Path = None, background_activity=True):
+    def __init__(self, context_dir: Path, background_activity=True):
         super().__init__()
 
         # Background activity includes watching the context file & parsing it
@@ -98,8 +98,6 @@ class MainWindow(QtWidgets.QMainWindow):
         self._tab_widget.addTab(self._editor_parent_widget, "Context file")
         self._tab_widget.currentChanged.connect(self.on_tab_changed)
 
-        # Disable the main window at first since we haven't loaded any database yet
-        self._tab_widget.setEnabled(False)
         self.setCentralWidget(self._tab_widget)
 
         self.save_context_finished.connect(self._save_context_finished)
@@ -113,8 +111,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.configure_editor()
         self.center_window()
 
-        if context_dir is not None:
-            self.autoconfigure(context_dir)
+        self.autoconfigure(context_dir)
 
         self._canvas_inspect = []
 
@@ -296,7 +293,6 @@ da-dev@xfel.eu"""
                                     [col_settings.get(col, True) for col in titles])
         self.plot.update_columns()
 
-        self._tab_widget.setEnabled(True)
         self.show_default_status_message()
         self.context_dir_changed.emit(str(path))
         if self._background_activity:
@@ -418,13 +414,9 @@ da-dev@xfel.eu"""
         self.action_create_var.setShortcut("Shift+U")
         self.action_create_var.setStatusTip("Create user editable variable")
         self.action_create_var.triggered.connect(self._menu_create_user_var)
-        self.action_create_var.setEnabled(False)
-        self.context_dir_changed.connect(lambda _: self.action_create_var.setEnabled(True))
 
         self.action_export = QtWidgets.QAction(QtGui.QIcon(icon_path("export.png")), "&Export", self)
         self.action_export.setStatusTip("Export to Excel/CSV")
-        self.action_export.setEnabled(False)
-        self.context_dir_changed.connect(lambda _: self.action_export.setEnabled(True))
         self.action_export.triggered.connect(self.export_table)
         self.action_process = QtWidgets.QAction("Reprocess runs", self)
         self.action_process.triggered.connect(self.process_runs)
@@ -956,10 +948,6 @@ da-dev@xfel.eu"""
         self.editor_ctx_size_mtime = ctx_size_mtime or self.get_context_size_mtime()
 
     def save_value(self, prop, run, name, value):
-        if self.db is None:
-            log.warning("No SQLite database in use, value not saved")
-            return
-
         log.debug("Saving data for variable %s for prop %d run %d", name, prop, run)
         self.db.set_variable(prop, run, name, ReducedData(value), provenance="manual-input")
         self.update_agent.run_values_updated(prop, run, name)

--- a/damnit/util.py
+++ b/damnit/util.py
@@ -1,9 +1,11 @@
+import json
 import sys
+import time
 from datetime import datetime, timezone
 
-import numpy as np
 import pandas as pd
-from pandas.api.types import infer_dtype
+
+from .definitions import update_brokers
 
 
 def timestamp2str(timestamp):
@@ -22,3 +24,49 @@ def isinstance_no_import(obj, mod: str, cls: str):
         return False
 
     return isinstance(obj, getattr(m, cls))
+
+
+class StubKafkaProducer:
+    def send(self, *args, **kwargs):
+        pass
+
+    def flush(self, *args, **kwargs):
+        pass
+
+    def close(self, *args, **kwargs):
+        pass
+
+
+def kafka_producer(dummy=False, **kwargs):
+    """Create a KafkaProducer, or a dummy
+
+    Pass dummy=True or set AMORE_BROKER=none to use the dummy
+    """
+    brokers = update_brokers()
+    if dummy or brokers == ["none"]:
+        return StubKafkaProducer()
+
+    from kafka import KafkaProducer
+    return KafkaProducer(
+        bootstrap_servers=update_brokers(),
+        value_serializer=lambda d: json.dumps(d).encode('utf-8')
+    )
+
+
+class StubKafkaConsumer:
+    def poll(self, timeout_ms=0, **kwargs):
+        time.sleep(timeout_ms / 1000)
+        return {}
+
+
+def kafka_consumer(*topics, dummy=False, **kwargs):
+    """Create a KafkaProducer, or a dummy
+
+    Pass dummy=True or set AMORE_BROKER=none to use the dummy
+    """
+    brokers = update_brokers()
+    if dummy or brokers == ["none"]:
+        return StubKafkaConsumer()
+
+    from kafka import KafkaConsumer
+    return KafkaConsumer(*topics, bootstrap_servers=brokers, **kwargs)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,17 +64,17 @@ def test_gui(monkeypatch):
     # Check passing neither a proposal number or directory
     with patch("damnit.gui.main_window.run_app") as run_app:
         main(["gui"])
-        run_app.assert_called_with(None, software_opengl=False, connect_to_kafka=ANY)
+        run_app.assert_called_with(None, software_opengl=False)
 
     # Check passing a proposal number
     with patch("damnit.gui.main_window.run_app") as run_app:
         main(["gui", "1234"])
-        run_app.assert_called_with(Path("/tmp/usr/Shared/amore"), software_opengl=False, connect_to_kafka=ANY)
+        run_app.assert_called_with(Path("/tmp/usr/Shared/amore"), software_opengl=False)
 
     # Check passing a directory
     with patch("damnit.gui.main_window.run_app") as run_app:
         main(["gui", "/tmp"])
-        run_app.assert_called_with(Path("/tmp"), software_opengl=False, connect_to_kafka=ANY)
+        run_app.assert_called_with(Path("/tmp"), software_opengl=False)
 
     # Check invalid argument
     with patch("damnit.gui.main_window.run_app") as run_app:

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -75,14 +75,7 @@ def test_connect_to_kafka(mock_db, qtbot):
 
     with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
          patch(f"{pkg}.KafkaProducer") as kafka_prd:
-        win = MainWindow(db_dir, False)
-        qtbot.addWidget(win)
-        kafka_cns.assert_not_called()
-        kafka_prd.assert_not_called()
-
-    with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
-         patch(f"{pkg}.KafkaProducer") as kafka_prd:
-        win = MainWindow(db_dir, True)
+        win = MainWindow(db_dir, background_activity=False)
         qtbot.addWidget(win, before_close_func=lambda _: win.stop_update_listener_thread())
         kafka_cns.assert_called_once()
         kafka_prd.assert_called_once()
@@ -1056,7 +1049,7 @@ def test_exporting(mock_db_with_data, mock_kafka_broker, qtbot, monkeypatch, ext
     (db_dir / "context.py").write_text(ctx.code)
     extract_mock_run(1)
 
-    win = MainWindow(db_dir, connect_to_kafka=False)
+    win = MainWindow(db_dir)
     qtbot.addWidget(win)
 
     export_path = db_dir / f"export{extension}"
@@ -1070,13 +1063,13 @@ def test_exporting(mock_db_with_data, mock_kafka_broker, qtbot, monkeypatch, ext
     df = pd.read_excel(export_path) if extension == ".xlsx" else pd.read_csv(export_path)
     assert df["Image"][0] == "<image>"
 
-def test_delete_variable(mock_db_with_data, qtbot, monkeypatch):
+def test_delete_variable(mock_db_with_data, qtbot, monkeypatch, mock_kafka_broker):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
 
     # We'll delete the 'array' variable
     assert "array" in db.variable_names()
-    win = MainWindow(db_dir, connect_to_kafka=False)
+    win = MainWindow(db_dir)
     qtbot.addWidget(win)
     tbl = win.table
     column_ids_before = [tbl.column_id(i) for i in range(tbl.columnCount())]
@@ -1111,7 +1104,7 @@ def test_delete_variable(mock_db_with_data, qtbot, monkeypatch):
         assert "array" not in f[".reduced"].keys()
 
 def test_delete_variable_with_tag_filter(
-    mock_db, tmp_path, qtbot, monkeypatch
+    mock_db, tmp_path, qtbot, monkeypatch, mock_kafka_broker
 ):
     def _visible_count(tv):
         count = 0
@@ -1128,7 +1121,7 @@ def test_delete_variable_with_tag_filter(
     monkeypatch.chdir(db_dir)
 
     with patch("pathlib.Path.home", return_value=tmp_path):
-        win = MainWindow(db_dir, connect_to_kafka=False)
+        win = MainWindow(db_dir, background_activity=False)
     qtbot.addWidget(win)
 
     table_view = win.table_view
@@ -1166,16 +1159,16 @@ def test_delete_variable_with_tag_filter(
     assert win.table_view.get_column_states() == expected_states
 
     with patch("pathlib.Path.home", return_value=tmp_path):
-        win2 = MainWindow(db_dir, connect_to_kafka=False)
+        win2 = MainWindow(db_dir)
     qtbot.addWidget(win2)
     assert win2.table_view.get_column_states() == expected_states
 
 
-def test_precreate_runs(mock_db_with_data, qtbot, monkeypatch):
+def test_precreate_runs(mock_db_with_data, qtbot, monkeypatch, mock_kafka_broker):
     db_dir, db = mock_db_with_data
     monkeypatch.chdir(db_dir)
 
-    win = MainWindow(db_dir, connect_to_kafka=False)
+    win = MainWindow(db_dir, background_activity=False)
     qtbot.addWidget(win)
     get_n_runs = lambda: db.conn.execute("SELECT COUNT(run) FROM runs").fetchone()[0]
     n_runs = get_n_runs()
@@ -1510,9 +1503,9 @@ def test_filter_menu(mock_db_with_data, qtbot):
     assert model.filters[thumb_col] == thumb_filter
 
 
-def test_processing_status(mock_db_with_data, qtbot):
+def test_processing_status(mock_db_with_data, qtbot, mock_kafka_broker):
     db_dir, db = mock_db_with_data
-    win = MainWindow(db_dir, connect_to_kafka=False)
+    win = MainWindow(db_dir, background_activity=False)
     qtbot.addWidget(win)
     tbl = win.table
 
@@ -1578,9 +1571,9 @@ def test_theme(mock_db, qtbot, tmp_path):
         assert win2.palette() != dark_palette  # Light theme should have different colors
 
 
-def test_filter_header(mock_db_with_data, qtbot):
+def test_filter_header(mock_db_with_data, qtbot, mock_kafka_broker):
     """Test that the filter header shows icons when filters are active."""
-    window = MainWindow(mock_db_with_data[0], connect_to_kafka=False)
+    window = MainWindow(mock_db_with_data[0], background_activity=False)
     qtbot.addWidget(window)
     window.show()
 
@@ -1945,7 +1938,7 @@ def test_variable_title_change(mock_db, mock_kafka_broker, monkeypatch, qtbot):
     old_title = "Scalar1"
     new_title = "Scalar1 updated"
 
-    win = MainWindow(db_dir)
+    win = MainWindow(db_dir, background_activity=False)
     qtbot.addWidget(win)
     qtbot.waitUntil(lambda: win.update_agent.running, timeout=1000)
 

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -69,16 +69,25 @@ def assert_sends_update(win, broker):
     l.extend([json.loads(r.value) for r in new_records])
 
 
-def test_connect_to_kafka(mock_db, qtbot):
+def test_connect_to_kafka(mock_db, qtbot, monkeypatch):
     db_dir, db = mock_db
-    pkg = "damnit.gui.kafka"
 
-    with patch(f"{pkg}.KafkaConsumer") as kafka_cns, \
-         patch(f"{pkg}.KafkaProducer") as kafka_prd:
+    with patch(f"kafka.KafkaConsumer") as kafka_cns, \
+         patch(f"kafka.KafkaProducer") as kafka_prd:
         win = MainWindow(db_dir, background_activity=False)
-        qtbot.addWidget(win, before_close_func=lambda _: win.stop_update_listener_thread())
+        win.close()
+        qtbot.addWidget(win)
         kafka_cns.assert_called_once()
         kafka_prd.assert_called_once()
+
+    monkeypatch.setenv("AMORE_BROKER", "none")
+    with patch(f"kafka.KafkaConsumer") as kafka_cns, \
+         patch(f"kafka.KafkaProducer") as kafka_prd:
+        win = MainWindow(db_dir, background_activity=False)
+        win.close()
+        qtbot.addWidget(win)
+        kafka_cns.assert_not_called()
+        kafka_prd.assert_not_called()
 
 def test_editor(mock_db, mock_ctx, qtbot):
     db_dir, db = mock_db
@@ -86,17 +95,16 @@ def test_editor(mock_db, mock_ctx, qtbot):
     ctx_path.write_text(mock_ctx.code)
 
     win = MainWindow(db_dir, False)
-    win.show()
-    qtbot.addWidget(win)
-    editor = win._editor
-    status_bar = win._status_bar
-
     # If the context file is not saved, the window will prompt the user about
     # it. This makes the tests hang, so before closing the window we manually
     # mark the context as saved. Useful if a test fails for some reason while
     # the context is changed.
     qtbot.addWidget(win, before_close_func=lambda win: win.mark_context_saved())
+    win.show()
     qtbot.waitExposed(win)
+
+    editor = win._editor
+    status_bar = win._status_bar
 
     # Loading a database should also load the context file
     assert editor.text() == mock_ctx.code

--- a/tests/test_gui.py
+++ b/tests/test_gui.py
@@ -25,7 +25,7 @@ from damnit.backend.db import DamnitDB, MsgKind, ReducedData
 from damnit.backend.extract_data import add_to_db
 from damnit.context import Pipeline
 from damnit.gui.editor import ContextTestResult
-from damnit.gui.main_window import AddUserVariableDialog, MainWindow
+from damnit.gui.main_window import AddUserVariableDialog, MainWindow, prompt_setup_db
 from damnit.gui.open_dialog import OpenDBDialog
 from damnit.gui.plot import HistogramPlotWindow, ScatterPlotWindow
 from damnit.gui.standalone_comments import TimeComment
@@ -449,10 +449,8 @@ def test_handle_update_plots(mock_db_with_data, monkeypatch, qtbot):
     db.set_variable(msg_data["proposal"], msg_data["run"], "scalar1", ReducedData(42), provenance="test")
     win.handle_update(msg)
 
-def test_autoconfigure(tmp_path, bound_port, request, qtbot):
+def test_prompt_setup_db(tmp_path, bound_port, request, qtbot):
     db_dir = tmp_path / "usr/Shared/amore"
-    win = MainWindow(None, False)
-    qtbot.addWidget(win)
     pkg = "damnit.gui.main_window"
     template_path = Path(damnit.__file__).parent / 'ctx-templates' / 'SA1_base.py'
 
@@ -460,31 +458,23 @@ def test_autoconfigure(tmp_path, bound_port, request, qtbot):
     def helper_patch():
         # Patch things such that the GUI thinks we're on GPFS trying to open
         # p1234, and the user always wants to create a database.
-        with (patch(f"{pkg}.OpenDBDialog.run_get_result", return_value=(db_dir, 1234)),
-              patch(f"{pkg}.NewContextFileDialog.run_get_result", return_value=(template_path, None)),
+        with (patch(f"{pkg}.NewContextFileDialog.run_get_result", return_value=(template_path, None)),
               patch.object(QMessageBox, "question", return_value=QMessageBox.Yes),
-              patch(f"{pkg}.initialize_proposal") as initialize_proposal,
-              patch.object(win, "autoconfigure")):
+              patch(f"{pkg}.initialize_proposal") as initialize_proposal):
             yield initialize_proposal
 
-    # Autoconfigure from scratch
+    # Set up a new DAMNIT directory
     with helper_patch() as initialize_proposal:
-        win._menu_bar_autoconfigure()
-
-        # We expect the database to be initialized
-        win.autoconfigure.assert_called_once_with(db_dir)
+        prompt_setup_db(db_dir, prop_no=1234)
         initialize_proposal.assert_called_once_with(db_dir, 1234, template_path, None)
 
     # Create the directory and database file to fake the database already existing
     db_dir.mkdir(parents=True)
-    DamnitDB.from_dir(db_dir, create=True)
+    DamnitDB.from_dir(db_dir, create=True).close()
 
     # Autoconfigure with database present
     with helper_patch() as initialize_proposal:
-        win._menu_bar_autoconfigure()
-
-        # We expect the database to be initialized
-        win.autoconfigure.assert_called_once_with(db_dir)
+        prompt_setup_db(db_dir, prop_no=1234)
         initialize_proposal.assert_not_called()
 
 def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qtbot):
@@ -510,8 +500,11 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qt
     with db.conn:
         add_to_db(reduced_data, db, proposal, run_number, provenance="test")
 
+    # Adds the variables to the db
+    for vv in mock_user_vars.values():
+        db.add_user_variable(vv, exist_ok=True)
 
-    win = MainWindow(background_activity=False)
+    win = MainWindow(db_dir, background_activity=False)
     win.show()
     qtbot.addWidget(win)
 
@@ -524,15 +517,6 @@ def test_user_vars(mock_ctx_user, mock_user_vars, mock_db, mock_kafka_broker, qt
 
     # Check that we found the actual menu
     assert create_user_menu is not None
-    # The menu should not be enabled if the context file is not loaded
-    assert not create_user_menu.isEnabled()
-
-    # Adds the variables to the db
-    for vv in mock_user_vars.values():
-        db.add_user_variable(vv, exist_ok=True)
-
-    # Loads the context file to do the other tests
-    win.autoconfigure(db_dir)
 
     # After loading a context file the menu should be enabled
     assert create_user_menu.isEnabled()


### PR DESCRIPTION
Simplifying the GUI code a bit by enforcing a couple of restrictions

- The MainWindow is always opened with a DAMNIT directory (already the case in actual use, only the tests still opened an empty window)
- One window doesn't switch to a different DAMNIT directory - we open a new window instead.
- It always connects to Kafka, or the mock Kafka broker for the tests

There may be more simplifications possible. I also hope this will avoid bugs in rarely exercised code paths.