### PR TITLE
Batch reduced-data DB writes

### DIFF
--- a/damnit/backend/db.py
+++ b/damnit/backend/db.py
@@ -346,7 +346,71 @@ class DamnitDB:
     def set_variable(
             self, proposal: int, run: int, name: str, reduced, provenance: str
     ):
+        self.set_variables(
+            proposal,
+            run,
+            {name: reduced},
+            provenance,
+        )
+
+    def set_variables(
+            self,
+            proposal: int,
+            run: int,
+            reduced_data: dict[str, ReducedData],
+            provenance: str,
+            *,
+            added_at: float=None,
+            start_time: float=None,
+    ):
         timestamp = datetime.now(tz=timezone.utc).timestamp()
+        rows = [
+            self._prepare_variable_row(
+                proposal, run, name, reduced, provenance, timestamp
+            )
+            for name, reduced in reduced_data.items()
+        ]
+
+        with time_db_transaction(self.conn, f"set_variables p{proposal} r{run}"):
+            self.ensure_run(
+                proposal,
+                run,
+                added_at=added_at,
+                start_time=start_time,
+            )
+            existing_variables = set(self.variable_names())
+
+            if rows:
+                # These columns should match those in the run_variables table
+                cols = [
+                    "proposal", "run", "name", "version", "value",
+                    "timestamp", "max_diff", "provenance", "summary_method",
+                    "summary_type", "attributes",
+                ]
+                col_list = ", ".join(cols)
+                col_values = ", ".join([f":{col}" for col in cols])
+                col_updates = ", ".join([f"{col} = :{col}" for col in cols])
+
+                self.conn.executemany(f"""
+                    INSERT INTO run_variables ({col_list})
+                    VALUES ({col_values})
+                    ON CONFLICT (proposal, run, name, version) DO UPDATE SET {col_updates}
+                """, rows)
+
+        if any(name not in existing_variables for name in reduced_data):
+            self.update_views()
+
+    def _prepare_variable_row(
+            self,
+            proposal: int,
+            run: int,
+            name: str,
+            reduced: ReducedData,
+            provenance: str,
+            timestamp: float,
+    ):
+        if not isinstance(reduced.value, (int, float, str, bytes, complex, np.ndarray, type(None))):
+            raise TypeError(f"Unsupported type for database: {type(reduced.value)}")
 
         variable = asdict(reduced)
 
@@ -380,26 +444,8 @@ class DamnitDB:
         #     SELECT max(version) FROM run_variables
         #     WHERE proposal=? AND run=? AND name=?
         # """, (proposal, run, name)).fetchone()[0]
-        variable["version"] = 1 # if latest_version is None else latest_version + 1
-
-        # These columns should match those in the run_variables table
-        cols = ["proposal", "run", "name", "version", "value", "timestamp", "max_diff", "provenance", "summary_method", "summary_type", "attributes"]
-        col_list = ", ".join(cols)
-        col_values = ", ".join([f":{col}" for col in cols])
-        col_updates = ", ".join([f"{col} = :{col}" for col in cols])
-
-        with time_db_transaction(self.conn, f"set_variable {name}"):
-            existing_variables = self.variable_names()
-            is_new = name not in existing_variables
-
-            self.conn.execute(f"""
-                INSERT INTO run_variables ({col_list})
-                VALUES ({col_values})
-                ON CONFLICT (proposal, run, name, version) DO UPDATE SET {col_updates}
-            """, variable)
-
-            if is_new:
-                self.update_views()
+        variable["version"] = 1  # if latest_version is None else latest_version + 1
+        return variable
 
     def delete_variable(self, name: str):
         with self.conn:

--- a/damnit/backend/extract_data.py
+++ b/damnit/backend/extract_data.py
@@ -130,7 +130,6 @@ def load_reduced_data(h5_path):
 
 
 def add_to_db(reduced_data, db: DamnitDB, proposal, run, provenance):
-    db.ensure_run(proposal, run)
     log.info("Adding p%d r%d to database, with %d columns",
              proposal, run, len(reduced_data))
 
@@ -146,14 +145,14 @@ def add_to_db(reduced_data, db: DamnitDB, proposal, run, provenance):
 
     # Handle the start_time variable specially
     start_time = reduced_data.pop("start_time", None)
-    if start_time is not None:
-        db.ensure_run(proposal, run, start_time=start_time.value)
 
-    for name, reduced in reduced_data.items():
-        if not isinstance(reduced.value, (int, float, str, bytes, complex, np.ndarray, type(None))):
-            raise TypeError(f"Unsupported type for database: {type(reduced.value)}")
-
-        db.set_variable(proposal, run, name, reduced, provenance=provenance)
+    db.set_variables(
+        proposal,
+        run,
+        reduced_data,
+        provenance=provenance,
+        start_time=None if start_time is None else start_time.value,
+    )
 
 
 def notify_new_file(damnit_dir, proposal: int, run: int, file_path: str):

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -788,6 +788,7 @@ def test_add_to_db(mock_db):
     ).fetchone()
     assert json.loads(row["attributes"]) == {"background": [255, 0, 0]}
 
+
 def test_trendline_summary_to_db(mock_run, mock_db, tmp_path):
     db_dir, db = mock_db
 


### PR DESCRIPTION
Group summary updates into one SQLite write transaction.

Quick benchmark for **100** variables:

**scalar**
per-variable ingestion
  total=1.004s mean=100.409ms median=101.989ms min=92.669ms max=103.202ms stdev=3.275ms
Batched ingestion
  total=0.034s mean=3.401ms median=3.381ms min=3.283ms max=3.544ms stdev=0.077ms
**Mean speedup: 29.53x**

**image**
per-variable ingestion
  total=1.348s mean=134.829ms median=134.788ms min=130.510ms max=140.912ms stdev=3.239ms
Batched ingestion
  total=0.340s mean=33.963ms median=33.614ms min=32.441ms max=38.162ms stdev=1.661ms
**Mean speedup: 3.97x**

**sparkline**
per-variable ingestion
  total=1.104s mean=110.380ms median=110.836ms min=101.874ms max=116.468ms stdev=4.739ms
Batched ingestion
  total=0.063s mean=6.282ms median=6.258ms min=6.117ms max=6.421ms stdev=0.088ms
**Mean speedup: 17.57x**

**mixed (60% scalar, 20% image, 20% sparkline)**
per-variable ingestion
  total=1.106s mean=110.620ms median=110.811ms min=106.965ms max=114.720ms stdev=2.601ms
Batched ingestion
  total=0.104s mean=10.425ms median=10.380ms min=10.147ms max=10.694ms stdev=0.200ms
**Mean speedup: 10.61x**